### PR TITLE
Phase 4 Slice 2: camera arc + initial entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@sentry/nextjs": "^10.51.0",
     "@sentry/node": "^10.51.0",
     "@vercel/blob": "^2.3.0",
+    "bezier-easing": "^3.0.0",
     "motion": "12.39.0",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vercel/blob':
         specifier: ^2.3.0
         version: 2.3.0
+      bezier-easing:
+        specifier: ^3.0.0
+        version: 3.0.0
       motion:
         specifier: 12.39.0
         version: 12.39.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2606,6 +2609,9 @@ packages:
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
+
+  bezier-easing@3.0.0:
+    resolution: {integrity: sha512-lE85voPXiK99T8NHOfhaUqCZpJdP1gBbbTEvdBDdPB+phyvPZPNWalBe42eb6lKOYchP0qZrtBiRCARtT4edRQ==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -7790,6 +7796,8 @@ snapshots:
   baseline-browser-mapping@2.10.23: {}
 
   basic-ftp@5.3.1: {}
+
+  bezier-easing@3.0.0: {}
 
   bidi-js@1.0.3:
     dependencies:

--- a/src/components/globe/country-outlines.tsx
+++ b/src/components/globe/country-outlines.tsx
@@ -1,7 +1,7 @@
 import type { CountryOutlines } from "@/lib/country-outlines";
 
 const TIER1_COLOR = "#3a4a5a";
-const TIER1_OPACITY = 0.5;
+const TIER1_OPACITY = 0.8;
 const TIER2_COLOR = "#88aacc";
 const TIER2_OPACITY = 0.85;
 

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, use, useCallback, useState } from "react";
+import { Suspense, use, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
@@ -11,6 +11,7 @@ import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
 import { StarBackdrop } from "./star-backdrop";
+import { useCameraArc } from "./use-camera-arc";
 
 const ALL_CODES = COUNTRIES.map((c) => c.code);
 
@@ -26,26 +27,23 @@ function CountryLayers() {
   return <CountryOutlinesLayer data={outlines} />;
 }
 
-export function GlobeScene() {
+function SceneContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedCode = validateCode(searchParams.get("cc"));
-  const [userInteracted, setUserInteracted] = useState(false);
+
+  const { isAnimating } = useCameraArc({ targetCode: selectedCode });
 
   const handleSelect = useCallback(
     (code: string) => {
-      setUserInteracted(true);
+      if (isAnimating) return;
       router.push(`/?cc=${code}`);
     },
-    [router],
+    [router, isAnimating],
   );
 
   return (
-    <Canvas
-      camera={{ fov: 45, position: [0, 0, 3.5] }}
-      dpr={[1, 2]}
-      gl={{ antialias: true }}
-    >
+    <>
       <ambientLight intensity={0.5} />
       <directionalLight position={[5, 3, 5]} intensity={1.2} />
       <StarBackdrop />
@@ -62,14 +60,26 @@ export function GlobeScene() {
       </Suspense>
       <CountryPins selectedCode={selectedCode} onSelect={handleSelect} />
       <OrbitControls
-        autoRotate={!userInteracted}
+        autoRotate={selectedCode === null}
         autoRotateSpeed={0.4}
         enableZoom={false}
         enablePan={false}
+        enableRotate={!isAnimating}
         enableDamping
         makeDefault
-        onStart={() => setUserInteracted(true)}
       />
+    </>
+  );
+}
+
+export function GlobeScene() {
+  return (
+    <Canvas
+      camera={{ fov: 45, position: [0, 0, 3.5] }}
+      dpr={[1, 2]}
+      gl={{ antialias: true }}
+    >
+      <SceneContent />
     </Canvas>
   );
 }

--- a/src/components/globe/use-camera-arc.ts
+++ b/src/components/globe/use-camera-arc.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { useThree } from "@react-three/fiber";
+
+import { cameraArcPath } from "@/lib/camera-arc";
+import { COUNTRIES } from "@/lib/countries";
+import { easeSpring } from "@/lib/ease-spring";
+
+const DUR_GLOBE_MS = 900;
+const RISE_FACTOR = 0.15;
+
+const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
+
+class ArcStore {
+  private listeners = new Set<() => void>();
+  private active = false;
+
+  subscribe = (cb: () => void) => {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
+  };
+
+  getSnapshot = () => this.active;
+
+  set = (value: boolean) => {
+    if (this.active === value) return;
+    this.active = value;
+    this.listeners.forEach((l) => l());
+  };
+}
+
+export interface UseCameraArcOptions {
+  targetCode: string | null;
+}
+
+interface ControlsLike {
+  update?: () => void;
+}
+
+export function useCameraArc({ targetCode }: UseCameraArcOptions) {
+  const camera = useThree((s) => s.camera);
+  const controls = useThree((s) => s.controls) as ControlsLike | null;
+  const [store] = useState(() => new ArcStore());
+
+  const isAnimating = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+
+  useEffect(() => {
+    if (!targetCode) return;
+    const country = COUNTRY_BY_CODE.get(targetCode);
+    if (!country) return;
+
+    const from = camera.position.clone();
+    const baseRadius = from.length();
+    const path = cameraArcPath({
+      from,
+      toLatLon: { lat: country.lat, lon: country.lon },
+      baseRadius,
+      riseFactor: RISE_FACTOR,
+    });
+
+    store.set(true);
+    const start = performance.now();
+    let rafId = 0;
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / DUR_GLOBE_MS);
+      const eased = easeSpring(t);
+      camera.position.copy(path(eased));
+      camera.lookAt(0, 0, 0);
+      if (t < 1) {
+        rafId = requestAnimationFrame(tick);
+      } else {
+        controls?.update?.();
+        store.set(false);
+      }
+    };
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      store.set(false);
+    };
+  }, [targetCode, camera, controls, store]);
+
+  return { isAnimating };
+}

--- a/src/components/globe/use-camera-arc.ts
+++ b/src/components/globe/use-camera-arc.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useThree } from "@react-three/fiber";
 
 import { cameraArcPath } from "@/lib/camera-arc";
@@ -43,7 +43,12 @@ interface ControlsLike {
 export function useCameraArc({ targetCode }: UseCameraArcOptions) {
   const camera = useThree((s) => s.camera);
   const controls = useThree((s) => s.controls) as ControlsLike | null;
+  const controlsRef = useRef<ControlsLike | null>(null);
   const [store] = useState(() => new ArcStore());
+
+  useEffect(() => {
+    controlsRef.current = controls;
+  }, [controls]);
 
   const isAnimating = useSyncExternalStore(
     store.subscribe,
@@ -76,7 +81,7 @@ export function useCameraArc({ targetCode }: UseCameraArcOptions) {
       if (t < 1) {
         rafId = requestAnimationFrame(tick);
       } else {
-        controls?.update?.();
+        controlsRef.current?.update?.();
         store.set(false);
       }
     };
@@ -86,7 +91,7 @@ export function useCameraArc({ targetCode }: UseCameraArcOptions) {
       cancelAnimationFrame(rafId);
       store.set(false);
     };
-  }, [targetCode, camera, controls, store]);
+  }, [targetCode, camera, store]);
 
   return { isAnimating };
 }

--- a/src/lib/camera-arc.test.ts
+++ b/src/lib/camera-arc.test.ts
@@ -48,3 +48,17 @@ test("cameraArcPath midpoint lies on the great circle from start to target", () 
 
   expect(Math.abs(mid.dot(arcAxis))).toBeLessThan(EPSILON);
 });
+
+test("cameraArcPath survives antipodal target with non-degenerate midpoint", () => {
+  const antipodalPath = cameraArcPath({
+    from: cameraStart,
+    toLatLon: { lat: 0, lon: 180 },
+    baseRadius,
+    riseFactor,
+  });
+
+  const mid = antipodalPath(0.5);
+
+  expect(Number.isFinite(mid.length())).toBe(true);
+  expect(mid.length()).toBeCloseTo(baseRadius * (1 + riseFactor), 6);
+});

--- a/src/lib/camera-arc.test.ts
+++ b/src/lib/camera-arc.test.ts
@@ -1,0 +1,50 @@
+import { Vector3 } from "three";
+import { expect, test } from "vitest";
+
+import { cameraArcPath } from "./camera-arc";
+import { latLonToVec3 } from "./lat-lon-to-vec3";
+
+const cameraStart = new Vector3(0, 0, 3.5);
+const targetLatLon = { lat: -22.9, lon: -43.2 };
+const baseRadius = cameraStart.length();
+const riseFactor = 0.15;
+const EPSILON = 1e-6;
+const path = cameraArcPath({
+  from: cameraStart,
+  toLatLon: targetLatLon,
+  baseRadius,
+  riseFactor,
+});
+
+test("cameraArcPath starts at the input camera position", () => {
+  const start = path(0);
+
+  expect(start.x).toBeCloseTo(cameraStart.x, 6);
+  expect(start.y).toBeCloseTo(cameraStart.y, 6);
+  expect(start.z).toBeCloseTo(cameraStart.z, 6);
+});
+
+test("cameraArcPath ends in the target lat/lon direction at the same distance", () => {
+  const end = path(1);
+
+  const target = latLonToVec3(targetLatLon.lat, targetLatLon.lon, baseRadius);
+  expect(end.x).toBeCloseTo(target.x, 6);
+  expect(end.y).toBeCloseTo(target.y, 6);
+  expect(end.z).toBeCloseTo(target.z, 6);
+});
+
+test("cameraArcPath midpoint rises to baseRadius × (1 + riseFactor)", () => {
+  const mid = path(0.5);
+
+  expect(mid.length()).toBeCloseTo(baseRadius * (1 + riseFactor), 6);
+});
+
+test("cameraArcPath midpoint lies on the great circle from start to target", () => {
+  const fromDir = cameraStart.clone().normalize();
+  const toDir = latLonToVec3(targetLatLon.lat, targetLatLon.lon, 1);
+  const arcAxis = new Vector3().crossVectors(fromDir, toDir).normalize();
+
+  const mid = path(0.5);
+
+  expect(Math.abs(mid.dot(arcAxis))).toBeLessThan(EPSILON);
+});

--- a/src/lib/camera-arc.ts
+++ b/src/lib/camera-arc.ts
@@ -1,0 +1,33 @@
+import { Vector3 } from "three";
+
+import { latLonToVec3 } from "./lat-lon-to-vec3";
+
+export interface CameraArcParams {
+  from: Vector3;
+  toLatLon: { lat: number; lon: number };
+  baseRadius: number;
+  riseFactor: number;
+}
+
+export function cameraArcPath(params: CameraArcParams): (t: number) => Vector3 {
+  const fromDir = params.from.clone().normalize();
+  const toDir = latLonToVec3(params.toLatLon.lat, params.toLatLon.lon, 1);
+  return (t) => {
+    const dir = slerpUnitVectors(fromDir, toDir, t);
+    const r =
+      params.baseRadius * (1 + params.riseFactor * Math.sin(Math.PI * t));
+    return dir.multiplyScalar(r);
+  };
+}
+
+function slerpUnitVectors(from: Vector3, to: Vector3, t: number): Vector3 {
+  const dot = Math.max(-1, Math.min(1, from.dot(to)));
+  const theta = Math.acos(dot);
+  const sinTheta = Math.sin(theta);
+  if (Math.abs(sinTheta) < 1e-6) {
+    return from.clone().lerp(to, t);
+  }
+  const a = Math.sin((1 - t) * theta) / sinTheta;
+  const b = Math.sin(t * theta) / sinTheta;
+  return from.clone().multiplyScalar(a).add(to.clone().multiplyScalar(b));
+}

--- a/src/lib/camera-arc.ts
+++ b/src/lib/camera-arc.ts
@@ -22,12 +22,22 @@ export function cameraArcPath(params: CameraArcParams): (t: number) => Vector3 {
 
 function slerpUnitVectors(from: Vector3, to: Vector3, t: number): Vector3 {
   const dot = Math.max(-1, Math.min(1, from.dot(to)));
+  if (dot > 1 - 1e-6) {
+    return from.clone().lerp(to, t).normalize();
+  }
+  if (dot < -1 + 1e-6) {
+    const helper =
+      Math.abs(from.x) < 0.9 ? new Vector3(1, 0, 0) : new Vector3(0, 1, 0);
+    const axis = new Vector3().crossVectors(from, helper).normalize();
+    return from.clone().applyAxisAngle(axis, Math.PI * t);
+  }
   const theta = Math.acos(dot);
   const sinTheta = Math.sin(theta);
-  if (Math.abs(sinTheta) < 1e-6) {
-    return from.clone().lerp(to, t);
-  }
   const a = Math.sin((1 - t) * theta) / sinTheta;
   const b = Math.sin(t * theta) / sinTheta;
-  return from.clone().multiplyScalar(a).add(to.clone().multiplyScalar(b));
+  return from
+    .clone()
+    .multiplyScalar(a)
+    .add(to.clone().multiplyScalar(b))
+    .normalize();
 }

--- a/src/lib/camera-arc.ts
+++ b/src/lib/camera-arc.ts
@@ -2,6 +2,9 @@ import { Vector3 } from "three";
 
 import { latLonToVec3 } from "./lat-lon-to-vec3";
 
+// Float tolerance for treating dot product as exactly ±1 (degenerate cases).
+const EPSILON = 1e-6;
+
 export interface CameraArcParams {
   from: Vector3;
   toLatLon: { lat: number; lon: number };
@@ -22,10 +25,10 @@ export function cameraArcPath(params: CameraArcParams): (t: number) => Vector3 {
 
 function slerpUnitVectors(from: Vector3, to: Vector3, t: number): Vector3 {
   const dot = Math.max(-1, Math.min(1, from.dot(to)));
-  if (dot > 1 - 1e-6) {
+  if (dot > 1 - EPSILON) {
     return from.clone().lerp(to, t).normalize();
   }
-  if (dot < -1 + 1e-6) {
+  if (dot < -1 + EPSILON) {
     const helper =
       Math.abs(from.x) < 0.9 ? new Vector3(1, 0, 0) : new Vector3(0, 1, 0);
     const axis = new Vector3().crossVectors(from, helper).normalize();

--- a/src/lib/ease-spring.ts
+++ b/src/lib/ease-spring.ts
@@ -1,0 +1,5 @@
+import BezierEasing from "bezier-easing";
+
+// Source of truth: --ease-spring in src/app/globals.css.
+// Keep these control points in sync with that CSS variable.
+export const easeSpring = BezierEasing(0.34, 1.56, 0.64, 1);


### PR DESCRIPTION
## Summary

- Pin click and `/?cc=xx` initial entry now fly the camera in a 900ms great-circle arc with a midpoint altitude rise (`riseFactor` 0.15, `ease-spring` curve from `--ease-spring` CSS token via `bezier-easing`).
- Drag (`OrbitControls`) and additional pin clicks are locked during the arc; auto-rotate stops as soon as a country is selected.
- Tier 1 (unsupported countries) outline opacity bumped 0.5 → 0.8 — was near-invisible against the navy globe (caught during manual verify).

## Test plan

Automated (CI):
- [x] `cameraArcPath` unit tests — 4 invariants (starts at `from`, ends at target lat/lon at same distance, midpoint rises to `baseRadius × (1 + riseFactor)`, midpoint lies on great circle)
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build`

Manual (desktop Chrome, dev server):
- [x] Initial entry `/` — auto-picked country arcs from default view in 900ms
- [x] Pin click — arc to clicked country, URL `?cc=` updates immediately (before arrival)
- [x] During arc — drag locked, further pin clicks ignored, `OrbitControls` re-syncs on completion (no snap-back)
- [x] Direct URL `/?cc=br` — lands on Brazil via same arc from default view
- [x] Antipodal math — Korea/Argentina dot ≈ -0.995, well above SLERP degeneracy threshold; `riseFactor` keeps midpoint at `baseRadius × 1.15` (no cut-through possible)

Deferred:
- [ ] iOS Safari / Android Chrome manual verify — moved to Phase 4 close
- [ ] Visual antipodal verify via in-app click — blocked by far-side pin occlusion (Slice 3 hover/visibility territory)

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth camera animation when navigating to countries on the globe.

* **Improvements**
  * Increased visibility of country outlines for clearer map rendering.
  * Refined animation easing for more natural camera motion.

* **Tests**
  * Added geometry tests validating camera-arc behavior and edge cases.

* **Chores**
  * Added a dependency to support the new easing implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->