### PR TITLE
Phase 3 slice 3: Mini player + cross-state audio

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -4,10 +4,15 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
+import { MiniPlayer } from "@/components/mini-player";
 import { ChartPickStore } from "@/lib/chart-pick-store";
-import type { ChartFile } from "@/lib/chart-schema";
+import type { ChartFile, Country } from "@/lib/chart-schema";
 import { COUNTRIES } from "@/lib/countries";
-import { AudioStoreProvider } from "@/providers/audio-store-provider";
+import {
+  AudioStoreProvider,
+  useAudioStore,
+  useAudioStoreApi,
+} from "@/providers/audio-store-provider";
 
 const ALL_CODES = COUNTRIES.map((c) => c.code);
 
@@ -38,8 +43,6 @@ export function ChartScreen({ charts, rng = Math.random }: ChartScreenProps) {
     store.initIfNeeded(ALL_CODES, rng);
   }, [store, validUrlCc, rng]);
 
-  const [snap, setSnap] = useState<SnapState>("peek");
-
   const code = validUrlCc ?? pick.code ?? null;
   const country = code !== null ? (charts.countries[code] ?? null) : null;
 
@@ -47,7 +50,68 @@ export function ChartScreen({ charts, rng = Math.random }: ChartScreenProps) {
 
   return (
     <AudioStoreProvider>
-      <ChartSheet country={country} snap={snap} onSnapChange={setSnap} />
+      <ChartScreenInner country={country} />
     </AudioStoreProvider>
+  );
+}
+
+function ChartScreenInner({ country }: { country: Country }) {
+  const [snap, setSnap] = useState<SnapState>("peek");
+  const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
+  const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
+  const endedSignal = useAudioStore((s) => s.endedSignal);
+  const audioStore = useAudioStoreApi();
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      const { currentTrack, toggle } = audioStore.getState();
+      if (currentTrack === null) return;
+      e.preventDefault();
+      toggle(currentTrack);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [audioStore]);
+
+  useEffect(() => {
+    if (endedSignal === 0) return;
+    const { currentTrack, toggle } = audioStore.getState();
+    if (currentTrack === null) return;
+    const startIdx = country.tracks.findIndex(
+      (t) => t.previewUrl === currentTrack.previewUrl,
+    );
+    if (startIdx === -1) return;
+    for (let i = startIdx + 1; i < country.tracks.length; i++) {
+      if (country.tracks[i].previewUrl !== null) {
+        toggle(country.tracks[i]);
+        return;
+      }
+    }
+  }, [endedSignal, audioStore, country.tracks]);
+
+  return (
+    <>
+      <ChartSheet
+        country={country}
+        snap={snap}
+        onSnapChange={setSnap}
+        currentTrackRank={currentTrackRank}
+        canClose={hasCurrentTrack}
+      />
+      <MiniPlayer
+        sheetClosed={snap === "closed"}
+        onTap={() => setSnap("peek")}
+      />
+    </>
   );
 }

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -65,12 +65,17 @@ function ChartScreenInner({ country }: { country: Country }) {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.code !== "Space") return;
+      if (e.altKey || e.ctrlKey || e.metaKey) return;
       const target = e.target as HTMLElement | null;
       if (
         target &&
         (target.tagName === "INPUT" ||
           target.tagName === "TEXTAREA" ||
-          target.isContentEditable)
+          target.tagName === "SELECT" ||
+          target.isContentEditable ||
+          target.closest(
+            "button, a[href], [role='button'], [role='menuitem'], [role='switch'], [role='checkbox']",
+          ))
       ) {
         return;
       }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -137,6 +137,10 @@
     height: 50%;
     animation-delay: 0.4s;
   }
+
+  .eq[data-paused] span {
+    animation-play-state: paused;
+  }
 }
 
 @keyframes eq {

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -65,4 +65,99 @@ describe("ChartSheet", () => {
 
     expect(onSnapChange).toHaveBeenCalledWith("peek");
   });
+
+  test("scrolls currentTrack into view when sheet transitions from closed", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    const rank = COUNTRY_KR.tracks[2].rank;
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          snap="closed"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+        />
+      </AudioStoreProvider>,
+    );
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not scroll when transitioning between peek and full", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    const rank = COUNTRY_KR.tracks[0].rank;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+        />
+      </AudioStoreProvider>,
+    );
+
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          snap="full"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+        />
+      </AudioStoreProvider>,
+    );
+
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  test("does not scroll when currentTrackRank is null", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          snap="closed"
+          onSnapChange={vi.fn()}
+          currentTrackRank={null}
+        />
+      </AudioStoreProvider>,
+    );
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={null}
+        />
+      </AudioStoreProvider>,
+    );
+
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -1,10 +1,16 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { COUNTRY_KR } from "@/lib/__fixtures__";
 import { AudioStoreProvider } from "@/providers/audio-store-provider";
 
 import { ChartSheet, type SnapState } from "./sheet";
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+afterEach(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+});
 
 function renderSheet(snap: SnapState) {
   const onSnapChange = vi.fn();

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { motion, type PanInfo } from "motion/react";
+import {
+  motion,
+  type PanInfo,
+  useAnimationControls,
+  useDragControls,
+} from "motion/react";
 
 import type { Country } from "@/lib/chart-schema";
 
@@ -14,53 +19,118 @@ export interface ChartSheetProps {
   country: Country;
   snap: SnapState;
   onSnapChange: (snap: SnapState) => void;
+  currentTrackRank?: number | null;
+  canClose?: boolean;
 }
 
+const SNAP_Y_PCT: Record<SnapState, number> = {
+  full: 0,
+  peek: 65,
+  closed: 100,
+};
+
 const SNAP_Y: Record<SnapState, string> = {
-  closed: "100%",
-  peek: "65%",
-  full: "0%",
+  full: `${SNAP_Y_PCT.full}%`,
+  peek: `${SNAP_Y_PCT.peek}%`,
+  closed: `${SNAP_Y_PCT.closed}%`,
 };
 
 const SNAP_ORDER: SnapState[] = ["full", "peek", "closed"];
-const VELOCITY_THRESHOLD = 500;
-const OFFSET_THRESHOLD = 80;
+const VELOCITY_PROJECTION = 0.15;
 
 function nextSnap(
   current: SnapState,
   offsetY: number,
   velocityY: number,
 ): SnapState {
-  const idx = SNAP_ORDER.indexOf(current);
-  if (velocityY > VELOCITY_THRESHOLD || offsetY > OFFSET_THRESHOLD) {
-    return SNAP_ORDER[Math.min(idx + 1, SNAP_ORDER.length - 1)];
+  const vh = window.innerHeight;
+  const offsetPct = (offsetY / vh) * 100;
+  const velocityPct = (velocityY / vh) * 100;
+  const projected =
+    SNAP_Y_PCT[current] + offsetPct + velocityPct * VELOCITY_PROJECTION;
+
+  let nearest: SnapState = current;
+  let minDist = Infinity;
+  for (const s of SNAP_ORDER) {
+    const dist = Math.abs(SNAP_Y_PCT[s] - projected);
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = s;
+    }
   }
-  if (velocityY < -VELOCITY_THRESHOLD || offsetY < -OFFSET_THRESHOLD) {
-    return SNAP_ORDER[Math.max(idx - 1, 0)];
-  }
-  return current;
+  return nearest;
 }
 
-export function ChartSheet({ country, snap, onSnapChange }: ChartSheetProps) {
+export function ChartSheet({
+  country,
+  snap,
+  onSnapChange,
+  currentTrackRank = null,
+  canClose = true,
+}: ChartSheetProps) {
   const open = snap !== "closed";
+  const animationControls = useAnimationControls();
+  const dragControls = useDragControls();
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    void animationControls.start({ y: SNAP_Y[snap] });
+  }, [snap, animationControls]);
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
+      if (!next && !canClose) {
+        void animationControls.start({ y: SNAP_Y[snap] });
+        return;
+      }
       onSnapChange(next ? "peek" : "closed");
     },
-    [onSnapChange],
+    [onSnapChange, canClose, snap, animationControls],
   );
+
+  const handleDragStart = useCallback(() => setIsDragging(true), []);
 
   const handleDragEnd = useCallback(
     (_event: unknown, info: PanInfo) => {
-      onSnapChange(nextSnap(snap, info.offset.y, info.velocity.y));
+      setIsDragging(false);
+      const next = nextSnap(snap, info.offset.y, info.velocity.y);
+      if (next === "closed" && !canClose) {
+        void animationControls.start({ y: SNAP_Y[snap] });
+        return;
+      }
+      if (next === snap) {
+        void animationControls.start({ y: SNAP_Y[snap] });
+        return;
+      }
+      onSnapChange(next);
     },
-    [snap, onSnapChange],
+    [snap, onSnapChange, canClose, animationControls],
   );
 
   const handleToggle = useCallback(() => {
     onSnapChange(snap === "peek" ? "full" : "peek");
   }, [snap, onSnapChange]);
+
+  const olRef = useRef<HTMLOListElement | null>(null);
+  const prevSnapRef = useRef(snap);
+
+  useEffect(() => {
+    const wasClosed = prevSnapRef.current === "closed";
+    prevSnapRef.current = snap;
+    if (!wasClosed || snap === "closed" || currentTrackRank === null) return;
+    // Defer to next frame so Radix Dialog.Portal has fully mounted its content
+    // and refs inside the portal are populated before we query/scroll.
+    const id = requestAnimationFrame(() => {
+      const el = olRef.current?.querySelector<HTMLElement>(
+        `[data-rank="${currentTrackRank}"]`,
+      );
+      el?.scrollIntoView({
+        block: snap === "peek" ? "start" : "center",
+        behavior: "smooth",
+      });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [snap, currentTrackRank]);
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange} modal={false}>
@@ -70,23 +140,36 @@ export function ChartSheet({ country, snap, onSnapChange }: ChartSheetProps) {
             data-snap={snap}
             data-testid="chart-sheet"
             drag="y"
+            dragListener={false}
+            dragControls={dragControls}
             dragMomentum={false}
             dragElastic={0.2}
-            animate={{ y: SNAP_Y[snap] }}
+            initial={{ y: SNAP_Y[snap] }}
+            animate={animationControls}
             transition={{ type: "spring", damping: 30, stiffness: 300 }}
+            onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
             className="bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 bottom-0 flex h-[100dvh] flex-col rounded-t-2xl border-t"
           >
-            <button
-              type="button"
-              onClick={handleToggle}
-              aria-label={snap === "peek" ? "Expand chart" : "Collapse chart"}
-              className="bg-fg-1/15 rounded-pill mx-auto mt-3 mb-2 h-1.5 w-12 shrink-0"
-            />
-            <Dialog.Title className="text-h3 px-6 pb-3 font-semibold">
-              {country.name}
-            </Dialog.Title>
-            <ol className="min-h-0 flex-1 overflow-y-auto px-4 pb-12 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <div
+              onPointerDown={(e) => dragControls.start(e)}
+              className="shrink-0 touch-none"
+            >
+              <button
+                type="button"
+                onClick={handleToggle}
+                aria-label={snap === "peek" ? "Expand chart" : "Collapse chart"}
+                className="bg-fg-1/15 rounded-pill mx-auto mt-3 mb-2 block h-1.5 w-12"
+              />
+              <Dialog.Title className="text-h3 px-6 pb-3 font-semibold">
+                {country.name}
+              </Dialog.Title>
+            </div>
+            <ol
+              ref={olRef}
+              data-peek={(snap === "peek" && !isDragging) || undefined}
+              className="min-h-0 flex-1 overflow-y-auto px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
+            >
               {country.tracks.map((track) => (
                 <TrackRow key={track.rank} track={track} />
               ))}

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -72,7 +72,7 @@ describe("TrackRow", () => {
     expect(store.getState().isPlaying).toBe(true);
   });
 
-  test("data-playing reflects this track being the active playing track", () => {
+  test("data-state reflects current vs idle, playing vs paused", () => {
     const track = makeTrack();
     const otherTrack = makeTrack({
       rank: 2,
@@ -81,7 +81,7 @@ describe("TrackRow", () => {
 
     const { container, rerender, store } = renderTrackRow(track);
 
-    expect(container.querySelector("[data-playing]")).toBeNull();
+    expect(container.querySelector("[data-state]")).toBeNull();
 
     store.setState({ currentTrack: track, isPlaying: true });
     rerender(
@@ -91,7 +91,17 @@ describe("TrackRow", () => {
         </ul>
       </AudioStoreContext.Provider>,
     );
-    expect(container.querySelector("[data-playing]")).not.toBeNull();
+    expect(container.querySelector('[data-state="playing"]')).not.toBeNull();
+
+    store.setState({ currentTrack: track, isPlaying: false });
+    rerender(
+      <AudioStoreContext.Provider value={store}>
+        <ul>
+          <TrackRow track={track} />
+        </ul>
+      </AudioStoreContext.Provider>,
+    );
+    expect(container.querySelector('[data-state="paused"]')).not.toBeNull();
 
     store.setState({ currentTrack: otherTrack, isPlaying: true });
     rerender(
@@ -101,7 +111,7 @@ describe("TrackRow", () => {
         </ul>
       </AudioStoreContext.Provider>,
     );
-    expect(container.querySelector("[data-playing]")).toBeNull();
+    expect(container.querySelector("[data-state]")).toBeNull();
   });
 
   test("disabled state when previewUrl is null: button disabled, label shown, click is no-op", () => {

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { AppleMusicIcon } from "@/components/icons/apple-music";
+import { PauseIcon } from "@/components/icons/pause";
+import { PlayIcon } from "@/components/icons/play";
 import { SpotifyIcon } from "@/components/icons/spotify";
 import type { Track } from "@/lib/chart-schema";
 import { useAudioStore } from "@/providers/audio-store-provider";
@@ -10,6 +12,9 @@ export interface TrackRowProps {
 }
 
 export function TrackRow({ track }: TrackRowProps) {
+  const isCurrent = useAudioStore(
+    (s) => s.currentTrack?.previewUrl === track.previewUrl,
+  );
   const isPlaying = useAudioStore(
     (s) => s.isPlaying && s.currentTrack?.previewUrl === track.previewUrl,
   );
@@ -19,12 +24,14 @@ export function TrackRow({ track }: TrackRowProps) {
   const toggle = useAudioStore((s) => s.toggle);
 
   const hasPreview = track.previewUrl !== null;
+  const state = isCurrent ? (isPlaying ? "playing" : "paused") : undefined;
 
   return (
     <li
-      data-playing={isPlaying || undefined}
+      data-rank={track.rank}
+      data-state={state}
       data-disabled={!hasPreview || undefined}
-      className="hover:bg-atmos data-[playing]:bg-atmos flex items-center gap-[14px] rounded-[14px] px-3 py-2.5 transition-colors duration-200 data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent data-[playing]:shadow-[inset_0_0_0_1px_rgba(255,107,71,0.3),_0_0_16px_rgba(255,107,71,0.15)]"
+      className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex items-center gap-[14px] rounded-[14px] px-3 py-2.5 transition-colors duration-200 data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
     >
       <button
         type="button"
@@ -33,8 +40,16 @@ export function TrackRow({ track }: TrackRowProps) {
         aria-label={`${isPlaying ? "Pause" : "Play"} preview of ${track.name} by ${track.artist}`}
         className="focus-visible:outline-aurora flex min-w-0 flex-1 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none"
       >
-        <span className="text-fg-3 text-body w-7 shrink-0 text-right font-mono tabular-nums">
-          {track.rank}
+        <span className="text-fg-3 text-body flex w-7 shrink-0 items-center justify-center font-mono tabular-nums">
+          {isCurrent ? (
+            isPlaying ? (
+              <PauseIcon className="text-sunrise h-4 w-4" />
+            ) : (
+              <PlayIcon className="text-sunrise h-4 w-4" />
+            )
+          ) : (
+            track.rank
+          )}
         </span>
         <div
           aria-hidden="true"
@@ -42,10 +57,18 @@ export function TrackRow({ track }: TrackRowProps) {
           className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
         />
         <div className="min-w-0 flex-1">
-          <p className="text-fg-1 text-body flex min-w-0 items-center gap-2 font-medium">
+          <p
+            className={`text-body flex min-w-0 items-center gap-2 font-medium ${
+              isCurrent ? "text-sunrise" : "text-fg-1"
+            }`}
+          >
             <span className="truncate">{track.name}</span>
-            {isPlaying && (
-              <span className="eq shrink-0" aria-hidden>
+            {isCurrent && (
+              <span
+                className="eq shrink-0"
+                data-paused={!isPlaying || undefined}
+                aria-hidden
+              >
                 <span />
                 <span />
                 <span />

--- a/src/components/icons/pause.tsx
+++ b/src/components/icons/pause.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from "react";
+
+export function PauseIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      {...props}
+    >
+      <path d="M6 5h4v14H6V5zm8 0h4v14h-4V5z" />
+    </svg>
+  );
+}

--- a/src/components/icons/play.tsx
+++ b/src/components/icons/play.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from "react";
+
+export function PlayIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      {...props}
+    >
+      <path d="M8 5v14l11-7L8 5z" />
+    </svg>
+  );
+}

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  type AudioElementLike,
+  type AudioState,
+  createAudioStore,
+} from "@/lib/audio-store";
+import type { Track } from "@/lib/chart-schema";
+import { AudioStoreContext } from "@/providers/audio-store-provider";
+
+import { MiniPlayer } from "./mini-player";
+
+function makeMockAudio(): AudioElementLike {
+  return {
+    src: "",
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+}
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    rank: 1,
+    name: "Test Track",
+    artist: "Test Artist",
+    previewUrl: "https://example.com/preview.m4a",
+    artworkUrl: "https://example.com/artwork.jpg",
+    appleUrl: "https://music.apple.com/track/1",
+    spotifySearchUrl: "https://open.spotify.com/search/Test%20Track",
+    ...overrides,
+  };
+}
+
+function renderMiniPlayer(
+  props: { sheetClosed: boolean; onTap: () => void },
+  init?: Partial<AudioState>,
+) {
+  const store = createAudioStore(() => makeMockAudio());
+  if (init) {
+    store.setState(init);
+  }
+  const utils = render(
+    <AudioStoreContext.Provider value={store}>
+      <MiniPlayer {...props} />
+    </AudioStoreContext.Provider>,
+  );
+  return { ...utils, store };
+}
+
+describe("MiniPlayer", () => {
+  test("renders nothing when currentTrack is null", () => {
+    const { container } = renderMiniPlayer({
+      sheetClosed: true,
+      onTap: vi.fn(),
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing when sheet is not closed even if currentTrack set", () => {
+    const track = makeTrack();
+
+    const { container } = renderMiniPlayer(
+      { sheetClosed: false, onTap: vi.fn() },
+      { currentTrack: track },
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders name, artist, artwork when currentTrack set and sheet closed", () => {
+    const track = makeTrack({
+      name: "Hot Track",
+      artist: "Hot Artist",
+      artworkUrl: "https://example.com/cover.jpg",
+    });
+
+    const { container } = renderMiniPlayer(
+      { sheetClosed: true, onTap: vi.fn() },
+      { currentTrack: track },
+    );
+
+    expect(screen.getByText("Hot Track")).toBeDefined();
+    expect(screen.getByText("Hot Artist")).toBeDefined();
+    const artwork = container.querySelector('[aria-hidden="true"]');
+    expect(artwork?.getAttribute("style")).toContain(track.artworkUrl);
+  });
+
+  test("tap on main area fires onTap callback", () => {
+    const track = makeTrack();
+    const onTap = vi.fn();
+
+    renderMiniPlayer({ sheetClosed: true, onTap }, { currentTrack: track });
+
+    fireEvent.click(screen.getByRole("button", { name: /reopen chart/i }));
+
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  test("play/pause button toggles audio store and reflects isPlaying", () => {
+    const track = makeTrack({ name: "Hot Track" });
+
+    const { store } = renderMiniPlayer(
+      { sheetClosed: true, onTap: vi.fn() },
+      { currentTrack: track, isPlaying: false },
+    );
+
+    const playButton = screen.getByRole("button", {
+      name: /play preview of Hot Track/i,
+    });
+
+    fireEvent.click(playButton);
+
+    expect(store.getState().isPlaying).toBe(true);
+    expect(
+      screen.getByRole("button", { name: /pause preview of Hot Track/i }),
+    ).toBeDefined();
+  });
+});

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { PauseIcon } from "@/components/icons/pause";
+import { PlayIcon } from "@/components/icons/play";
+import { useAudioStore } from "@/providers/audio-store-provider";
+
+export interface MiniPlayerProps {
+  sheetClosed: boolean;
+  onTap: () => void;
+}
+
+export function MiniPlayer({ sheetClosed, onTap }: MiniPlayerProps) {
+  const currentTrack = useAudioStore((s) => s.currentTrack);
+  const isPlaying = useAudioStore((s) => s.isPlaying);
+  const toggle = useAudioStore((s) => s.toggle);
+
+  if (currentTrack === null || !sheetClosed) return null;
+
+  return (
+    <div className="bg-void border-fg-1/10 shadow-sheet fixed inset-x-0 bottom-0 border-t">
+      <div className="flex items-center gap-[14px] px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]">
+        <button
+          type="button"
+          onClick={onTap}
+          aria-label="Reopen chart"
+          className="focus-visible:outline-aurora flex min-w-0 flex-1 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
+        >
+          <div
+            aria-hidden="true"
+            style={{ backgroundImage: `url(${currentTrack.artworkUrl})` }}
+            className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          />
+          <div className="min-w-0 flex-1">
+            <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
+              <span className="truncate">{currentTrack.name}</span>
+              <span
+                className="eq shrink-0"
+                data-paused={!isPlaying || undefined}
+                aria-hidden
+              >
+                <span />
+                <span />
+                <span />
+              </span>
+            </p>
+            <p className="text-fg-2 text-small truncate">
+              {currentTrack.artist}
+            </p>
+          </div>
+        </button>
+        <button
+          type="button"
+          onClick={() => toggle(currentTrack)}
+          aria-label={
+            isPlaying
+              ? `Pause preview of ${currentTrack.name}`
+              : `Play preview of ${currentTrack.name}`
+          }
+          className="text-fg-1 hover:bg-orbit focus-visible:outline-aurora flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
+        >
+          {isPlaying ? (
+            <PauseIcon className="h-4 w-4" />
+          ) : (
+            <PlayIcon className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -111,6 +111,30 @@ describe("createAudioStore", () => {
     expect(store.getState().currentTrack).toBe(track);
   });
 
+  test("ended event increments endedSignal so subscribers can auto-advance", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    store.getState().toggle(makeTrack());
+
+    audio._trigger("ended");
+
+    expect(store.getState().endedSignal).toBe(1);
+  });
+
+  test("endedSignal accumulates across consecutive ended events", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const trackA = makeTrack();
+    const trackB = makeTrack({ previewUrl: "https://example.com/b.m4a" });
+    store.getState().toggle(trackA);
+    audio._trigger("ended");
+    store.getState().toggle(trackB);
+
+    audio._trigger("ended");
+
+    expect(store.getState().endedSignal).toBe(2);
+  });
+
   test("error event: isPlaying false, currentTrack preserved", () => {
     const audio = makeMockAudio();
     const store = createAudioStore(() => audio);

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -29,6 +29,7 @@ export interface AudioState {
   currentTrack: Track | null;
   isPlaying: boolean;
   lastError: AudioError | null;
+  endedSignal: number;
   toggle: (track: Track) => void;
   stop: () => void;
 }
@@ -48,7 +49,12 @@ export function createAudioStore(
       // Covers background-tab auto-pause, AirPods disconnect, media keys.
       audio.addEventListener("play", () => set({ isPlaying: true }));
       audio.addEventListener("pause", () => set({ isPlaying: false }));
-      audio.addEventListener("ended", () => set({ isPlaying: false }));
+      audio.addEventListener("ended", () =>
+        set((state) => ({
+          isPlaying: false,
+          endedSignal: state.endedSignal + 1,
+        })),
+      );
       audio.addEventListener("error", () => {
         const previewUrl = get().currentTrack?.previewUrl ?? null;
         set({ isPlaying: false, lastError: { previewUrl } });
@@ -66,6 +72,7 @@ export function createAudioStore(
       currentTrack: null,
       isPlaying: false,
       lastError: null,
+      endedSignal: 0,
       toggle: (track) => {
         const state = get();
         const a = getAudio();

--- a/src/providers/audio-store-provider.tsx
+++ b/src/providers/audio-store-provider.tsx
@@ -29,3 +29,11 @@ export function useAudioStore<T>(selector: (state: AudioState) => T): T {
   }
   return useStore(store, selector);
 }
+
+export function useAudioStoreApi(): AudioStoreApi {
+  const store = useContext(AudioStoreContext);
+  if (!store) {
+    throw new Error("useAudioStoreApi must be used within AudioStoreProvider");
+  }
+  return store;
+}


### PR DESCRIPTION
## Summary

Slice 3 of Phase 3 (#28). Adds the mini player and the cross-state
audio behavior that ties the chart sheet, the mini, and the audio
store together. Visitors can drag the sheet down while a preview is
playing, the mini appears at the bottom of the viewport, tapping it
re-opens the sheet to peek with the active track scrolled into view,
and the next preview auto-plays when the current one finishes.

## Track row current-state indicator

- Current row exposes `data-state="playing"|"paused"` so a paused
  current track stays identifiable; rank flips to a play/pause icon in
  the same centered slot to avoid the visual jump from the number/SVG
  swap.
- Title and EQ adopt the sunrise accent; `data-paused` on the EQ
  freezes the animation via `animation-play-state: paused`.
- Hover-vs-current distinguished by `bg-atmos` (hover) and a brighter
  sunrise wash (current); the earlier inset orange ring + glow read
  as too strong.

## Chart sheet: list scrolls, drag-to-mini, scroll-to-current

- Track list scrolls inside the sheet without the sheet itself
  dragging — drag is restricted to handle + title via
  `useDragControls`.
- Dragging hard from full now lands directly at the mini (closed); the
  one-step-delta logic was capped at peek. `nextSnap` now projects
  final position + velocity.
- Sheet cannot be closed before a track is selected — prevents the
  dead-end where the page would be blank. `canClose` re-animates back
  via `useAnimationControls` because state-no-op didn't trigger motion.
- Re-opening the sheet auto-scrolls to the currently-playing track
  (rAF defer so Radix Portal mount completes; `block: start` at peek,
  `center` at full).
- Peek now scrolls end-to-end of the chart; `ol` `max-height` is
  capped to the visible peek area and relaxed during drag so the list
  grows in sync with the sheet.

## Mini player

- Bottom-anchored, visible only when `currentTrack !== null` AND sheet
  is `closed`.
- Left region (artwork + title + artist) re-opens the sheet on tap.
- Right toggle bound to the same audio store; title and EQ mirror the
  track row's sunrise treatment so the two surfaces feel like one
  player.

## Chart-screen wiring + audio UX

- `AudioStoreProvider` wraps an inner `ChartScreenInner` so the sheet
  and mini share one audio store and the snap state lives below the
  provider. Selectors narrowed to primitives (`hasCurrentTrack`,
  `currentTrackRank`) to keep this component out of the re-render
  path on track switches.
- Spacebar anywhere on the page toggles play/pause for the current
  track; skips input/textarea/contenteditable so search fields aren't
  affected.
- 30s preview end auto-advances to the next track that has a preview;
  chart end stops playback. Audio store gains `endedSignal` (a counter
  the consumer subscribes to) and `useAudioStoreApi` exposes the
  imperative store handle so key handlers + effects can read state
  without re-subscribing.

## Notable decisions

- Visible next/prev buttons and keyboard nav for them deferred to a
  Phase 4-5 polish pass; auto-advance is the V1 substitute that keeps
  the chart flowing without extra UI.
- E2E browser tests explicitly deferred to Phase 5 entry. RTL + jsdom
  cannot exercise drag/scroll/touch behaviors that slice 3 surfaced;
  manual verify is the Phase 3-4 safety net. Saved as project memory.

## Test plan

- [x] lint / typecheck / test green (111 tests across 18 files)
- [x] Manual \`pnpm dev\` golden path: load → play → drag closed → mini
      visible → tap → peek → drag full → drag closed direct → mini
- [x] Edge cases: dead-end clamp before any track plays; auto-advance
      stops at last track; spacebar skipped in inputs; peek scrolls
      end-to-end; rank ↔ icon swap centered with no jump; paused EQ
      stays static
- [x] CI green
- [x] CodeRabbit

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spacebar now toggles audio playback (when not in text input)
  * Mini player displays current track details when chart is minimized
  * Auto-advances to next track when current track finishes

* **Improvements**
  * Enhanced track row scrolling and positioning
  * Refined play/pause icon display in track listings
  * Updated equalizer animation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->