### PR TITLE
chore(ci): drop redundant build step comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
         run: mise exec -- pnpm test:ci
 
       - name: Build
-        # `/` is statically generated and reads CHARTS_BLOB_URL at prerender time.
         env:
           CHARTS_BLOB_URL: ${{ secrets.CHARTS_BLOB_URL }}
         run: mise exec -- pnpm build


### PR DESCRIPTION
## Summary

Drop the comment above the build step's `env:` injection in `ci.yml`. The comment was restating WHAT the env line already shows; WHY lives in commit 4dbffb1 (PR #33).

Follow-up to #33.

## Test plan

- [x] CI green (no functional change)
