### PR TITLE
chore(docs): refresh AGENTS.md for Phase 2 close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,13 @@ Uses pnpm 10 + Node 24 via mise. Wrap commands with `mise exec --` so non-intera
 
 - `mise exec -- pnpm dev` — dev server (Turbopack)
 - `mise exec -- pnpm build` — production build
-- `mise exec -- pnpm lint` / `pnpm format` / `pnpm typecheck`
+- `mise exec -- pnpm lint` / `pnpm format` / `pnpm typecheck` / `pnpm test`
 
 Pre-commit hook runs format + lint + typecheck on staged files via Husky 9 + lint-staged.
 
 ## Branching
 
-Phase 1 commits directly to `main`. From Phase 2 onward, each Phase gets its own feature branch and PR.
+Phase 1 commits directly to `main`. From Phase 2 onward, each slice gets its own branch and PR into `main` (no umbrella phase branch).
 
 ## Where to look
 


### PR DESCRIPTION
## Summary

- Add `pnpm test` to Run commands (Vitest from #9 was missing here).
- Fix branching: each slice gets a branch, not each phase — the slice-based policy is what Phase 2 actually used.

## Test plan
- [x] typecheck, lint, test green locally (pre-commit)
- [x] CI green on PR