### PR TITLE
refactor(fixtures): drop TRACK_KR_1 asymmetric export

### DIFF
--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -1,31 +1,41 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 
-import { TRACK_KR_1 } from "@/lib/__fixtures__";
+import type { Track } from "@/lib/chart-schema";
 
 import { TrackRow } from "./track-row";
+
+const track: Track = {
+  rank: 1,
+  name: "Test Track",
+  artist: "Test Artist",
+  previewUrl: "https://example.com/preview.m4a",
+  artworkUrl: "https://example.com/artwork.jpg",
+  appleUrl: "https://music.apple.com/track/1",
+  spotifySearchUrl: "https://open.spotify.com/search/Test%20Track",
+};
 
 describe("TrackRow", () => {
   test("renders rank, name, and artist", () => {
     render(
       <ul>
-        <TrackRow track={TRACK_KR_1} />
+        <TrackRow track={track} />
       </ul>,
     );
 
-    expect(screen.getByText(String(TRACK_KR_1.rank))).toBeDefined();
-    expect(screen.getByText(TRACK_KR_1.name)).toBeDefined();
-    expect(screen.getByText(TRACK_KR_1.artist)).toBeDefined();
+    expect(screen.getByText(String(track.rank))).toBeDefined();
+    expect(screen.getByText(track.name)).toBeDefined();
+    expect(screen.getByText(track.artist)).toBeDefined();
   });
 
   test("renders artwork as a background image with the track's artworkUrl", () => {
     const { container } = render(
       <ul>
-        <TrackRow track={TRACK_KR_1} />
+        <TrackRow track={track} />
       </ul>,
     );
 
     const artwork = container.querySelector('[aria-hidden="true"]');
-    expect(artwork?.getAttribute("style")).toContain(TRACK_KR_1.artworkUrl);
+    expect(artwork?.getAttribute("style")).toContain(track.artworkUrl);
   });
 });

--- a/src/lib/__fixtures__/index.ts
+++ b/src/lib/__fixtures__/index.ts
@@ -14,14 +14,6 @@ if (!kr || !us || !br) {
   );
 }
 
-if (kr.tracks.length === 0) {
-  throw new Error(
-    "Test fixture kr.tracks is empty — update __fixtures__/charts.json",
-  );
-}
-
 export const COUNTRY_KR = kr;
 export const COUNTRY_US = us;
 export const COUNTRY_BR = br;
-
-export const TRACK_KR_1 = kr.tracks[0];


### PR DESCRIPTION
## Summary

Reach-in `kr.tracks[0]` next to country-level exports — doesn't scale.
TrackRow test owns a typed `Track` literal locally. The empty-array
preflight existed only to back `[0]` and goes too; kr/us/br guard stays.

## Test plan

- [x] typecheck + test green locally
- [x] CI green
- [x] CodeRabbit

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test utilities and fixtures to improve test maintainability.

* **Chores**
  * Refactored test data management for better test isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->