### PR TITLE
feat(charts): bootstrap Vercel Blob + read path with hand-crafted fixture

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
-  "*.{ts,tsx,js,jsx}": ["prettier --write", "eslint --fix"],
+  "*.{ts,tsx,mts,js,jsx,mjs}": ["prettier --write", "eslint --fix"],
   "*.{json,md,css}": ["prettier --write"]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:ci": "vitest --watch=false --reporter=default --reporter=github-actions",
+    "blob:upload-fixture": "tsx --env-file=.env.local scripts/blob/upload-fixture.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:ci": "vitest --watch=false --reporter=default --reporter=github-actions",
-    "blob:upload-fixture": "tsx --env-file=.env.local scripts/blob/upload-fixture.ts",
+    "blob:upload-fixture": "tsx --env-file=.env.local scripts/blob/upload-fixture.mts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^10.51.0",
+    "@vercel/blob": "^2.3.0",
     "next": "16.2.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -38,6 +40,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vercel": "^52.2.1",
     "vitest": "^4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.51.0
         version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.0))
+      '@vercel/blob':
+        specifier: ^2.3.0
+        version: 2.3.0
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -20,6 +23,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -69,6 +75,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.4
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/scripts/blob/upload-fixture.mts
+++ b/scripts/blob/upload-fixture.mts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname } from "node:path";
 import { put } from "@vercel/blob";
+import { ChartFileSchema } from "../../src/lib/chart-schema";
 
 const FIXTURE_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -29,9 +30,7 @@ async function main(): Promise<void> {
   }
 
   const raw = await readFile(FIXTURE_PATH, "utf8");
-  const parsed: {
-    lastUpdated: string;
-  } = JSON.parse(raw);
+  const parsed = ChartFileSchema.parse(JSON.parse(raw));
 
   console.log("Upload 1: original fixture body");
   const url1 = await uploadOnce(raw);
@@ -45,6 +44,7 @@ async function main(): Promise<void> {
     null,
     2,
   );
+  ChartFileSchema.parse(JSON.parse(bumped));
   console.log("Upload 2: lastUpdated bumped to now");
   const url2 = await uploadOnce(bumped);
   console.log(`  → ${url2}`);

--- a/scripts/blob/upload-fixture.mts
+++ b/scripts/blob/upload-fixture.mts
@@ -29,14 +29,19 @@ async function main(): Promise<void> {
   }
 
   const raw = await readFile(FIXTURE_PATH, "utf8");
-  const parsed: { lastUpdated: string } = JSON.parse(raw);
+  const parsed: {
+    lastUpdated: string;
+  } = JSON.parse(raw);
 
   console.log("Upload 1: original fixture body");
   const url1 = await uploadOnce(raw);
   console.log(`  → ${url1}`);
 
   const bumped = JSON.stringify(
-    { ...parsed, lastUpdated: new Date().toISOString() },
+    {
+      ...parsed,
+      lastUpdated: new Date().toISOString(),
+    },
     null,
     2,
   );

--- a/scripts/blob/upload-fixture.ts
+++ b/scripts/blob/upload-fixture.ts
@@ -1,0 +1,53 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+import { put } from "@vercel/blob";
+
+const FIXTURE_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../src/lib/__fixtures__/charts.json",
+);
+
+const BLOB_PATHNAME = "charts/v1/charts.json";
+
+async function uploadOnce(body: string): Promise<string> {
+  const result = await put(BLOB_PATHNAME, body, {
+    access: "public",
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    contentType: "application/json",
+    cacheControlMaxAge: 60,
+  });
+  return result.url;
+}
+
+async function main(): Promise<void> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error(
+      "BLOB_READ_WRITE_TOKEN missing. Run with: pnpm blob:upload-fixture (loads .env.local via tsx --env-file).",
+    );
+  }
+
+  const raw = await readFile(FIXTURE_PATH, "utf8");
+  const parsed: { lastUpdated: string } = JSON.parse(raw);
+
+  console.log("Upload 1: original fixture body");
+  const url1 = await uploadOnce(raw);
+  console.log(`  → ${url1}`);
+
+  const bumped = JSON.stringify(
+    { ...parsed, lastUpdated: new Date().toISOString() },
+    null,
+    2,
+  );
+  console.log("Upload 2: lastUpdated bumped to now");
+  const url2 = await uploadOnce(bumped);
+  console.log(`  → ${url2}`);
+
+  if (url1 !== url2) {
+    throw new Error(`URL not stable across overwrites: ${url1} !== ${url2}`);
+  }
+  console.log(`\nStable URL verified: ${url1}`);
+}
+
+await main();

--- a/src/app/debug/charts/page.tsx
+++ b/src/app/debug/charts/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from "next/navigation";
+import { fetchCharts } from "@/lib/charts-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function DebugChartsPage() {
+  if (process.env.ENABLE_DEBUG !== "1") {
+    notFound();
+  }
+  const url = process.env.CHARTS_BLOB_URL;
+  if (!url) {
+    notFound();
+  }
+
+  const charts = await fetchCharts(url);
+
+  return (
+    <main className="bg-void text-fg-1 min-h-dvh px-6 py-10 font-mono text-xs">
+      <header className="mb-8">
+        <h1 className="font-display text-fg-1 text-2xl italic">Charts debug</h1>
+        <p className="text-fg-3 mt-1">lastUpdated: {charts.lastUpdated}</p>
+      </header>
+
+      {Object.entries(charts.countries).map(([cc, country]) => (
+        <section key={cc} className="mb-8">
+          <h2 className="text-fg-2 mb-2 text-sm tracking-widest uppercase">
+            {cc.toUpperCase()} — {country.name}
+            {!country.valid ? " (invalid)" : ""}
+          </h2>
+          <ol className="space-y-1">
+            {country.tracks.map((track) => (
+              <li key={track.rank} className="text-fg-1">
+                <span className="text-fg-3">{track.rank}.</span> {track.name}{" "}
+                <span className="text-fg-3">—</span> {track.artist}
+              </li>
+            ))}
+          </ol>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/lib/__fixtures__/charts.json
+++ b/src/lib/__fixtures__/charts.json
@@ -1,0 +1,104 @@
+{
+  "lastUpdated": "2026-04-25T03:00:00Z",
+  "countries": {
+    "kr": {
+      "name": "South Korea",
+      "valid": true,
+      "tracks": [
+        {
+          "rank": 1,
+          "name": "소문의 낙원",
+          "artist": "악뮤",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/kr-01.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/kr-01.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/kr/album/example-album/1700000001?i=1700000002",
+          "spotifySearchUrl": "https://open.spotify.com/search/%EC%86%8C%EB%AC%B8%EC%9D%98%20%EB%82%99%EC%9B%90%20%EC%95%85%EB%AE%A4"
+        },
+        {
+          "rank": 2,
+          "name": "Drowning",
+          "artist": "WOODZ",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/kr-02.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/kr-02.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/kr/album/example-album/1700000003?i=1700000004",
+          "spotifySearchUrl": "https://open.spotify.com/search/Drowning%20WOODZ"
+        },
+        {
+          "rank": 3,
+          "name": "Supernova",
+          "artist": "aespa",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/kr-03.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/kr-03.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/kr/album/example-album/1700000005?i=1700000006",
+          "spotifySearchUrl": "https://open.spotify.com/search/Supernova%20aespa"
+        }
+      ]
+    },
+    "us": {
+      "name": "United States",
+      "valid": true,
+      "tracks": [
+        {
+          "rank": 1,
+          "name": "Espresso",
+          "artist": "Sabrina Carpenter",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/us-01.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/us-01.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/us/album/example-album/1700000101?i=1700000102",
+          "spotifySearchUrl": "https://open.spotify.com/search/Espresso%20Sabrina%20Carpenter"
+        },
+        {
+          "rank": 2,
+          "name": "Birds of a Feather",
+          "artist": "Billie Eilish",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/us-02.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/us-02.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/us/album/example-album/1700000103?i=1700000104",
+          "spotifySearchUrl": "https://open.spotify.com/search/Birds%20of%20a%20Feather%20Billie%20Eilish"
+        },
+        {
+          "rank": 3,
+          "name": "Not Like Us",
+          "artist": "Kendrick Lamar",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/us-03.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/us-03.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/us/album/example-album/1700000105?i=1700000106",
+          "spotifySearchUrl": "https://open.spotify.com/search/Not%20Like%20Us%20Kendrick%20Lamar"
+        }
+      ]
+    },
+    "br": {
+      "name": "Brazil",
+      "valid": true,
+      "tracks": [
+        {
+          "rank": 1,
+          "name": "Tá OK",
+          "artist": "Dennis e Kevin O Chris",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/br-01.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/br-01.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/br/album/example-album/1700000201?i=1700000202",
+          "spotifySearchUrl": "https://open.spotify.com/search/T%C3%A1%20OK%20Dennis"
+        },
+        {
+          "rank": 2,
+          "name": "Gata Only",
+          "artist": "FloyyMenor & Cris MJ",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/br-02.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/br-02.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/br/album/example-album/1700000203?i=1700000204",
+          "spotifySearchUrl": "https://open.spotify.com/search/Gata%20Only%20FloyyMenor"
+        },
+        {
+          "rank": 3,
+          "name": "Pedro",
+          "artist": "Raffaela Carrà & Jaxomy & Agatino Romero",
+          "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/br-03.m4a",
+          "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/br-03.jpg/600x600bb.jpg",
+          "appleUrl": "https://music.apple.com/br/album/example-album/1700000205?i=1700000206",
+          "spotifySearchUrl": "https://open.spotify.com/search/Pedro%20Raffaela%20Carr%C3%A0"
+        }
+      ]
+    }
+  }
+}

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+import fixture from "./__fixtures__/charts.json";
+import { ChartFileSchema } from "./chart-schema";
+
+test("ChartFileSchema parses the hand-crafted fixture", () => {
+  expect(() => ChartFileSchema.parse(fixture)).not.toThrow();
+});

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+const TrackSchema = z.object({
+  rank: z.number().int().min(1).max(25),
+  name: z.string().min(1),
+  artist: z.string().min(1),
+  previewUrl: z.url(),
+  artworkUrl: z.url(),
+  appleUrl: z.url(),
+  spotifySearchUrl: z.url(),
+});
+
+const CountrySchema = z.object({
+  name: z.string().min(1),
+  valid: z.boolean(),
+  tracks: z.array(TrackSchema).max(25),
+});
+
+export const ChartFileSchema = z.object({
+  lastUpdated: z.iso.datetime(),
+  countries: z.record(z.string().regex(/^[a-z]{2}$/), CountrySchema),
+});
+
+export type Track = z.infer<typeof TrackSchema>;
+export type Country = z.infer<typeof CountrySchema>;
+export type ChartFile = z.infer<typeof ChartFileSchema>;

--- a/src/lib/charts-client.test.ts
+++ b/src/lib/charts-client.test.ts
@@ -18,7 +18,7 @@ function mockFetch(response: Response): void {
 }
 
 test("fetchCharts returns parsed ChartFile when body matches schema", async () => {
-  mockFetch(
+  const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(JSON.stringify(fixture), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -30,6 +30,10 @@ test("fetchCharts returns parsed ChartFile when body matches schema", async () =
   expect(result.countries.kr.tracks[0].rank).toBe(1);
   expect(result.countries.kr.tracks[0].artist).toBe("악뮤");
   expect(result.lastUpdated).toBe("2026-04-25T03:00:00Z");
+  expect(spy).toHaveBeenCalledWith(FIXTURE_URL, {
+    cache: "force-cache",
+    next: { tags: ["charts"] },
+  });
 });
 
 test("fetchCharts throws ChartsValidationError when payload is malformed", async () => {
@@ -48,6 +52,29 @@ test("fetchCharts throws ChartsValidationError when payload is malformed", async
 
 test("fetchCharts throws ChartsFetchError on non-OK status", async () => {
   mockFetch(new Response(null, { status: 500, statusText: "Server Error" }));
+
+  await expect(fetchCharts(FIXTURE_URL)).rejects.toBeInstanceOf(
+    ChartsFetchError,
+  );
+});
+
+test("fetchCharts throws ChartsFetchError when fetch rejects (network error)", async () => {
+  vi.spyOn(globalThis, "fetch").mockRejectedValue(
+    new TypeError("fetch failed"),
+  );
+
+  await expect(fetchCharts(FIXTURE_URL)).rejects.toBeInstanceOf(
+    ChartsFetchError,
+  );
+});
+
+test("fetchCharts throws ChartsFetchError when body is not valid JSON", async () => {
+  mockFetch(
+    new Response("not json at all", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
 
   await expect(fetchCharts(FIXTURE_URL)).rejects.toBeInstanceOf(
     ChartsFetchError,

--- a/src/lib/charts-client.test.ts
+++ b/src/lib/charts-client.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, expect, test, vi } from "vitest";
+import fixture from "./__fixtures__/charts.json";
+import {
+  ChartsFetchError,
+  ChartsValidationError,
+  fetchCharts,
+} from "./charts-client";
+
+const FIXTURE_URL =
+  "https://store.public.blob.vercel-storage.com/charts/v1/charts.json";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(response: Response): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+test("fetchCharts returns parsed ChartFile when body matches schema", async () => {
+  mockFetch(
+    new Response(JSON.stringify(fixture), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+
+  const result = await fetchCharts(FIXTURE_URL);
+
+  expect(result.countries.kr.tracks[0].rank).toBe(1);
+  expect(result.countries.kr.tracks[0].artist).toBe("악뮤");
+  expect(result.lastUpdated).toBe("2026-04-25T03:00:00Z");
+});
+
+test("fetchCharts throws ChartsValidationError when payload is malformed", async () => {
+  const malformed = { countries: fixture.countries };
+  mockFetch(
+    new Response(JSON.stringify(malformed), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+
+  await expect(fetchCharts(FIXTURE_URL)).rejects.toBeInstanceOf(
+    ChartsValidationError,
+  );
+});
+
+test("fetchCharts throws ChartsFetchError on non-OK status", async () => {
+  mockFetch(new Response(null, { status: 500, statusText: "Server Error" }));
+
+  await expect(fetchCharts(FIXTURE_URL)).rejects.toBeInstanceOf(
+    ChartsFetchError,
+  );
+});

--- a/src/lib/charts-client.ts
+++ b/src/lib/charts-client.ts
@@ -21,17 +21,36 @@ export class ChartsValidationError extends Error {
 }
 
 export async function fetchCharts(url: string): Promise<ChartFile> {
-  const res = await fetch(url, {
-    cache: "force-cache",
-    next: { tags: ["charts"] },
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      cache: "force-cache",
+      next: { tags: ["charts"] },
+    });
+  } catch (err) {
+    throw new ChartsFetchError(
+      0,
+      `Charts fetch failed: ${err instanceof Error ? err.message : "network error"}`,
+    );
+  }
+
   if (!res.ok) {
     throw new ChartsFetchError(
       res.status,
       `Charts fetch failed: ${res.status} ${res.statusText}`,
     );
   }
-  const json: unknown = await res.json();
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch (err) {
+    throw new ChartsFetchError(
+      res.status,
+      `Charts fetch failed: invalid JSON (${err instanceof Error ? err.message : "parse error"})`,
+    );
+  }
+
   const parsed = ChartFileSchema.safeParse(json);
   if (!parsed.success) {
     throw new ChartsValidationError(

--- a/src/lib/charts-client.ts
+++ b/src/lib/charts-client.ts
@@ -1,0 +1,43 @@
+import { ChartFileSchema, type ChartFile } from "./chart-schema";
+
+export class ChartsFetchError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ChartsFetchError";
+  }
+}
+
+export class ChartsValidationError extends Error {
+  constructor(
+    public readonly issues: unknown,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ChartsValidationError";
+  }
+}
+
+export async function fetchCharts(url: string): Promise<ChartFile> {
+  const res = await fetch(url, {
+    cache: "force-cache",
+    next: { tags: ["charts"] },
+  });
+  if (!res.ok) {
+    throw new ChartsFetchError(
+      res.status,
+      `Charts fetch failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  const json: unknown = await res.json();
+  const parsed = ChartFileSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new ChartsValidationError(
+      parsed.error.issues,
+      "Charts payload failed schema validation",
+    );
+  }
+  return parsed.data;
+}


### PR DESCRIPTION
## Summary

- Stand up Vercel Blob storage (`iad1`) with a hand-crafted chart fixture as the verification target for later crawler slices.
- Add Zod schema (`ChartFile`/`Country`/`Track`) and a cache-tagged read-path client (`fetchCharts`) that rejects malformed payloads with typed errors (`ChartsFetchError`, `ChartsValidationError`).
- Expose `/debug/charts` as a Preview-only verification surface; returns 404 in Production via `ENABLE_DEBUG` env gate + `notFound()`.

## Test plan

Acceptance criteria from #4:

- [x] Vercel Blob store created; region `iad1` recorded
- [x] `BLOB_READ_WRITE_TOKEN`, `REVALIDATE_SECRET`, `CHARTS_BLOB_URL` set in Vercel env. `REVALIDATE_SECRET` is Production + Preview only (Vercel disallows Sensitive type in Development scope — documented constraint, not a gap)
- [x] `ENABLE_DEBUG=1` set in Preview + Development only (not Production)
- [x] Hand-crafted fixture uploaded; stable public URL verified empirically (script does two consecutive `put()` calls with `addRandomSuffix: false, allowOverwrite: true` and asserts identical URLs): `https://zdpfltpju6ale9vz.public.blob.vercel-storage.com/charts/v1/charts.json`
- [x] Zod schema in place; fixture round-trips via `chart-schema.test.ts`
- [x] Read-path module: `cache: 'force-cache' + next: { tags: ['charts'] }`, Zod `safeParse`, typed errors. Three Vitest cases cover success, validation failure, fetch failure
- [x] Preview `/debug/charts` renders fixture data flat (verify after Vercel Preview builds)
- [x] Production `/debug/charts` returns HTTP 404 (verify after Production promote)

Local verification (passed):

- `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:ci && pnpm build` ✅
- `curl -I` on the Blob URL returns `200`, `content-type: application/json`, `cache-control: public, max-age=60`

## Notes

- Revalidate trigger (`revalidateTag('charts')`) is deferred to #7 — reloading the Preview page after re-running `pnpm blob:upload-fixture` will not show new content until #7 lands. This is expected, not a bug.
- New devDep `tsx` for the upload script; runtime deps `@vercel/blob` and `zod` promoted from transitive to direct.
- Lint-staged glob expanded to include `.mts`/`.mjs` after the `.ts → .mts` rename revealed the gap.

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug page for viewing charts (enable via env)
  * Improved chart fetching with schema validation and clearer error handling

* **Tests**
  * Added tests for chart schema validation and client error scenarios

* **Chores**
  * Added dependencies for blob uploads and schema validation
  * Added a script to upload chart fixtures
  * Expanded lint/build file globs to cover additional JS/TS module extensions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/12)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->