### PR TITLE
feat(crawl): scale to 40 countries with partial-failure policy

### DIFF
--- a/scripts/crawl/main.ts
+++ b/scripts/crawl/main.ts
@@ -2,17 +2,18 @@ import { COUNTRIES } from "../../src/lib/countries";
 
 import { fetchAppleRss } from "./apple-rss";
 import { lookupTrack } from "./itunes-lookup";
-import { crawlCountry } from "./run";
+import { triggerRevalidate } from "./revalidate-trigger";
+import { crawlAll, crawlCountry } from "./run";
 import { createThrottle } from "./throttle";
+import { uploadCharts } from "./upload-blob";
 
 async function main(): Promise<void> {
   const cc = process.argv[2];
-  if (!cc) {
-    throw new Error(
-      "All-countries mode not wired up yet. For now run: pnpm crawl <cc>",
-    );
+  if (cc) {
+    await runSingleCountry(cc);
+    return;
   }
-  await runSingleCountry(cc);
+  await runAllCountries();
 }
 
 async function runSingleCountry(cc: string): Promise<void> {
@@ -37,6 +38,23 @@ async function runSingleCountry(cc: string): Promise<void> {
   );
   console.log("[crawl] (dry run — no upload, no revalidate)");
   console.log(JSON.stringify({ [cc]: country }, null, 2));
+}
+
+async function runAllCountries(): Promise<void> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error(
+      "BLOB_READ_WRITE_TOKEN missing. Run with: pnpm crawl (loads .env.local via tsx --env-file).",
+    );
+  }
+  const throttle = createThrottle();
+  await crawlAll({
+    countries: COUNTRIES,
+    fetchRss: fetchAppleRss,
+    lookupTrack,
+    throttle,
+    uploadCharts,
+    triggerRevalidate,
+  });
 }
 
 await main();

--- a/scripts/crawl/main.ts
+++ b/scripts/crawl/main.ts
@@ -1,47 +1,42 @@
+import { COUNTRIES } from "../../src/lib/countries";
+
 import { fetchAppleRss } from "./apple-rss";
 import { lookupTrack } from "./itunes-lookup";
-import { triggerRevalidate } from "./revalidate-trigger";
 import { crawlCountry } from "./run";
 import { createThrottle } from "./throttle";
-import { uploadCharts } from "./upload-blob";
-
-const COUNTRY_NAMES: Readonly<Record<string, string>> = {
-  kr: "South Korea",
-};
 
 async function main(): Promise<void> {
-  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  const cc = process.argv[2];
+  if (!cc) {
     throw new Error(
-      "BLOB_READ_WRITE_TOKEN missing. Run with: pnpm crawl (loads .env.local via tsx --env-file).",
+      "All-countries mode not wired up yet. For now run: pnpm crawl <cc>",
     );
   }
+  await runSingleCountry(cc);
+}
 
-  const cc = process.argv[2] ?? "kr";
-  const name = COUNTRY_NAMES[cc];
-  if (!name) {
+async function runSingleCountry(cc: string): Promise<void> {
+  const entry = COUNTRIES.find((c) => c.code === cc);
+  if (!entry) {
     throw new Error(
-      `Unknown country code "${cc}". Known: ${Object.keys(COUNTRY_NAMES).join(", ")}`,
+      `Unknown country code "${cc}". Known: ${COUNTRIES.map((c) => c.code).join(", ")}`,
     );
   }
 
   const throttle = createThrottle();
-
-  console.log(`[crawl] starting one-country crawl for ${cc} (${name})...`);
-  const result = await crawlCountry({
+  console.log(`[crawl ${cc}] starting single-country debug crawl...`);
+  const { country } = await crawlCountry({
     cc,
-    name,
+    name: entry.name,
     fetchRss: fetchAppleRss,
     lookupTrack,
     throttle,
-    uploadCharts,
-    triggerRevalidate,
   });
-
-  const country = result.chartFile.countries[cc];
   console.log(
-    `[crawl] uploaded ${country.tracks.length}/25 tracks (valid=${country.valid})`,
+    `[crawl ${cc}] ${country.tracks.length} tracks (valid=${country.valid})`,
   );
-  console.log(`[crawl] → ${result.url}`);
+  console.log("[crawl] (dry run — no upload, no revalidate)");
+  console.log(JSON.stringify({ [cc]: country }, null, 2));
 }
 
 await main();

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -1,8 +1,16 @@
 import { expect, test, vi } from "vitest";
 
+import { ChartFileSchema } from "../../src/lib/chart-schema";
+import type { CountryEntry } from "../../src/lib/countries";
+
 import { AppleRssError, type AppleRssTrack } from "./apple-rss";
 import { ItunesLookupError, type LookupResult } from "./itunes-lookup";
-import { crawlCountry, type CrawlCountryDeps } from "./run";
+import {
+  crawlAll,
+  crawlCountry,
+  type CrawlAllDeps,
+  type CrawlCountryDeps,
+} from "./run";
 
 function sampleRssTracks(): AppleRssTrack[] {
   return [
@@ -155,4 +163,86 @@ test("crawlCountry routes every external call through the injected throttle", as
   await crawlCountry(deps);
 
   expect(count).toBe(expectedCount);
+});
+
+const FROZEN_NOW = new Date("2026-05-15T12:00:00.000Z");
+const BLOB_URL = "https://blob/charts/v1/charts.json";
+
+function fakeRssFor(cc: string): AppleRssTrack[] {
+  return [
+    {
+      rank: 1,
+      id: `${cc}-1`,
+      name: `${cc} song`,
+      artist: `${cc} artist`,
+      appleUrl: `https://music.apple.com/${cc}/album/1`,
+      artworkUrl: `https://art/${cc}/1/600x600bb.jpg`,
+    },
+  ];
+}
+
+function makeCrawlAllDeps(input: {
+  countries: readonly CountryEntry[];
+  fetchRss?: (cc: string) => Promise<AppleRssTrack[]>;
+}): CrawlAllDeps {
+  return {
+    countries: input.countries,
+    fetchRss: input.fetchRss ?? vi.fn(async (cc) => fakeRssFor(cc)),
+    lookupTrack: vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
+      async (id, cc) => ({ id, previewUrl: `https://preview/${cc}/${id}.m4a` }),
+    ),
+    throttle: async (fn) => fn(),
+    uploadCharts: vi.fn(async () => BLOB_URL),
+    triggerRevalidate: vi.fn(async () => {}),
+    now: () => FROZEN_NOW,
+  };
+}
+
+test("crawlAll assembles a valid ChartFile, uploads once, and revalidates once", async () => {
+  const countries: CountryEntry[] = [
+    { code: "kr", name: "South Korea", region: "Asia" },
+    { code: "us", name: "United States", region: "Americas" },
+  ];
+  const deps = makeCrawlAllDeps({ countries });
+  const expectedCodes = countries.map((c) => c.code);
+
+  const result = await crawlAll(deps);
+  const parsed = ChartFileSchema.parse(result.chartFile);
+
+  expect(parsed.lastUpdated).toBe(FROZEN_NOW.toISOString());
+  expect(Object.keys(parsed.countries)).toEqual(expectedCodes);
+  for (const code of expectedCodes) {
+    expect(parsed.countries[code].valid).toBe(true);
+    expect(parsed.countries[code].tracks).toHaveLength(fakeRssFor(code).length);
+  }
+  expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
+  expect(deps.uploadCharts).toHaveBeenCalledWith(result.chartFile);
+  expect(deps.triggerRevalidate).toHaveBeenCalledTimes(1);
+});
+
+test("crawlAll publishes whatever succeeded when one country's RSS fails", async () => {
+  const failingCode = "ng";
+  const successCode = "kr";
+  const countries: CountryEntry[] = [
+    { code: successCode, name: "South Korea", region: "Asia" },
+    { code: failingCode, name: "Nigeria", region: "Africa" },
+  ];
+  const fetchRss = vi.fn(async (cc: string) => {
+    if (cc === failingCode) {
+      throw new AppleRssError(cc, "503 Service Unavailable");
+    }
+    return fakeRssFor(cc);
+  });
+  const deps = makeCrawlAllDeps({ countries, fetchRss });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries[successCode].valid).toBe(true);
+  expect(result.chartFile.countries[successCode].tracks).toHaveLength(
+    fakeRssFor(successCode).length,
+  );
+  expect(result.chartFile.countries[failingCode].valid).toBe(false);
+  expect(result.chartFile.countries[failingCode].tracks).toEqual([]);
+  expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
+  expect(deps.triggerRevalidate).toHaveBeenCalledTimes(1);
 });

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -91,25 +91,29 @@ test("crawlCountry composes RSS + Lookup into typed tracks with synthesized spot
   });
 });
 
-test("crawlCountry drops a missed track but keeps the country valid=true", async () => {
+test("crawlCountry inserts a placeholder with previewUrl=null on lookup failure", async () => {
   const failingId = "2";
   const lookupTrack = vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
     async (id, cc) => {
       if (id === failingId)
-        throw new ItunesLookupError(id, cc, "miss", "no track");
+        throw new ItunesLookupError(id, cc, "http", "503 Service Unavailable");
       return { id, previewUrl: previewUrlForId(id) };
     },
   );
   const deps = makeCrawlCountryDeps({ lookupTrack });
-  const expectedSurvivingRanks = sampleRssTracks()
-    .filter((t) => t.id !== failingId)
-    .map((t) => t.rank);
+  const allRss = sampleRssTracks();
+  const failingRss = allRss.find((t) => t.id === failingId)!;
 
   const { country } = await crawlCountry(deps);
 
   expect(country.valid).toBe(true);
-  expect(country.tracks).toHaveLength(expectedSurvivingRanks.length);
-  expect(country.tracks.map((t) => t.rank)).toEqual(expectedSurvivingRanks);
+  expect(country.tracks).toHaveLength(allRss.length);
+  const failingTrack = country.tracks.find((t) => t.rank === failingRss.rank);
+  expect(failingTrack?.previewUrl).toBeNull();
+  expect(failingTrack?.name).toBe(failingRss.name);
+  expect(failingTrack?.artist).toBe(failingRss.artist);
+  expect(failingTrack?.appleUrl).toBe(failingRss.appleUrl);
+  expect(failingTrack?.artworkUrl).toBe(failingRss.artworkUrl);
 });
 
 test("crawlCountry returns valid=false with empty tracks when RSS throws AppleRssError", async () => {

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -1,12 +1,8 @@
 import { expect, test, vi } from "vitest";
 
-import { ChartFileSchema } from "../../src/lib/chart-schema";
-
-import type { AppleRssTrack } from "./apple-rss";
+import { AppleRssError, type AppleRssTrack } from "./apple-rss";
 import { ItunesLookupError, type LookupResult } from "./itunes-lookup";
 import { crawlCountry, type CrawlCountryDeps } from "./run";
-
-const FROZEN_NOW = new Date("2026-05-12T12:00:00.000Z");
 
 function sampleRssTracks(): AppleRssTrack[] {
   return [
@@ -37,120 +33,126 @@ function sampleRssTracks(): AppleRssTrack[] {
   ];
 }
 
-function makeDeps(overrides: Partial<CrawlCountryDeps> = {}): CrawlCountryDeps {
+function previewUrlForId(id: string): string {
+  return `https://preview/${id}.m4a`;
+}
+
+function makeCrawlCountryDeps(
+  overrides: Partial<CrawlCountryDeps> = {},
+): CrawlCountryDeps {
   const tracks = sampleRssTracks();
   return {
     cc: "kr",
     name: "South Korea",
     fetchRss: vi.fn(async () => tracks),
     lookupTrack: vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
-      async (id) => ({
-        id,
-        previewUrl: `https://preview/${id}.m4a`,
-      }),
+      async (id) => ({ id, previewUrl: previewUrlForId(id) }),
     ),
     throttle: async (fn) => fn(),
-    uploadCharts: vi.fn(async () => "https://blob/charts/v1/charts.json"),
-    triggerRevalidate: vi.fn(async () => {}),
-    now: () => FROZEN_NOW,
     ...overrides,
   };
 }
 
-test("returns a chart file that satisfies ChartFileSchema on full success", async () => {
-  const deps = makeDeps();
+test("crawlCountry returns valid=true with all tracks on full success", async () => {
+  const deps = makeCrawlCountryDeps();
 
-  const result = await crawlCountry(deps);
+  const { cc, country } = await crawlCountry(deps);
 
-  const parsed = ChartFileSchema.parse(result.chartFile);
-  expect(parsed.lastUpdated).toBe(FROZEN_NOW.toISOString());
-  expect(parsed.countries.kr.name).toBe("South Korea");
-  expect(parsed.countries.kr.valid).toBe(true);
-  expect(parsed.countries.kr.tracks).toHaveLength(3);
+  expect(cc).toBe(deps.cc);
+  expect(country.name).toBe(deps.name);
+  expect(country.valid).toBe(true);
+  expect(country.tracks).toHaveLength(sampleRssTracks().length);
 });
 
-test("composes RSS + Lookup into typed tracks with synthesized spotifySearchUrl", async () => {
+test("crawlCountry composes RSS + Lookup into typed tracks with synthesized spotifySearchUrl", async () => {
   const [firstRss] = sampleRssTracks();
-  const deps = makeDeps();
+  const deps = makeCrawlCountryDeps();
 
-  const { chartFile } = await crawlCountry(deps);
+  const { country } = await crawlCountry(deps);
 
-  expect(chartFile.countries.kr.tracks[0]).toEqual({
+  expect(country.tracks[0]).toEqual({
     rank: firstRss.rank,
     name: firstRss.name,
     artist: firstRss.artist,
     appleUrl: firstRss.appleUrl,
     artworkUrl: firstRss.artworkUrl,
-    previewUrl: `https://preview/${firstRss.id}.m4a`,
+    previewUrl: previewUrlForId(firstRss.id),
     spotifySearchUrl: `https://open.spotify.com/search/${encodeURIComponent(
       `${firstRss.name} ${firstRss.artist}`,
     )}`,
   });
 });
 
-test("marks country valid=false and drops failing tracks when a lookup misses", async () => {
+test("crawlCountry drops a missed track but keeps the country valid=true", async () => {
+  const failingId = "2";
   const lookupTrack = vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
     async (id, cc) => {
-      if (id === "2") throw new ItunesLookupError(id, cc, "miss", "no track");
-      return { id, previewUrl: `https://preview/${id}.m4a` };
+      if (id === failingId)
+        throw new ItunesLookupError(id, cc, "miss", "no track");
+      return { id, previewUrl: previewUrlForId(id) };
     },
   );
-  const deps = makeDeps({ lookupTrack });
+  const deps = makeCrawlCountryDeps({ lookupTrack });
+  const expectedSurvivingRanks = sampleRssTracks()
+    .filter((t) => t.id !== failingId)
+    .map((t) => t.rank);
 
-  const { chartFile } = await crawlCountry(deps);
+  const { country } = await crawlCountry(deps);
 
-  expect(chartFile.countries.kr.valid).toBe(false);
-  expect(chartFile.countries.kr.tracks).toHaveLength(2);
-  expect(chartFile.countries.kr.tracks.map((t) => t.rank)).toEqual([1, 3]);
+  expect(country.valid).toBe(true);
+  expect(country.tracks).toHaveLength(expectedSurvivingRanks.length);
+  expect(country.tracks.map((t) => t.rank)).toEqual(expectedSurvivingRanks);
 });
 
-test("rethrows when RSS fetch fails (no upload attempted)", async () => {
-  const errorMessage = "rss fetch error";
-  const deps = makeDeps({
+test("crawlCountry returns valid=false with empty tracks when RSS throws AppleRssError", async () => {
+  const fetchRss = vi.fn(async () => {
+    throw new AppleRssError("kr", "503 Service Unavailable");
+  });
+  const deps = makeCrawlCountryDeps({ fetchRss });
+
+  const { country } = await crawlCountry(deps);
+
+  expect(country.valid).toBe(false);
+  expect(country.tracks).toEqual([]);
+  expect(country.name).toBe(deps.name);
+});
+
+test("crawlCountry rethrows non-AppleRssError from fetchRss", async () => {
+  const errorMessage = "unexpected rss error";
+  const deps = makeCrawlCountryDeps({
     fetchRss: vi.fn(async () => {
-      throw new Error(errorMessage);
+      throw new TypeError(errorMessage);
     }),
   });
 
-  await expect(crawlCountry(deps)).rejects.toThrow(errorMessage);
-  expect(deps.uploadCharts).not.toHaveBeenCalled();
-  expect(deps.triggerRevalidate).not.toHaveBeenCalled();
+  const promise = crawlCountry(deps);
+
+  await expect(promise).rejects.toThrow(errorMessage);
 });
 
-test("rethrows non-ItunesLookupError from lookupTrack (no silent recovery)", async () => {
+test("crawlCountry rethrows non-ItunesLookupError from lookupTrack", async () => {
   const errorMessage = "unexpected lookup error";
-  const deps = makeDeps({
+  const deps = makeCrawlCountryDeps({
     lookupTrack: vi.fn(async () => {
       throw new TypeError(errorMessage);
     }),
   });
 
-  await expect(crawlCountry(deps)).rejects.toThrow(errorMessage);
-  expect(deps.uploadCharts).not.toHaveBeenCalled();
-  expect(deps.triggerRevalidate).not.toHaveBeenCalled();
+  const promise = crawlCountry(deps);
+
+  await expect(promise).rejects.toThrow(errorMessage);
 });
 
-test("uploads the chart file and triggers revalidate exactly once", async () => {
-  const deps = makeDeps();
-
-  const result = await crawlCountry(deps);
-
-  expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
-  expect(deps.uploadCharts).toHaveBeenCalledWith(result.chartFile);
-  expect(deps.triggerRevalidate).toHaveBeenCalledTimes(1);
-  expect(result.url).toBe("https://blob/charts/v1/charts.json");
-});
-
-test("routes every external call through the injected throttle", async () => {
+test("crawlCountry routes every external call through the injected throttle", async () => {
   let count = 0;
   const throttle = async <T>(fn: () => Promise<T>): Promise<T> => {
     count += 1;
     return fn();
   };
-  const deps = makeDeps({ throttle });
+  const deps = makeCrawlCountryDeps({ throttle });
+  const expectedCount = 1 + sampleRssTracks().length; // 1 RSS + N Lookups
 
   await crawlCountry(deps);
 
-  // 1 RSS + 3 Lookups
-  expect(count).toBe(4);
+  expect(count).toBe(expectedCount);
 });

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -1,4 +1,5 @@
-import type { Country, Track } from "../../src/lib/chart-schema";
+import type { ChartFile, Country, Track } from "../../src/lib/chart-schema";
+import type { CountryEntry } from "../../src/lib/countries";
 
 import { AppleRssError, type AppleRssTrack } from "./apple-rss";
 import { ItunesLookupError, type LookupResult } from "./itunes-lookup";
@@ -15,6 +16,21 @@ export interface CrawlCountryDeps {
 export interface CrawlCountryResult {
   cc: string;
   country: Country;
+}
+
+export interface CrawlAllDeps {
+  countries: readonly CountryEntry[];
+  fetchRss: (cc: string) => Promise<AppleRssTrack[]>;
+  lookupTrack: (id: string, cc: string) => Promise<LookupResult>;
+  throttle: Throttle;
+  uploadCharts: (chartFile: ChartFile) => Promise<string>;
+  triggerRevalidate: () => Promise<void>;
+  now?: () => Date;
+}
+
+export interface CrawlAllResult {
+  url: string;
+  chartFile: ChartFile;
 }
 
 function spotifySearchUrl(name: string, artist: string): string {
@@ -57,4 +73,46 @@ export async function crawlCountry(
   }
 
   return { cc, country: { name, valid: true, tracks } };
+}
+
+export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
+  const {
+    countries,
+    fetchRss,
+    lookupTrack,
+    throttle,
+    uploadCharts,
+    triggerRevalidate,
+  } = deps;
+  const now = deps.now ?? (() => new Date());
+
+  console.log(
+    `[crawl] starting all-countries crawl (${countries.length} countries)...`,
+  );
+
+  const countriesMap: ChartFile["countries"] = {};
+  for (const entry of countries) {
+    const { cc, country } = await crawlCountry({
+      cc: entry.code,
+      name: entry.name,
+      fetchRss,
+      lookupTrack,
+      throttle,
+    });
+    countriesMap[cc] = country;
+    console.log(
+      `[crawl ${cc}] ${country.tracks.length} tracks (valid=${country.valid})`,
+    );
+  }
+
+  const chartFile: ChartFile = {
+    lastUpdated: now().toISOString(),
+    countries: countriesMap,
+  };
+
+  const url = await uploadCharts(chartFile);
+  console.log(`[crawl] uploaded → ${url}`);
+  await triggerRevalidate();
+
+  return { url, chartFile };
 }

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -1,6 +1,6 @@
-import type { ChartFile, Country, Track } from "../../src/lib/chart-schema";
+import type { Country, Track } from "../../src/lib/chart-schema";
 
-import type { AppleRssTrack } from "./apple-rss";
+import { AppleRssError, type AppleRssTrack } from "./apple-rss";
 import { ItunesLookupError, type LookupResult } from "./itunes-lookup";
 import type { Throttle } from "./throttle";
 
@@ -10,14 +10,11 @@ export interface CrawlCountryDeps {
   fetchRss: (cc: string) => Promise<AppleRssTrack[]>;
   lookupTrack: (id: string, cc: string) => Promise<LookupResult>;
   throttle: Throttle;
-  uploadCharts: (chartFile: ChartFile) => Promise<string>;
-  triggerRevalidate: () => Promise<void>;
-  now?: () => Date;
 }
 
 export interface CrawlCountryResult {
-  url: string;
-  chartFile: ChartFile;
+  cc: string;
+  country: Country;
 }
 
 function spotifySearchUrl(name: string, artist: string): string {
@@ -27,21 +24,18 @@ function spotifySearchUrl(name: string, artist: string): string {
 export async function crawlCountry(
   deps: CrawlCountryDeps,
 ): Promise<CrawlCountryResult> {
-  const {
-    cc,
-    name,
-    fetchRss,
-    lookupTrack,
-    throttle,
-    uploadCharts,
-    triggerRevalidate,
-  } = deps;
-  const now = deps.now ?? (() => new Date());
+  const { cc, name, fetchRss, lookupTrack, throttle } = deps;
 
-  const rssTracks = await throttle(() => fetchRss(cc));
+  let rssTracks: AppleRssTrack[];
+  try {
+    rssTracks = await throttle(() => fetchRss(cc));
+  } catch (err) {
+    if (!(err instanceof AppleRssError)) throw err;
+    console.warn(`[crawl ${cc}] RSS failed: ${err.message}`);
+    return { cc, country: { name, valid: false, tracks: [] } };
+  }
 
   const tracks: Track[] = [];
-  let failures = 0;
   for (const rss of rssTracks) {
     try {
       const lookup = await throttle(() => lookupTrack(rss.id, cc));
@@ -56,27 +50,11 @@ export async function crawlCountry(
       });
     } catch (err) {
       if (!(err instanceof ItunesLookupError)) throw err;
-
-      failures += 1;
       console.warn(
         `[crawl ${cc}] lookup failed for rank ${rss.rank} id=${rss.id}: ${err.message}`,
       );
     }
   }
 
-  const country: Country = {
-    name,
-    valid: failures === 0,
-    tracks,
-  };
-
-  const chartFile: ChartFile = {
-    lastUpdated: now().toISOString(),
-    countries: { [cc]: country },
-  };
-
-  const url = await uploadCharts(chartFile);
-  await triggerRevalidate();
-
-  return { url, chartFile };
+  return { cc, country: { name, valid: true, tracks } };
 }

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -53,23 +53,26 @@ export async function crawlCountry(
 
   const tracks: Track[] = [];
   for (const rss of rssTracks) {
+    let previewUrl: string | null;
     try {
       const lookup = await throttle(() => lookupTrack(rss.id, cc));
-      tracks.push({
-        rank: rss.rank,
-        name: rss.name,
-        artist: rss.artist,
-        previewUrl: lookup.previewUrl,
-        artworkUrl: rss.artworkUrl,
-        appleUrl: rss.appleUrl,
-        spotifySearchUrl: spotifySearchUrl(rss.name, rss.artist),
-      });
+      previewUrl = lookup.previewUrl;
     } catch (err) {
       if (!(err instanceof ItunesLookupError)) throw err;
       console.warn(
-        `[crawl ${cc}] lookup failed for rank ${rss.rank} id=${rss.id}: ${err.message}`,
+        `[crawl ${cc}] lookup ${err.kind} for rank ${rss.rank} id=${rss.id}: ${err.message}`,
       );
+      previewUrl = null;
     }
+    tracks.push({
+      rank: rss.rank,
+      name: rss.name,
+      artist: rss.artist,
+      previewUrl,
+      artworkUrl: rss.artworkUrl,
+      appleUrl: rss.appleUrl,
+      spotifySearchUrl: spotifySearchUrl(rss.name, rss.artist),
+    });
   }
 
   return { cc, country: { name, valid: true, tracks } };

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -6,3 +6,28 @@ import { ChartFileSchema } from "./chart-schema";
 test("ChartFileSchema parses the hand-crafted fixture", () => {
   expect(() => ChartFileSchema.parse(fixture)).not.toThrow();
 });
+
+test("ChartFileSchema accepts null previewUrl (placeholder for lookup-failed tracks)", () => {
+  const withNullPreview = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withNullPreview)).not.toThrow();
+});

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -4,7 +4,7 @@ const TrackSchema = z.object({
   rank: z.number().int().min(1).max(25),
   name: z.string().min(1),
   artist: z.string().min(1),
-  previewUrl: z.url(),
+  previewUrl: z.url().nullable(),
   artworkUrl: z.url(),
   appleUrl: z.url(),
   spotifySearchUrl: z.url(),

--- a/src/lib/countries.test.ts
+++ b/src/lib/countries.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest";
+
+import { COUNTRIES } from "./countries";
+
+test("has 40 entries", () => {
+  expect(COUNTRIES).toHaveLength(40);
+});
+
+test("country codes are unique", () => {
+  const codes = COUNTRIES.map((c) => c.code);
+  expect(new Set(codes).size).toBe(codes.length);
+});
+
+test("country codes are lowercase ISO 3166-1 alpha-2", () => {
+  for (const c of COUNTRIES) {
+    expect(c.code).toMatch(/^[a-z]{2}$/);
+  }
+});

--- a/src/lib/countries.test.ts
+++ b/src/lib/countries.test.ts
@@ -2,10 +2,6 @@ import { expect, test } from "vitest";
 
 import { COUNTRIES } from "./countries";
 
-test("has 40 entries", () => {
-  expect(COUNTRIES).toHaveLength(40);
-});
-
 test("country codes are unique", () => {
   const codes = COUNTRIES.map((c) => c.code);
   expect(new Set(codes).size).toBe(codes.length);

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -1,0 +1,59 @@
+export type Region = "Americas" | "Europe" | "Asia" | "Oceania" | "Africa";
+
+export interface CountryEntry {
+  code: string;
+  name: string;
+  region: Region;
+}
+
+export const COUNTRIES: readonly CountryEntry[] = [
+  // Americas (8)
+  { code: "us", name: "United States", region: "Americas" },
+  { code: "ca", name: "Canada", region: "Americas" },
+  { code: "mx", name: "Mexico", region: "Americas" },
+  { code: "br", name: "Brazil", region: "Americas" },
+  { code: "ar", name: "Argentina", region: "Americas" },
+  { code: "cl", name: "Chile", region: "Americas" },
+  { code: "co", name: "Colombia", region: "Americas" },
+  { code: "pe", name: "Peru", region: "Americas" },
+
+  // Europe (14)
+  { code: "gb", name: "United Kingdom", region: "Europe" },
+  { code: "fr", name: "France", region: "Europe" },
+  { code: "de", name: "Germany", region: "Europe" },
+  { code: "es", name: "Spain", region: "Europe" },
+  { code: "it", name: "Italy", region: "Europe" },
+  { code: "nl", name: "Netherlands", region: "Europe" },
+  { code: "se", name: "Sweden", region: "Europe" },
+  { code: "no", name: "Norway", region: "Europe" },
+  { code: "dk", name: "Denmark", region: "Europe" },
+  { code: "fi", name: "Finland", region: "Europe" },
+  { code: "ie", name: "Ireland", region: "Europe" },
+  { code: "pt", name: "Portugal", region: "Europe" },
+  { code: "pl", name: "Poland", region: "Europe" },
+  { code: "tr", name: "Turkey", region: "Europe" },
+
+  // Asia (14)
+  { code: "jp", name: "Japan", region: "Asia" },
+  { code: "kr", name: "South Korea", region: "Asia" },
+  { code: "tw", name: "Taiwan", region: "Asia" },
+  { code: "hk", name: "Hong Kong", region: "Asia" },
+  { code: "sg", name: "Singapore", region: "Asia" },
+  { code: "th", name: "Thailand", region: "Asia" },
+  { code: "id", name: "Indonesia", region: "Asia" },
+  { code: "vn", name: "Vietnam", region: "Asia" },
+  { code: "ph", name: "Philippines", region: "Asia" },
+  { code: "my", name: "Malaysia", region: "Asia" },
+  { code: "in", name: "India", region: "Asia" },
+  { code: "ae", name: "United Arab Emirates", region: "Asia" },
+  { code: "sa", name: "Saudi Arabia", region: "Asia" },
+  { code: "il", name: "Israel", region: "Asia" },
+
+  // Oceania (2)
+  { code: "au", name: "Australia", region: "Oceania" },
+  { code: "nz", name: "New Zealand", region: "Oceania" },
+
+  // Africa (2)
+  { code: "za", name: "South Africa", region: "Africa" },
+  { code: "ng", name: "Nigeria", region: "Africa" },
+];


### PR DESCRIPTION
## Summary

Scales the crawler from one country to 40. `crawlCountry` produces
one country's result; `crawlAll` iterates, aggregates, uploads
once, revalidates once. Partial failures land as `valid: false,
tracks: []` without aborting the run.

## Design notes

**Country list**: 40 from the V1 handoff doc, grouped by 5 continents.

**Partial-failure semantics** (issue defers to implementation):
- RSS fail → country `valid: false, tracks: []`
- Lookup miss → drop the track, country stays `valid: true`

`valid` reads as "country has data at all", not "100% complete" —
clean binary signal for the Phase 3 UI.

**CLI**: `pnpm crawl` = all 40 (uploads); `pnpm crawl <cc>` =
single-country dry-run (no Blob write).

## Test plan

- [x] `mise exec -- pnpm test` (42 tests across 8 files)
- [x] `mise exec -- pnpm typecheck`
- [x] `pnpm crawl kr` dry-run round-trips, 25/25 valid=true
- [x] 3-country smoke (kr/us/ng) writes valid Blob, all 25/25 valid=true
- [x] 40-country full run: all 40 valid=true, 25/25 tracks each, no failures

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized country reference data and a single-country “dry run” mode separate from full multi-country crawls.

* **Improvements**
  * Crawl orchestration now distinguishes feed-level failures from lookup failures; lookup failures keep tracks but set previewUrl=null.
  * Full crawls upload charts and trigger revalidation once, with improved logging.

* **Tests**
  * Added tests for country data, chart schema (nullable previewUrl), and multi-country crawl behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->