### PR TITLE
chore(ci): set CodeRabbit Docstring Coverage threshold to 0

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -72,6 +72,9 @@ reviews:
       mode: "warning"
     issue_assessment:
       mode: "warning"
+    docstrings:
+      mode: "warning"
+      threshold: 0
 
 chat:
   art: false


### PR DESCRIPTION
## Summary

- Set `pre_merge_checks.docstrings.threshold` to 0 in `.coderabbit.yaml` (mode stays `warning`).
- The check counts functions across all touched files (not just added/modified ones) against the default 80% threshold. Lint and refactor PRs that touch import lines pull in existing undocumented Next.js components → 0% warning every time.
- Keep the check visible in CR's walkthrough so the bar can be raised later, but stop it from warning at current coverage.

First observed on #14.

## Test plan

- [x] `mode: "warning"` and `threshold: 0` are documented values in CR's YAML schema
- [ ] Next PR's CR review walkthrough shows Docstring Coverage as passed instead of warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings for internal development processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/16)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->