### PR TITLE
fix(cron): use @sentry/node in standalone tsx scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^10.51.0",
+    "@sentry/node": "^10.51.0",
     "@vercel/blob": "^2.3.0",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.51.0
         version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.0))
+      '@sentry/node':
+        specifier: ^10.51.0
+        version: 10.51.0
       '@vercel/blob':
         specifier: ^2.3.0
         version: 2.3.0

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -1,5 +1,5 @@
 import "./sentry-init";
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/node";
 
 import { COUNTRIES } from "../../src/lib/countries";
 

--- a/scripts/crawl/sentry-init.ts
+++ b/scripts/crawl/sentry-init.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/node";
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 if (!dsn) {


### PR DESCRIPTION
## Why

GH Actions cron `crawl:cron` failed with `TypeError: Sentry.flush is not a function`. Root cause: `@sentry/nextjs`'s CJS build re-exports most of `@sentry/node`'s API via a runtime `Object.keys().forEach()` loop. Node's `cjs-module-lexer` only sees static `exports.X = ...` assignments, so `import * as Sentry from "@sentry/nextjs"` in an ESM tsx script leaves `withMonitor`, `flush`, `captureMessage` all `undefined`.

The visible error pointed at `flush` (line 51), but `withMonitor` (line 21) had failed first — the `finally` block's TypeError masked the original. `crawlAll` never ran.

`src/` is unaffected because the Next bundler handles CJS interop separately.

## What

- Add `@sentry/node@^10.51.0` as direct dep (pinned to `@sentry/nextjs` major)
- `scripts/crawl/cron.ts` and `scripts/crawl/sentry-init.ts` import from `@sentry/node`
- `src/` imports unchanged

## Verification

Smoke test confirming all four APIs resolve via tsx ESM:

```
init           | nextjs: function  | node: function
withMonitor    | nextjs: undefined | node: function
flush          | nextjs: undefined | node: function
captureMessage | nextjs: undefined | node: function
```

`pnpm typecheck` and `pnpm lint` pass.

## Test plan

- [x] Re-run `cron-crawl.yml` via workflow_dispatch on this branch before merge — expect green
- [x] Sentry receives `charts-crawl` monitor check-in
- [x] `charts:published` message appears in Sentry with run metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error monitoring configuration for background operations to enhance system reliability and diagnostic capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->