### PR TITLE
feat(cron): production cron with Sentry monitor and revalidate trigger

### DIFF
--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -1,0 +1,39 @@
+name: Cron Crawl
+
+# Drop all GITHUB_TOKEN permissions; this workflow only runs pnpm install + crawl.
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 4,11,16,22 * * *" # UTC; ADR-0002
+  workflow_dispatch:
+
+# A run takes ~50 minutes; never cancel an in-flight run for a superseding trigger.
+concurrency:
+  group: cron-crawl
+  cancel-in-progress: false
+
+jobs:
+  crawl:
+    name: Crawl + Publish + Revalidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    env:
+      SITE_URL: https://sounds-abroad.vercel.app
+      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+      NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node and pnpm via mise
+        uses: jdx/mise-action@v2
+
+      - name: Install dependencies
+        run: mise exec -- pnpm install --frozen-lockfile
+
+      - name: Crawl, publish, and revalidate
+        run: mise exec -- pnpm crawl:cron

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest",
     "test:ci": "vitest --watch=false --reporter=default --reporter=github-actions",
     "crawl": "tsx --env-file=.env.local scripts/crawl/main.ts",
+    "crawl:cron": "tsx scripts/crawl/cron.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -1,0 +1,45 @@
+import "./sentry-init";
+import * as Sentry from "@sentry/nextjs";
+
+import { COUNTRIES } from "../../src/lib/countries";
+
+import { fetchAppleRss } from "./apple-rss";
+import { lookupTrack } from "./itunes-lookup";
+import { triggerRevalidate } from "./revalidate-trigger";
+import { crawlAll } from "./run";
+import { createThrottle } from "./throttle";
+import { uploadCharts } from "./upload-blob";
+
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  throw new Error("BLOB_READ_WRITE_TOKEN missing.");
+}
+
+await Sentry.withMonitor(
+  "charts-crawl",
+  async () => {
+    const result = await crawlAll({
+      countries: COUNTRIES,
+      fetchRss: fetchAppleRss,
+      lookupTrack,
+      throttle: createThrottle(),
+      uploadCharts,
+      triggerRevalidate,
+    });
+    const countries = Object.values(result.chartFile.countries);
+    Sentry.captureMessage("charts:published", {
+      level: "info",
+      extra: {
+        run_id: process.env.GITHUB_RUN_ID,
+        country_count: countries.length,
+        valid_count: countries.filter((c) => c.valid).length,
+        blob_url: result.url,
+      },
+    });
+  },
+  {
+    schedule: { type: "crontab", value: "0 4,11,16,22 * * *" },
+    timezone: "UTC",
+    checkinMargin: 5,
+    maxRuntime: 90,
+  },
+);

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -14,32 +14,39 @@ if (!process.env.BLOB_READ_WRITE_TOKEN) {
   throw new Error("BLOB_READ_WRITE_TOKEN missing.");
 }
 
-await Sentry.withMonitor(
-  "charts-crawl",
-  async () => {
-    const result = await crawlAll({
-      countries: COUNTRIES,
-      fetchRss: fetchAppleRss,
-      lookupTrack,
-      throttle: createThrottle(),
-      uploadCharts,
-      triggerRevalidate,
-    });
-    const countries = Object.values(result.chartFile.countries);
-    Sentry.captureMessage("charts:published", {
-      level: "info",
-      extra: {
-        run_id: process.env.GITHUB_RUN_ID,
-        country_count: countries.length,
-        valid_count: countries.filter((c) => c.valid).length,
-        blob_url: result.url,
-      },
-    });
-  },
-  {
-    schedule: { type: "crontab", value: "0 4,11,16,22 * * *" },
-    timezone: "UTC",
-    checkinMargin: 5,
-    maxRuntime: 90,
-  },
-);
+// Short-lived process: must flush before exit so the monitor check-in + the
+// charts:published message actually reach Sentry. withMonitor returning is not
+// the same as the events being transmitted.
+try {
+  await Sentry.withMonitor(
+    "charts-crawl",
+    async () => {
+      const result = await crawlAll({
+        countries: COUNTRIES,
+        fetchRss: fetchAppleRss,
+        lookupTrack,
+        throttle: createThrottle(),
+        uploadCharts,
+        triggerRevalidate,
+      });
+      const countries = Object.values(result.chartFile.countries);
+      Sentry.captureMessage("charts:published", {
+        level: "info",
+        extra: {
+          run_id: process.env.GITHUB_RUN_ID,
+          country_count: countries.length,
+          valid_count: countries.filter((c) => c.valid).length,
+          blob_url: result.url,
+        },
+      });
+    },
+    {
+      schedule: { type: "crontab", value: "0 4,11,16,22 * * *" },
+      timezone: "UTC",
+      checkinMargin: 5,
+      maxRuntime: 90,
+    },
+  );
+} finally {
+  await Sentry.flush(5000);
+}

--- a/scripts/crawl/main.ts
+++ b/scripts/crawl/main.ts
@@ -2,7 +2,6 @@ import { COUNTRIES } from "../../src/lib/countries";
 
 import { fetchAppleRss } from "./apple-rss";
 import { lookupTrack } from "./itunes-lookup";
-import { triggerRevalidate } from "./revalidate-trigger";
 import { crawlAll, crawlCountry } from "./run";
 import { createThrottle } from "./throttle";
 import { uploadCharts } from "./upload-blob";
@@ -53,7 +52,10 @@ async function runAllCountries(): Promise<void> {
     lookupTrack,
     throttle,
     uploadCharts,
-    triggerRevalidate,
+    // Local debug entry never hits production revalidate — cron.ts injects the real one.
+    triggerRevalidate: async () => {
+      console.log("[crawl] revalidate skipped (local debug)");
+    },
   });
 }
 

--- a/scripts/crawl/revalidate-trigger.test.ts
+++ b/scripts/crawl/revalidate-trigger.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { triggerRevalidate } from "./revalidate-trigger";
+
+const SITE_URL = "https://example.test";
+const SECRET = "fixture-secret";
+const PROPAGATION_MS = 120_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  process.env.SITE_URL = SITE_URL;
+  process.env.REVALIDATE_SECRET = SECRET;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete process.env.SITE_URL;
+  delete process.env.REVALIDATE_SECRET;
+});
+
+test("throws when SITE_URL is missing", async () => {
+  delete process.env.SITE_URL;
+
+  await expect(triggerRevalidate()).rejects.toThrow(/SITE_URL/);
+});
+
+test("throws when REVALIDATE_SECRET is missing", async () => {
+  delete process.env.REVALIDATE_SECRET;
+
+  await expect(triggerRevalidate()).rejects.toThrow(/REVALIDATE_SECRET/);
+});
+
+test("waits PROPAGATION_MS before issuing the bearer POST", async () => {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response(null, { status: 200 }));
+
+  const pending = triggerRevalidate();
+  expect(fetchSpy).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(PROPAGATION_MS - 1);
+  expect(fetchSpy).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(1);
+  await pending;
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  expect(fetchSpy).toHaveBeenCalledWith(`${SITE_URL}/api/revalidate`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${SECRET}` },
+  });
+});
+
+test("throws with status code when revalidate responds non-2xx", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(null, { status: 401, statusText: "Unauthorized" }),
+  );
+
+  // Attach the rejection assertion before driving timers so the rejection is
+  // observed synchronously — otherwise Node flags it as unhandled.
+  const assertion = expect(triggerRevalidate()).rejects.toThrow(/401/);
+  await vi.advanceTimersByTimeAsync(PROPAGATION_MS);
+  await assertion;
+});

--- a/scripts/crawl/revalidate-trigger.test.ts
+++ b/scripts/crawl/revalidate-trigger.test.ts
@@ -46,10 +46,14 @@ test("waits PROPAGATION_MS before issuing the bearer POST", async () => {
   await pending;
 
   expect(fetchSpy).toHaveBeenCalledTimes(1);
-  expect(fetchSpy).toHaveBeenCalledWith(`${SITE_URL}/api/revalidate`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${SECRET}` },
-  });
+  expect(fetchSpy).toHaveBeenCalledWith(
+    `${SITE_URL}/api/revalidate`,
+    expect.objectContaining({
+      method: "POST",
+      headers: { Authorization: `Bearer ${SECRET}` },
+      signal: expect.any(AbortSignal),
+    }),
+  );
 });
 
 test("throws with status code when revalidate responds non-2xx", async () => {

--- a/scripts/crawl/revalidate-trigger.ts
+++ b/scripts/crawl/revalidate-trigger.ts
@@ -13,6 +13,9 @@ export async function triggerRevalidate(): Promise<void> {
   const res = await fetch(`${url}/api/revalidate`, {
     method: "POST",
     headers: { Authorization: `Bearer ${secret}` },
+    // Bound the request so a hung endpoint doesn't push the cron past its
+    // schedule window. TimeoutError surfaces unchanged via Sentry.
+    signal: AbortSignal.timeout(15_000),
   });
   if (!res.ok) {
     throw new Error(`revalidate failed: ${res.status} ${res.statusText}`);

--- a/scripts/crawl/revalidate-trigger.ts
+++ b/scripts/crawl/revalidate-trigger.ts
@@ -1,5 +1,20 @@
+// 2× Vercel Blob s-maxage (60s, see upload-blob.ts) — gives edge propagation
+// headroom so revalidate doesn't re-cache stale Blob.
+const PROPAGATION_MS = 120_000;
+
 export async function triggerRevalidate(): Promise<void> {
-  console.log(
-    "[crawl] revalidate trigger: no-op (Issue #7 will wire to /api/revalidate)",
-  );
+  const url = process.env.SITE_URL;
+  const secret = process.env.REVALIDATE_SECRET;
+  if (!url) throw new Error("SITE_URL missing");
+  if (!secret) throw new Error("REVALIDATE_SECRET missing");
+
+  await new Promise((r) => setTimeout(r, PROPAGATION_MS));
+
+  const res = await fetch(`${url}/api/revalidate`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${secret}` },
+  });
+  if (!res.ok) {
+    throw new Error(`revalidate failed: ${res.status} ${res.statusText}`);
+  }
 }

--- a/scripts/crawl/sentry-init.ts
+++ b/scripts/crawl/sentry-init.ts
@@ -1,0 +1,13 @@
+import * as Sentry from "@sentry/nextjs";
+
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+if (!dsn) {
+  throw new Error("NEXT_PUBLIC_SENTRY_DSN missing — set as GitHub Secret.");
+}
+
+Sentry.init({
+  dsn,
+  environment: "production-cron",
+  release: process.env.GITHUB_SHA?.slice(0, 7),
+  tracesSampleRate: 0,
+});


### PR DESCRIPTION
## Summary

Wires the 40-country crawler to GitHub Actions on the ADR-0002 cadence (UTC 04/11/16/22). Each run is wrapped in `Sentry.withMonitor` so missed/late executions surface as alerts. After publishing to Blob, the cron waits 120s for CDN propagation, then POSTs the bearer-authenticated `/api/revalidate` to invalidate the `music-charts` cache tag.

## Design notes

- **Entry split**: `cron.ts` is CI-only with Sentry + real revalidate. `main.ts` (local `pnpm crawl`) injects a noop `triggerRevalidate` so debug runs cannot invalidate the production cache.
- **CDN propagation = 120s**: 2x Vercel Blob `s-maxage` (60s) for headroom; avoids revalidate re-caching a stale Blob.
- **Monitor slug**: `charts-crawl`; schedule `0 4,11,16,22 * * *` UTC. Sentry auto-upserts the monitor on first check-in.
- **Workflow concurrency**: `cancel-in-progress: false` so a ~50min run completes even if a manual trigger overlaps.

## Test plan

- [x] `mise exec -- pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:ci && pnpm build` all green
- [x] `revalidate-trigger.test.ts` 4 tests: env guards, 120s wait, bearer header, non-2xx throw
- [ ] (post-merge) workflow_dispatch run: Sentry monitor `charts-crawl` heartbeat ok, `charts:published` message with country_count=40 + valid_count + blob_url, debug page reflects fresh data within ~90s

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled automated chart data crawls running multiple times daily via GitHub Actions.
  * Integrated Sentry monitoring for crawl operations with published metrics and statistics.
  * Enabled automatic site revalidation after successful data crawls.

* **Tests**
  * Added comprehensive test coverage for revalidation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->