### PR TITLE
feat(api): POST /api/revalidate invalidates music-charts tag

### DIFF
--- a/src/app/api/revalidate/route.test.ts
+++ b/src/app/api/revalidate/route.test.ts
@@ -4,13 +4,20 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 import { MUSIC_CHARTS_TAG } from "@/lib/cache-tags";
 
-import { BREADCRUMB, revalidateCharts } from "./route";
+import { BREADCRUMB, MISCONFIGURED_MESSAGE, revalidateCharts } from "./route";
 
-// First module-mock pattern in this repo. `revalidateTag` and `addBreadcrumb`
-// are named ESM exports from third-party modules; `vi.spyOn(globalThis, ...)`
-// (the repo's existing pattern) does not apply here.
+// First module-mock pattern in this repo. `revalidateTag`, `addBreadcrumb`, and
+// `captureMessage` are named ESM exports from third-party modules;
+// `vi.spyOn(globalThis, ...)` (the repo's existing pattern) does not apply here.
 vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
-vi.mock("@sentry/nextjs", () => ({ addBreadcrumb: vi.fn() }));
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+const revalidateTagMock = vi.mocked(revalidateTag);
+const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
+const captureMessageMock = vi.mocked(Sentry.captureMessage);
 
 const SECRET = "test-fixture-secret";
 
@@ -43,8 +50,6 @@ afterEach(() => {
 
 test("returns 200 and revalidates MUSIC_CHARTS_TAG with valid bearer", async () => {
   const req = makeReq({ authorization: `Bearer ${SECRET}` });
-  const revalidateTagMock = vi.mocked(revalidateTag);
-  const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
 
   const res = await revalidateCharts(req);
   const body = await res.json();
@@ -63,8 +68,6 @@ test("returns 200 and revalidates MUSIC_CHARTS_TAG with valid bearer", async () 
 
 test("returns 401 with WWW-Authenticate when Authorization header is missing", async () => {
   const req = makeReq();
-  const revalidateTagMock = vi.mocked(revalidateTag);
-  const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
 
   const res = await revalidateCharts(req);
   const body = await res.json();
@@ -83,8 +86,6 @@ test("returns 401 with WWW-Authenticate when Authorization header is missing", a
 
 test("returns 401 when bearer token is wrong", async () => {
   const req = makeReq({ authorization: "Bearer wrong" });
-  const revalidateTagMock = vi.mocked(revalidateTag);
-  const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
 
   const res = await revalidateCharts(req);
   const body = await res.json();
@@ -111,13 +112,19 @@ test("401 responses are byte-identical for missing vs wrong bearer", async () =>
   expect(missing).toEqual(wrong);
 });
 
-test("returns 500 when REVALIDATE_SECRET env var is unset", async () => {
+test("returns 500 and captures message when REVALIDATE_SECRET is unset", async () => {
   delete process.env.REVALIDATE_SECRET;
   const req = makeReq({ authorization: `Bearer ${SECRET}` });
-  const revalidateTagMock = vi.mocked(revalidateTag);
 
   const res = await revalidateCharts(req);
+  const body = await res.json();
 
   expect(res.status).toBe(500);
+  expect(body).toEqual({ ok: false });
   expect(revalidateTagMock).not.toHaveBeenCalled();
+  expect(addBreadcrumbMock).not.toHaveBeenCalled();
+  expect(captureMessageMock).toHaveBeenCalledWith(
+    MISCONFIGURED_MESSAGE,
+    "error",
+  );
 });

--- a/src/app/api/revalidate/route.test.ts
+++ b/src/app/api/revalidate/route.test.ts
@@ -1,0 +1,123 @@
+import { revalidateTag } from "next/cache";
+import * as Sentry from "@sentry/nextjs";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { MUSIC_CHARTS_TAG } from "@/lib/cache-tags";
+
+import { BREADCRUMB, revalidateCharts } from "./route";
+
+// First module-mock pattern in this repo. `revalidateTag` and `addBreadcrumb`
+// are named ESM exports from third-party modules; `vi.spyOn(globalThis, ...)`
+// (the repo's existing pattern) does not apply here.
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+vi.mock("@sentry/nextjs", () => ({ addBreadcrumb: vi.fn() }));
+
+const SECRET = "test-fixture-secret";
+
+function makeReq(headers?: Record<string, string>): Request {
+  return new Request("http://test/api/revalidate", {
+    method: "POST",
+    headers,
+  });
+}
+
+async function snapshot(
+  req: Request,
+): Promise<{ status: number; headers: [string, string][]; body: string }> {
+  const res = await revalidateCharts(req);
+  return {
+    status: res.status,
+    headers: [...res.headers.entries()].sort(),
+    body: await res.text(),
+  };
+}
+
+beforeEach(() => {
+  process.env.REVALIDATE_SECRET = SECRET;
+});
+
+afterEach(() => {
+  delete process.env.REVALIDATE_SECRET;
+  vi.clearAllMocks();
+});
+
+test("returns 200 and revalidates MUSIC_CHARTS_TAG with valid bearer", async () => {
+  const req = makeReq({ authorization: `Bearer ${SECRET}` });
+  const revalidateTagMock = vi.mocked(revalidateTag);
+  const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
+
+  const res = await revalidateCharts(req);
+  const body = await res.json();
+
+  expect(res.status).toBe(200);
+  expect(body).toEqual({ ok: true });
+  expect(revalidateTagMock).toHaveBeenCalledTimes(1);
+  expect(revalidateTagMock).toHaveBeenCalledWith(MUSIC_CHARTS_TAG, "max");
+  expect(addBreadcrumbMock).toHaveBeenCalledWith({
+    category: BREADCRUMB.category,
+    level: "info",
+    message: BREADCRUMB.ok,
+    data: { tag: MUSIC_CHARTS_TAG },
+  });
+});
+
+test("returns 401 with WWW-Authenticate when Authorization header is missing", async () => {
+  const req = makeReq();
+  const revalidateTagMock = vi.mocked(revalidateTag);
+  const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
+
+  const res = await revalidateCharts(req);
+  const body = await res.json();
+
+  expect(res.status).toBe(401);
+  expect(body).toEqual({ ok: false });
+  expect(res.headers.get("www-authenticate")).toBe('Bearer realm="revalidate"');
+  expect(revalidateTagMock).not.toHaveBeenCalled();
+  expect(addBreadcrumbMock).toHaveBeenCalledWith({
+    category: BREADCRUMB.category,
+    level: "warning",
+    message: BREADCRUMB.unauthorized,
+    data: { tag: MUSIC_CHARTS_TAG },
+  });
+});
+
+test("returns 401 when bearer token is wrong", async () => {
+  const req = makeReq({ authorization: "Bearer wrong" });
+  const revalidateTagMock = vi.mocked(revalidateTag);
+  const addBreadcrumbMock = vi.mocked(Sentry.addBreadcrumb);
+
+  const res = await revalidateCharts(req);
+  const body = await res.json();
+
+  expect(res.status).toBe(401);
+  expect(body).toEqual({ ok: false });
+  expect(res.headers.get("www-authenticate")).toBe('Bearer realm="revalidate"');
+  expect(revalidateTagMock).not.toHaveBeenCalled();
+  expect(addBreadcrumbMock).toHaveBeenCalledWith({
+    category: BREADCRUMB.category,
+    level: "warning",
+    message: BREADCRUMB.unauthorized,
+    data: { tag: MUSIC_CHARTS_TAG },
+  });
+});
+
+test("401 responses are byte-identical for missing vs wrong bearer", async () => {
+  const reqMissing = makeReq();
+  const reqWrong = makeReq({ authorization: "Bearer wrong" });
+
+  const missing = await snapshot(reqMissing);
+  const wrong = await snapshot(reqWrong);
+
+  expect(missing).toEqual(wrong);
+});
+
+test("returns 500 when REVALIDATE_SECRET env var is unset", async () => {
+  delete process.env.REVALIDATE_SECRET;
+  const req = makeReq({ authorization: `Bearer ${SECRET}` });
+  const revalidateTagMock = vi.mocked(revalidateTag);
+
+  const res = await revalidateCharts(req);
+
+  expect(res.status).toBe(500);
+  expect(revalidateTagMock).not.toHaveBeenCalled();
+});

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -14,6 +14,8 @@ export const BREADCRUMB = {
   unauthorized: "revalidate.unauthorized",
 } as const;
 
+export const MISCONFIGURED_MESSAGE = "REVALIDATE_SECRET is not configured";
+
 function sha256(s: string): Buffer {
   return createHash("sha256").update(s).digest();
 }
@@ -26,6 +28,7 @@ function extractBearer(req: Request): string {
 export async function revalidateCharts(req: Request): Promise<Response> {
   const expected = process.env.REVALIDATE_SECRET;
   if (!expected) {
+    Sentry.captureMessage(MISCONFIGURED_MESSAGE, "error");
     return new Response(JSON.stringify({ ok: false }), {
       status: 500,
       headers: { "content-type": "application/json" },

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,62 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+import { revalidateTag } from "next/cache";
+import * as Sentry from "@sentry/nextjs";
+
+import { MUSIC_CHARTS_TAG } from "@/lib/cache-tags";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const BREADCRUMB = {
+  category: "revalidate",
+  ok: "revalidate.ok",
+  unauthorized: "revalidate.unauthorized",
+} as const;
+
+function sha256(s: string): Buffer {
+  return createHash("sha256").update(s).digest();
+}
+
+function extractBearer(req: Request): string {
+  const h = req.headers.get("authorization") ?? "";
+  return h.startsWith("Bearer ") ? h.slice(7) : "";
+}
+
+export async function revalidateCharts(req: Request): Promise<Response> {
+  const expected = process.env.REVALIDATE_SECRET;
+  if (!expected) {
+    return new Response(JSON.stringify({ ok: false }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const presented = extractBearer(req);
+  const ok = timingSafeEqual(sha256(presented), sha256(expected));
+
+  Sentry.addBreadcrumb({
+    category: BREADCRUMB.category,
+    level: ok ? "info" : "warning",
+    message: ok ? BREADCRUMB.ok : BREADCRUMB.unauthorized,
+    data: { tag: MUSIC_CHARTS_TAG },
+  });
+
+  if (!ok) {
+    return new Response(JSON.stringify({ ok: false }), {
+      status: 401,
+      headers: {
+        "content-type": "application/json",
+        "www-authenticate": 'Bearer realm="revalidate"',
+      },
+    });
+  }
+
+  revalidateTag(MUSIC_CHARTS_TAG, "max");
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export { revalidateCharts as POST };

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,0 +1,1 @@
+export const MUSIC_CHARTS_TAG = "music-charts";

--- a/src/lib/charts-client.test.ts
+++ b/src/lib/charts-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from "vitest";
 
 import fixture from "./__fixtures__/charts.json";
+import { MUSIC_CHARTS_TAG } from "./cache-tags";
 import {
   ChartsFetchError,
   ChartsValidationError,
@@ -33,7 +34,7 @@ test("fetchCharts returns parsed ChartFile when body matches schema", async () =
   expect(result.lastUpdated).toBe("2026-04-25T03:00:00Z");
   expect(spy).toHaveBeenCalledWith(FIXTURE_URL, {
     cache: "force-cache",
-    next: { tags: ["charts"] },
+    next: { tags: [MUSIC_CHARTS_TAG] },
   });
 });
 

--- a/src/lib/charts-client.ts
+++ b/src/lib/charts-client.ts
@@ -1,3 +1,4 @@
+import { MUSIC_CHARTS_TAG } from "./cache-tags";
 import { ChartFileSchema, type ChartFile } from "./chart-schema";
 
 export class ChartsFetchError extends Error {
@@ -25,7 +26,7 @@ export async function fetchCharts(url: string): Promise<ChartFile> {
   try {
     res = await fetch(url, {
       cache: "force-cache",
-      next: { tags: ["charts"] },
+      next: { tags: [MUSIC_CHARTS_TAG] },
     });
   } catch (err) {
     throw new ChartsFetchError(


### PR DESCRIPTION
## Summary

POST endpoint the Phase 2 cron (#8) will call to invalidate the `music-charts` cache tag. Bearer-authed against `REVALIDATE_SECRET`.

- SHA-256 + `timingSafeEqual`: missing and wrong tokens share one code path — same response shape and timing (per AC).
- `revalidateTag(MUSIC_CHARTS_TAG, "max")` on success; Sentry breadcrumb on 200 (info) and 401 (warning).
- 500 + `Sentry.captureMessage(..., "error")` when `REVALIDATE_SECRET` is unset — creates an alerting Sentry Issue rather than failing silently.

## Decisions

- **Tag rename**: `"charts"` → `"music-charts"` via `MUSIC_CHARTS_TAG` constant. 4 call sites with this slice; typo silently breaks revalidation.
- **Alias**: handler named `revalidateCharts`, exported as `POST`. Domain name in stack traces.
- **`BREADCRUMB` constant**: test and runtime share one source of truth for category/message strings.
- **Next 16**: `revalidateTag(tag, cacheLife)` is 2-arg required. Passed `"max"` for SWR.
- **500 path uses `captureMessage`, not breadcrumb**: a breadcrumb attaches to a future event; on a deploy-config bug no other event fires, so breadcrumb alone is invisible. `captureMessage` IS the event.
- **External callers need Vercel Protection Bypass token**: Vercel Preview (and Production by default) gate routes behind SSO. The cron in #8 must include `?x-vercel-protection-bypass=<token>&x-vercel-set-bypass-cookie=true`. Token generated under Project Settings → Deployment Protection → Protection Bypass for Automation.

## Test plan

- [x] 5 vitest cases: 200, 401 missing, 401 wrong, 401 byte-identical, 500 captureMessage
- [x] `charts-client.test.ts` still green after constant migration
- [x] `pnpm test`, `typecheck`, `lint`, `format:check` clean locally

Manual on Preview (with bypass cookie):
- [x] Valid → 200 `{"ok":true}`
- [x] Missing → 401 `{"ok":false}`, `WWW-Authenticate` present
- [x] Wrong → 401, structurally identical to missing

## Out of scope

`triggerRevalidate` wiring (#8), rate limiting, multi-tag revalidation.

Closes #7
Part of #1