### PR TITLE
chore: Phase 2 close cleanup — README + LICENSE + CREDITS

### DIFF
--- a/.claude/skills/CREDITS.md
+++ b/.claude/skills/CREDITS.md
@@ -1,0 +1,47 @@
+# Credits
+
+Some skills in this directory are vendored from:
+
+https://github.com/mattpocock/skills
+
+Vendored skills (used under the MIT License reproduced below):
+
+- caveman
+- diagnose
+- git-guardrails-claude-code
+- grill-me
+- grill-with-docs
+- handoff
+- improve-codebase-architecture
+- prototype
+- setup-pre-commit
+- tdd
+- to-issues
+- to-prd
+- triage
+- write-a-skill
+- zoom-out
+
+---
+
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Taewan Lim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ A 3D globe-based world music discovery web app — explore trending music around
 - **UI**: `@radix-ui/react-dialog`, `motion` _(planned, Phase 3)_
 - **Design system**: generated with Claude Design and refined through pointing-and-feedback — tokens live in [`src/app/globals.css`](src/app/globals.css), self-hosted fonts in [`src/app/fonts/`](src/app/fonts/), brand assets in [`public/`](public/)
 - **Toolchain**: Node 24 + pnpm 10 via [mise](https://mise.jdx.dev) (see [`mise.toml`](mise.toml)); Husky 9 + lint-staged for pre-commit format/lint/typecheck
-- **Hosting**: Vercel _(Phase 1, in flight)_
-- **Observability**: Sentry _(Phase 1, in flight)_
+- **Testing**: Vitest
+- **Hosting**: Vercel
+- **Observability**: Sentry (errors + Cron Monitor on the data pipeline)
 
 ## Run
 
@@ -24,6 +25,7 @@ mise exec -- pnpm build      # production build
 mise exec -- pnpm lint
 mise exec -- pnpm format
 mise exec -- pnpm typecheck
+mise exec -- pnpm test
 ```
 
 ## Where to look

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sounds-abroad",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@10.23.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Pre-tag cleanup so Phase 2 closes on attributed, license-compliant `main`:

1. README — drop "(Phase 1, in flight)" labels, add Vitest + `pnpm test` + Cron Monitor note.
2. `.claude/skills/CREDITS.md` — MIT attribution for 15 skills vendored from mattpocock/skills since ef74719 (2026-05-10).
3. `/LICENSE` — added via GitHub MIT template; repo was `licenseInfo: null`.
4. `package.json` `"license": "MIT"` — SPDX identifier paired with `/LICENSE`.

No behavioral change.

## Test plan
- [x] typecheck, lint, test green locally
- [x] CI green on PR