### PR TITLE
test(cron): assert workflow + cron.ts cron schedules stay in sync

### DIFF
--- a/scripts/crawl/schedule-drift.test.ts
+++ b/scripts/crawl/schedule-drift.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const workflowPath = ".github/workflows/cron-crawl.yml";
+const cronTsPath = "scripts/crawl/cron.ts";
+
+function extractCron(relPath: string, pattern: RegExp): string {
+  const contents = readFileSync(resolve(repoRoot, relPath), "utf8");
+  const match = contents.match(pattern);
+  if (!match) {
+    throw new Error(`Cron expression not found in ${relPath}`);
+  }
+  return match[1];
+}
+
+test(`cron schedule in ${workflowPath} matches ${cronTsPath}`, () => {
+  const workflowCron = extractCron(
+    workflowPath,
+    /^\s*-\s*cron:\s*["']([^"']+)["']/m,
+  );
+  const tsCron = extractCron(
+    cronTsPath,
+    /schedule:\s*\{[^}]*value:\s*["']([^"']+)["']/,
+  );
+  expect(workflowCron).toBe(tsCron);
+});

--- a/scripts/crawl/schedule-drift.test.ts
+++ b/scripts/crawl/schedule-drift.test.ts
@@ -25,7 +25,7 @@ test(`cron schedule in ${workflowPath} matches ${cronTsPath}`, () => {
   );
   const tsCron = extractCron(
     cronTsPath,
-    /schedule:\s*\{[^}]*value:\s*["']([^"']+)["']/,
+    /^\s*schedule:\s*\{[\s\S]*?\bvalue:\s*["']([^"']+)["']/m,
   );
   expect(workflowCron).toBe(tsCron);
 });


### PR DESCRIPTION
## Summary

- Adds a Vitest test that reads `.github/workflows/cron-crawl.yml` and `scripts/crawl/cron.ts`, extracts the cron expression from each, and asserts equality.
- Test name embeds both file paths, so a CI failure surfaces the drift target without needing to open the assertion diff.

Why a test guard instead of single-sourcing: GH Actions parses `on.schedule.cron` as a literal at workflow-load time. No expression evaluation, no file include — the value must remain duplicated. Codegen would add more maintenance surface than the duplication it eliminates. The test is zero-infra and turns hand-edit drift CI-red.

## Test plan

- [x] CI green (lint, format, typecheck, test, build)
- [x] CodeRabbit review

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added testing to ensure system reliability and consistency across scheduled operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->