### PR TITLE
Phase 4 Slice 3: hover state + Tier 3 polygon fill

### DIFF
--- a/src/components/globe/country-fill.tsx
+++ b/src/components/globe/country-fill.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from "react";
+import { CanvasTexture, type MeshBasicMaterial, SRGBColorSpace } from "three";
+
+import type { CountryRings } from "@/lib/country-outlines";
+
+const FILL_R = 1.003;
+const CANVAS_W = 2048;
+const CANVAS_H = 1024;
+// #FF6B47 sunrise × α 0.55 — selected-state brand color.
+const FILL_COLOR = "rgba(255, 107, 71, 0.55)";
+// Aligns the equirectangular canvas (lon=0 at canvas-x=CANVAS_W/2) with three.js
+// SphereGeometry default seam, given the project's latLonToVec3 (lon=0 → +Z axis).
+const UV_OFFSET_X = 0.25;
+
+interface CountryFillProps {
+  selectedIsoNum: number | null;
+  byIsoRings: Map<number, CountryRings>;
+}
+
+export function CountryFill({ selectedIsoNum, byIsoRings }: CountryFillProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const textureRef = useRef<CanvasTexture | null>(null);
+  const materialRef = useRef<MeshBasicMaterial | null>(null);
+
+  useEffect(() => {
+    const canvas = document.createElement("canvas");
+    canvas.width = CANVAS_W;
+    canvas.height = CANVAS_H;
+    const tex = new CanvasTexture(canvas);
+    tex.offset.x = UV_OFFSET_X;
+    tex.colorSpace = SRGBColorSpace;
+    canvasRef.current = canvas;
+    textureRef.current = tex;
+    const mat = materialRef.current;
+    if (mat) {
+      mat.map = tex;
+      mat.needsUpdate = true;
+    }
+    return () => {
+      tex.dispose();
+      canvasRef.current = null;
+      textureRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const texture = textureRef.current;
+    if (!canvas || !texture) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+    if (selectedIsoNum !== null) {
+      const rings = byIsoRings.get(selectedIsoNum);
+      if (rings) {
+        ctx.fillStyle = FILL_COLOR;
+        for (const ring of rings) {
+          ctx.beginPath();
+          for (let i = 0; i < ring.length; i++) {
+            const [lon, lat] = ring[i];
+            const x = ((lon + 180) / 360) * CANVAS_W;
+            const y = ((90 - lat) / 180) * CANVAS_H;
+            if (i === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
+          }
+          ctx.closePath();
+          ctx.fill();
+        }
+      }
+    }
+    texture.needsUpdate = true;
+  }, [selectedIsoNum, byIsoRings]);
+
+  return (
+    <mesh>
+      <sphereGeometry args={[FILL_R, 64, 64]} />
+      <meshBasicMaterial ref={materialRef} transparent depthWrite={false} />
+    </mesh>
+  );
+}

--- a/src/components/globe/country-fill.tsx
+++ b/src/components/globe/country-fill.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef } from "react";
-import { CanvasTexture, type MeshBasicMaterial, SRGBColorSpace } from "three";
+import {
+  CanvasTexture,
+  type MeshBasicMaterial,
+  RepeatWrapping,
+  SRGBColorSpace,
+} from "three";
 
 import type { CountryRings } from "@/lib/country-outlines";
 
@@ -28,6 +33,9 @@ export function CountryFill({ selectedIsoNum, byIsoRings }: CountryFillProps) {
     canvas.height = CANVAS_H;
     const tex = new CanvasTexture(canvas);
     tex.offset.x = UV_OFFSET_X;
+    // RepeatWrapping required because offset.x shifts sample u into [0.25, 1.25];
+    // default ClampToEdge would smear the rightmost canvas column across lon=-90 to -180.
+    tex.wrapS = RepeatWrapping;
     tex.colorSpace = SRGBColorSpace;
     canvasRef.current = canvas;
     textureRef.current = tex;
@@ -54,8 +62,8 @@ export function CountryFill({ selectedIsoNum, byIsoRings }: CountryFillProps) {
       const rings = byIsoRings.get(selectedIsoNum);
       if (rings) {
         ctx.fillStyle = FILL_COLOR;
+        ctx.beginPath();
         for (const ring of rings) {
-          ctx.beginPath();
           for (let i = 0; i < ring.length; i++) {
             const [lon, lat] = ring[i];
             const x = ((lon + 180) / 360) * CANVAS_W;
@@ -64,8 +72,8 @@ export function CountryFill({ selectedIsoNum, byIsoRings }: CountryFillProps) {
             else ctx.lineTo(x, y);
           }
           ctx.closePath();
-          ctx.fill();
         }
+        ctx.fill("evenodd");
       }
     }
     texture.needsUpdate = true;

--- a/src/components/globe/country-outlines.tsx
+++ b/src/components/globe/country-outlines.tsx
@@ -4,8 +4,23 @@ const TIER1_COLOR = "#3a4a5a";
 const TIER1_OPACITY = 0.8;
 const TIER2_COLOR = "#88aacc";
 const TIER2_OPACITY = 0.85;
+const HOVER_OUTLINE_COLOR = "#FF8866";
+const LINE_R_HOVER = 1.002;
 
-export function CountryOutlinesLayer({ data }: { data: CountryOutlines }) {
+interface CountryOutlinesLayerProps {
+  data: CountryOutlines;
+  hoveredIsoNum?: number | null;
+}
+
+export function CountryOutlinesLayer({
+  data,
+  hoveredIsoNum,
+}: CountryOutlinesLayerProps) {
+  const hoveredPositions =
+    hoveredIsoNum !== null && hoveredIsoNum !== undefined
+      ? data.byIso.get(hoveredIsoNum)
+      : null;
+
   return (
     <>
       <lineSegments>
@@ -36,6 +51,20 @@ export function CountryOutlinesLayer({ data }: { data: CountryOutlines }) {
           opacity={TIER2_OPACITY}
         />
       </lineSegments>
+      {hoveredPositions && (
+        <group scale={[LINE_R_HOVER, LINE_R_HOVER, LINE_R_HOVER]}>
+          <lineSegments>
+            <bufferGeometry>
+              <bufferAttribute
+                attach="attributes-position"
+                args={[hoveredPositions, 3]}
+                count={hoveredPositions.length / 3}
+              />
+            </bufferGeometry>
+            <lineBasicMaterial color={HOVER_OUTLINE_COLOR} />
+          </lineSegments>
+        </group>
+      )}
     </>
   );
 }

--- a/src/components/globe/country-pins.tsx
+++ b/src/components/globe/country-pins.tsx
@@ -7,17 +7,27 @@ import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
 const PIN_ELEVATION = 1.015;
 const PIN_RADIUS = 0.012;
 const PIN_SCALE_SELECTED = 1.3;
+const PIN_SCALE_HOVER = 1.5;
 const GLOW_RADIUS = 0.04;
+const HOVER_HALO_RADIUS = PIN_RADIUS * 1.4;
 const HIT_RADIUS = 0.07;
 const PIN_COLOR = "#B8B5AE";
 const PIN_COLOR_SELECTED = "#FF6B47";
+const PIN_COLOR_HOVER = "#FF8866";
 
 interface CountryPinsProps {
   selectedCode: string | null;
+  hoveredCode: string | null;
   onSelect: (code: string) => void;
+  onHoverChange: (code: string | null) => void;
 }
 
-export function CountryPins({ selectedCode, onSelect }: CountryPinsProps) {
+export function CountryPins({
+  selectedCode,
+  hoveredCode,
+  onSelect,
+  onHoverChange,
+}: CountryPinsProps) {
   const pins = useMemo(
     () =>
       COUNTRIES.map((c) => ({
@@ -31,9 +41,12 @@ export function CountryPins({ selectedCode, onSelect }: CountryPinsProps) {
     <>
       {pins.map(({ country, position }) => {
         const isSelected = selectedCode === country.code;
+        const isHovered = !isSelected && hoveredCode === country.code;
         const dotRadius = isSelected
           ? PIN_RADIUS * PIN_SCALE_SELECTED
-          : PIN_RADIUS;
+          : isHovered
+            ? PIN_RADIUS * PIN_SCALE_HOVER
+            : PIN_RADIUS;
         return (
           <group
             key={country.code}
@@ -43,6 +56,17 @@ export function CountryPins({ selectedCode, onSelect }: CountryPinsProps) {
               onClick={(e) => {
                 e.stopPropagation();
                 onSelect(country.code);
+              }}
+              onPointerEnter={(e) => {
+                if (e.pointerType === "touch") return;
+                if (isSelected) return;
+                e.stopPropagation();
+                onHoverChange(country.code);
+              }}
+              onPointerLeave={(e) => {
+                if (e.pointerType === "touch") return;
+                if (hoveredCode !== country.code) return;
+                onHoverChange(null);
               }}
             >
               <sphereGeometry args={[HIT_RADIUS, 8, 8]} />
@@ -62,10 +86,29 @@ export function CountryPins({ selectedCode, onSelect }: CountryPinsProps) {
               </mesh>
             )}
 
+            {isHovered && (
+              <mesh>
+                <sphereGeometry args={[HOVER_HALO_RADIUS, 16, 16]} />
+                <meshBasicMaterial
+                  color={PIN_COLOR_HOVER}
+                  transparent
+                  opacity={0.18}
+                  blending={AdditiveBlending}
+                  depthWrite={false}
+                />
+              </mesh>
+            )}
+
             <mesh>
               <sphereGeometry args={[dotRadius, 12, 12]} />
               <meshBasicMaterial
-                color={isSelected ? PIN_COLOR_SELECTED : PIN_COLOR}
+                color={
+                  isSelected
+                    ? PIN_COLOR_SELECTED
+                    : isHovered
+                      ? PIN_COLOR_HOVER
+                      : PIN_COLOR
+                }
               />
             </mesh>
           </group>

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, use, useCallback } from "react";
+import { Suspense, use, useCallback, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
@@ -8,12 +8,14 @@ import { Canvas } from "@react-three/fiber";
 import { COUNTRIES } from "@/lib/countries";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 
+import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
 import { StarBackdrop } from "./star-backdrop";
 import { useCameraArc } from "./use-camera-arc";
 
 const ALL_CODES = COUNTRIES.map((c) => c.code);
+const ISO_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c.isoNum]));
 
 function validateCode(raw: string | null): string | null {
   if (raw === null) return null;
@@ -21,16 +23,36 @@ function validateCode(raw: string | null): string | null {
   return ALL_CODES.includes(lower) ? lower : null;
 }
 
-function CountryLayers() {
+function CountryLayers({
+  hoveredIsoNum,
+  selectedIsoNum,
+}: {
+  hoveredIsoNum: number | null;
+  selectedIsoNum: number | null;
+}) {
   const outlines = use(getCountryOutlinesPromise());
   if (!outlines) return null;
-  return <CountryOutlinesLayer data={outlines} />;
+  return (
+    <>
+      <CountryOutlinesLayer data={outlines} hoveredIsoNum={hoveredIsoNum} />
+      <CountryFill
+        selectedIsoNum={selectedIsoNum}
+        byIsoRings={outlines.byIsoRings}
+      />
+    </>
+  );
 }
 
 function SceneContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedCode = validateCode(searchParams.get("cc"));
+
+  const [hoveredCode, setHoveredCode] = useState<string | null>(null);
+  const hoveredIsoNum =
+    hoveredCode !== null ? (ISO_BY_CODE.get(hoveredCode) ?? null) : null;
+  const selectedIsoNum =
+    selectedCode !== null ? (ISO_BY_CODE.get(selectedCode) ?? null) : null;
 
   const { isAnimating } = useCameraArc({ targetCode: selectedCode });
 
@@ -56,9 +78,17 @@ function SceneContent() {
         />
       </mesh>
       <Suspense fallback={null}>
-        <CountryLayers />
+        <CountryLayers
+          hoveredIsoNum={hoveredIsoNum}
+          selectedIsoNum={selectedIsoNum}
+        />
       </Suspense>
-      <CountryPins selectedCode={selectedCode} onSelect={handleSelect} />
+      <CountryPins
+        selectedCode={selectedCode}
+        hoveredCode={hoveredCode}
+        onSelect={handleSelect}
+        onHoverChange={setHoveredCode}
+      />
       <OrbitControls
         autoRotate={selectedCode === null}
         autoRotateSpeed={0.4}

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -50,7 +50,9 @@ function SceneContent() {
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
-    hoveredCode !== null ? (ISO_BY_CODE.get(hoveredCode) ?? null) : null;
+    hoveredCode !== null && hoveredCode !== selectedCode
+      ? (ISO_BY_CODE.get(hoveredCode) ?? null)
+      : null;
   const selectedIsoNum =
     selectedCode !== null ? (ISO_BY_CODE.get(selectedCode) ?? null) : null;
 

--- a/src/lib/country-outlines.test.ts
+++ b/src/lib/country-outlines.test.ts
@@ -45,3 +45,59 @@ test("buildCountryOutlines includes a non-empty geometry for every 40-set countr
     ).toBeGreaterThan(0);
   }
 });
+
+test("buildCountryOutlines exposes lat/lon rings for every 40-set country", () => {
+  const outlines = buildCountryOutlines(realTopology);
+
+  for (const country of COUNTRIES) {
+    const rings = outlines.byIsoRings.get(country.isoNum);
+    expect(
+      rings,
+      `missing rings for ${country.code} (isoNum=${country.isoNum})`,
+    ).toBeDefined();
+    expect(
+      rings!.length,
+      `empty rings for ${country.code} (isoNum=${country.isoNum})`,
+    ).toBeGreaterThan(0);
+  }
+});
+
+test("buildCountryOutlines merges features sharing an ISO num (AU 036: Australia + Ashmore)", () => {
+  const outlines = buildCountryOutlines(realTopology);
+  const auRings = outlines.byIsoRings.get(36);
+
+  expect(auRings).toBeDefined();
+
+  const includesMainland = auRings!.some((ring) => {
+    let minLon = Infinity;
+    let maxLon = -Infinity;
+    let minLat = Infinity;
+    let maxLat = -Infinity;
+    for (const [lon, lat] of ring) {
+      if (lon < minLon) minLon = lon;
+      if (lon > maxLon) maxLon = lon;
+      if (lat < minLat) minLat = lat;
+      if (lat > maxLat) maxLat = lat;
+    }
+    return minLon <= 135 && 135 <= maxLon && minLat <= -25 && -25 <= maxLat;
+  });
+
+  expect(includesMainland).toBe(true);
+});
+
+test("buildCountryOutlines rings entries are [lon, lat] pairs within valid ranges", () => {
+  const outlines = buildCountryOutlines(realTopology);
+  const kr = outlines.byIsoRings.get(410);
+
+  expect(kr).toBeDefined();
+  for (const ring of kr!) {
+    for (const point of ring) {
+      const [lon, lat] = point;
+
+      expect(lon).toBeGreaterThanOrEqual(-180);
+      expect(lon).toBeLessThanOrEqual(180);
+      expect(lat).toBeGreaterThanOrEqual(-90);
+      expect(lat).toBeLessThanOrEqual(90);
+    }
+  }
+});

--- a/src/lib/country-outlines.ts
+++ b/src/lib/country-outlines.ts
@@ -4,10 +4,13 @@ import type { GeometryCollection, Topology } from "topojson-specification";
 import { COUNTRIES } from "./countries";
 import { latLonToVec3 } from "./lat-lon-to-vec3";
 
+export type CountryRings = [number, number][][];
+
 export interface CountryOutlines {
   tier1Positions: Float32Array;
   tier2Positions: Float32Array;
   byIso: Map<number, Float32Array>;
+  byIsoRings: Map<number, CountryRings>;
 }
 
 const SET_40_ISO_NUMS = new Set(COUNTRIES.map((c) => c.isoNum));
@@ -20,61 +23,82 @@ export function buildCountryOutlines(
 
   const tier1Buffers: number[] = [];
   const tier2Buffers: number[] = [];
-  const byIso = new Map<number, Float32Array>();
+  const byIsoRings = new Map<number, CountryRings>();
 
   for (const f of collection.features) {
-    const idRaw = f.id;
-    const id =
-      typeof idRaw === "string"
-        ? parseInt(idRaw, 10)
-        : typeof idRaw === "number"
-          ? idRaw
-          : NaN;
+    const id = parseFeatureId(f.id);
     const inSet = !Number.isNaN(id) && SET_40_ISO_NUMS.has(id);
+    const rings = polygonToLatLonRings(f.geometry);
 
-    const segments = polygonToLineSegments(f.geometry, sphereRadius);
+    const segmentTarget = inSet ? tier2Buffers : tier1Buffers;
+    for (const ring of rings) {
+      pushRingSegments(ring, sphereRadius, segmentTarget);
+    }
 
     if (inSet) {
-      byIso.set(id, new Float32Array(segments));
-      tier2Buffers.push(...segments);
-    } else {
-      tier1Buffers.push(...segments);
+      // Multiple features can share an ISO num (e.g. AU 036 = "Australia" + "Ashmore
+      // and Cartier Is."). Accumulate all rings so we don't lose the mainland.
+      let acc = byIsoRings.get(id);
+      if (!acc) {
+        acc = [];
+        byIsoRings.set(id, acc);
+      }
+      for (const ring of rings) acc.push(ring);
     }
+  }
+
+  const byIso = new Map<number, Float32Array>();
+  for (const [id, rings] of byIsoRings) {
+    const segs: number[] = [];
+    for (const ring of rings) {
+      pushRingSegments(ring, sphereRadius, segs);
+    }
+    byIso.set(id, new Float32Array(segs));
   }
 
   return {
     tier1Positions: new Float32Array(tier1Buffers),
     tier2Positions: new Float32Array(tier2Buffers),
     byIso,
+    byIsoRings,
   };
 }
 
 type PolygonGeom = { type: "Polygon"; coordinates: number[][][] };
 type MultiPolygonGeom = { type: "MultiPolygon"; coordinates: number[][][][] };
 
-function polygonToLineSegments(
-  geom: PolygonGeom | MultiPolygonGeom | { type: string },
-  r: number,
-): number[] {
-  const out: number[] = [];
-  if (geom.type === "Polygon") {
-    for (const ring of (geom as PolygonGeom).coordinates) {
-      pushRing(ring as [number, number][], r, out);
-    }
-  } else if (geom.type === "MultiPolygon") {
-    for (const polygon of (geom as MultiPolygonGeom).coordinates) {
-      for (const ring of polygon) {
-        pushRing(ring as [number, number][], r, out);
-      }
-    }
-  }
-  return out;
+function parseFeatureId(idRaw: unknown): number {
+  if (typeof idRaw === "string") return parseInt(idRaw, 10);
+  if (typeof idRaw === "number") return idRaw;
+  return NaN;
 }
 
-function pushRing(ring: [number, number][], r: number, out: number[]): void {
+function pushRingSegments(
+  ring: [number, number][],
+  r: number,
+  out: number[],
+): void {
   for (let i = 0; i < ring.length - 1; i++) {
     const a = latLonToVec3(ring[i][1], ring[i][0], r);
     const b = latLonToVec3(ring[i + 1][1], ring[i + 1][0], r);
     out.push(a.x, a.y, a.z, b.x, b.y, b.z);
   }
+}
+
+function polygonToLatLonRings(
+  geom: PolygonGeom | MultiPolygonGeom | { type: string },
+): CountryRings {
+  const out: CountryRings = [];
+  if (geom.type === "Polygon") {
+    for (const ring of (geom as PolygonGeom).coordinates) {
+      out.push(ring as [number, number][]);
+    }
+  } else if (geom.type === "MultiPolygon") {
+    for (const polygon of (geom as MultiPolygonGeom).coordinates) {
+      for (const ring of polygon) {
+        out.push(ring as [number, number][]);
+      }
+    }
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

- Hover (desktop only): non-selected pin brightens dot + halo, country outline brightens to sunrise-bright. Selected country exempt from hover.
- Tier 3 fill: selected country gets a translucent sunrise wash via a canvas-texture overlay sphere (equirectangular projection, `offset.x = 0.25` alignment).
- Bundled fix: world-atlas 50m has two features sharing `id="036"` (Australia + Ashmore and Cartier Is.). `buildCountryOutlines` was overwriting Australia's mainland; now merges all features per ISO num. `byIsoRings` is the canonical store; `byIso` derives from it.

## Divergences from PRD

- Hover state lifted to `SceneContent`, not local `useState` in `<CountryPins>` — outline highlight in a sibling component needs the same state, so single source of truth at the parent.
- Pin hover halo uses an additive mesh, not `meshStandardMaterial.emissive` — keeps the existing selected-glow pattern from Slice 1.
- Pointer filter is `pointerType === "touch"` (block touch only), not "mouse-only" — pen users on Wacom/Surface deserve hover.
- Pin dot color also brightens on hover (`#FF8866`) — late iteration addition; tonal consistency with the halo and country outline.

## Test plan

- [x] `pnpm test` (122 passing — +1 regression for AU 036 merge)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Local manual verify all desktop ACs
- [ ] Vercel preview: iOS Safari + Android Chrome (AC 9)

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selected countries now display a filled highlight on the globe.
  * Hovering a country shows a distinct outline.
  * Country pins support hover state with a halo and scaled visual feedback.
  * Clearer visual differentiation for selected, hovered, and default country states.

* **Tests**
  * Added tests validating country geometry/ring data and coordinate bounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taewanu/sounds-abroad/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->