### PR TITLE
chore(ci): bump jdx/mise-action v2 → v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node and pnpm via mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Install dependencies
         run: mise exec -- pnpm install --frozen-lockfile

--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node and pnpm via mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Install dependencies
         run: mise exec -- pnpm install --frozen-lockfile


### PR DESCRIPTION
## Why

`jdx/mise-action@v2` pinned across all workflows is two majors behind (`v4.0.1`, released 2026-03-22).

v4 migrates the action runtime from Node 20 → Node 24 because GitHub deprecates Node 20 for Actions on **2026-06-02**. Both v2 and v3 are on the deprecation cliff and will start surfacing warnings, then break.

Per upstream v4.0.0 release notes: "seamless upgrade for the vast majority of users — no configuration changes needed beyond updating the version reference." Both workflows use `uses: jdx/mise-action@v2` with no inputs → no compat surface to break.

## What

- `.github/workflows/ci.yml` — `@v2` → `@v4`
- `.github/workflows/cron-crawl.yml` — `@v2` → `@v4`

## Test plan

- [x] CI on this PR runs with `@v4` and passes (lint, typecheck, test, build)
- [ ] After merge: next scheduled `cron-crawl` run uses `@v4` and passes (within 6h)