### PR TITLE
fix(cron): shift slot to :17 and raise checkin margin

### DIFF
--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -5,7 +5,7 @@ permissions: {}
 
 on:
   schedule:
-    - cron: "0 4,11,16,22 * * *" # UTC; ADR-0002
+    - cron: "17 4,11,16,22 * * *" # UTC; ADR-0002. Minute off :00 to avoid GH Actions scheduler peak.
   workflow_dispatch:
 
 # A run takes ~50 minutes; never cancel an in-flight run for a superseding trigger.

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -41,9 +41,9 @@ try {
       });
     },
     {
-      schedule: { type: "crontab", value: "0 4,11,16,22 * * *" },
+      schedule: { type: "crontab", value: "17 4,11,16,22 * * *" },
       timezone: "UTC",
-      checkinMargin: 5,
+      checkinMargin: 15,
       maxRuntime: 90,
     },
   );


### PR DESCRIPTION
## Summary

GitHub Actions cron at `:00` is delayed 25–73 min on this workflow
(measured across 3 schedule-triggered runs on 2026-05-18). With
`checkinMargin: 5`, every tick produced **two** Sentry check-ins:

- A **Missed** bound to the expected slot (margin expired before
  the run arrived)
- An **OK** bound to the *next* expected slot as an "early" arrival,
  because the past slot was already closed as Missed

Shift the schedule minute off `:00` and raise the margin so the
common case matches a single OK against its own slot.

## Changes

- `.github/workflows/cron-crawl.yml` — `0` → `17` in the minute field
- `scripts/crawl/cron.ts` — same schedule shift, `checkinMargin: 5` → `15`
- Cadence (4×/day) unchanged, so ADR-0002 stays accurate

## Measured GHA delays (2026-05-18, schedule trigger)

| Expected (UTC) | Actual start | Delay |
|---|---|---|
| 11:00 | 12:12 | +73 min |
| 16:00 | 17:03 | +63 min |
| 22:00 | 22:25 | +26 min |

Off-`:00` minutes are widely reported to land within a few minutes
of the scheduled tick — `checkinMargin: 15` gives headroom.

## Follow-up (not in this PR)

The cron expression lives in two places (workflow + cron.ts) and must
stay in sync, or Sentry's monitor schedule will drift from the actual
trigger. Worth extracting later, but out of scope here.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (51/51) green locally
- [x] CI green on PR
- [ ] After merge: next scheduled tick at `HH:17` produces a single OK check-in in Sentry with `EXPECTED ≈ STARTED`, no Missed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the scheduled timing for the automated crawl workflow.
  * Updated monitoring parameters to improve reliability tracking of scheduled tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->