### PR TITLE
Persistent mini player with 4-state chart sheet

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -71,7 +71,6 @@ function ChartScreenInner({
   countryCode: string;
 }) {
   const [snap, setSnap] = useState<SnapState>("peek");
-  const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
   const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
   const endedSignal = useAudioStore((s) => s.endedSignal);
   const audioStore = useAudioStoreApi();
@@ -112,11 +111,20 @@ function ChartScreenInner({
     if (startIdx === -1) return;
     for (let i = startIdx + 1; i < country.tracks.length; i++) {
       if (country.tracks[i].previewUrl !== null) {
-        toggle(country.tracks[i]);
+        toggle(country.tracks[i], countryCode);
         return;
       }
     }
-  }, [endedSignal, audioStore, country.tracks]);
+  }, [endedSignal, audioStore, country.tracks, countryCode]);
+
+  // Hidden sheet has no on-screen affordance; the next pointerdown anywhere
+  // restores it.
+  useEffect(() => {
+    if (snap !== "hidden") return;
+    const handler = () => setSnap("peek");
+    window.addEventListener("pointerdown", handler, { once: true });
+    return () => window.removeEventListener("pointerdown", handler);
+  }, [snap]);
 
   return (
     <>
@@ -126,7 +134,6 @@ function ChartScreenInner({
         snap={snap}
         onSnapChange={setSnap}
         currentTrackRank={currentTrackRank}
-        canClose={hasCurrentTrack}
       />
       <MiniPlayer
         sheetClosed={snap === "closed"}

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -71,6 +71,7 @@ function ChartScreenInner({
   countryCode: string;
 }) {
   const [snap, setSnap] = useState<SnapState>("peek");
+  const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
   const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
   const endedSignal = useAudioStore((s) => s.endedSignal);
   const audioStore = useAudioStoreApi();
@@ -134,11 +135,9 @@ function ChartScreenInner({
         snap={snap}
         onSnapChange={setSnap}
         currentTrackRank={currentTrackRank}
+        hasMiniPlayer={hasCurrentTrack}
       />
-      <MiniPlayer
-        sheetClosed={snap === "closed"}
-        onTap={() => setSnap("peek")}
-      />
+      <MiniPlayer onTap={() => setSnap("peek")} />
     </>
   );
 }

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -58,12 +58,18 @@ export function ChartScreen({ charts }: ChartScreenProps) {
 
   return (
     <AudioStoreProvider>
-      <ChartScreenInner country={country} />
+      <ChartScreenInner country={country} countryCode={validUrlCc} />
     </AudioStoreProvider>
   );
 }
 
-function ChartScreenInner({ country }: { country: Country }) {
+function ChartScreenInner({
+  country,
+  countryCode,
+}: {
+  country: Country;
+  countryCode: string;
+}) {
   const [snap, setSnap] = useState<SnapState>("peek");
   const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
   const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
@@ -116,6 +122,7 @@ function ChartScreenInner({ country }: { country: Country }) {
     <>
       <ChartSheet
         country={country}
+        countryCode={countryCode}
         snap={snap}
         onSnapChange={setSnap}
         currentTrackRank={currentTrackRank}

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
@@ -70,7 +70,9 @@ function ChartScreenInner({
   country: Country;
   countryCode: string;
 }) {
+  const router = useRouter();
   const [snap, setSnap] = useState<SnapState>("peek");
+  const [scrollSignal, setScrollSignal] = useState(0);
   const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
   const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
   const endedSignal = useAudioStore((s) => s.endedSignal);
@@ -127,6 +129,15 @@ function ChartScreenInner({
     return () => window.removeEventListener("pointerdown", handler);
   }, [snap]);
 
+  const handleMiniTap = useCallback(() => {
+    const source = audioStore.getState().currentCountryCode;
+    if (source && source !== countryCode) {
+      router.push(`/?cc=${source}`);
+    }
+    setSnap((s) => (s === "hidden" || s === "closed" ? "peek" : s));
+    setScrollSignal((n) => n + 1);
+  }, [audioStore, countryCode, router]);
+
   return (
     <>
       <ChartSheet
@@ -136,8 +147,9 @@ function ChartScreenInner({
         onSnapChange={setSnap}
         currentTrackRank={currentTrackRank}
         hasMiniPlayer={hasCurrentTrack}
+        scrollSignal={scrollSignal}
       />
-      <MiniPlayer onTap={() => setSnap("peek")} />
+      <MiniPlayer onTap={handleMiniTap} />
     </>
   );
 }

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
@@ -58,7 +58,11 @@ export function ChartScreen({ charts }: ChartScreenProps) {
 
   return (
     <AudioStoreProvider>
-      <ChartScreenInner country={country} countryCode={validUrlCc} />
+      <ChartScreenInner
+        country={country}
+        countryCode={validUrlCc}
+        charts={charts}
+      />
     </AudioStoreProvider>
   );
 }
@@ -66,9 +70,11 @@ export function ChartScreen({ charts }: ChartScreenProps) {
 function ChartScreenInner({
   country,
   countryCode,
+  charts,
 }: {
   country: Country;
   countryCode: string;
+  charts: ChartFile;
 }) {
   const router = useRouter();
   const [snap, setSnap] = useState<SnapState>("peek");
@@ -104,21 +110,28 @@ function ChartScreenInner({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [audioStore]);
 
+  // Advance within the source country, not the visible one. Ref-gated so
+  // only an actual ended event triggers advance, never a dep-only re-run.
+  const prevEndedRef = useRef(endedSignal);
   useEffect(() => {
+    if (endedSignal === prevEndedRef.current) return;
+    prevEndedRef.current = endedSignal;
     if (endedSignal === 0) return;
-    const { currentTrack, toggle } = audioStore.getState();
-    if (currentTrack === null) return;
-    const startIdx = country.tracks.findIndex(
+    const { currentTrack, currentCountryCode, toggle } = audioStore.getState();
+    if (currentTrack === null || currentCountryCode === null) return;
+    const source = charts.countries[currentCountryCode];
+    if (!source) return;
+    const startIdx = source.tracks.findIndex(
       (t) => t.previewUrl === currentTrack.previewUrl,
     );
     if (startIdx === -1) return;
-    for (let i = startIdx + 1; i < country.tracks.length; i++) {
-      if (country.tracks[i].previewUrl !== null) {
-        toggle(country.tracks[i], countryCode);
+    for (let i = startIdx + 1; i < source.tracks.length; i++) {
+      if (source.tracks[i].previewUrl !== null) {
+        toggle(source.tracks[i], currentCountryCode);
         return;
       }
     }
-  }, [endedSignal, audioStore, country.tracks, countryCode]);
+  }, [endedSignal, audioStore, charts.countries]);
 
   // Hidden sheet has no on-screen affordance; the next pointerdown anywhere
   // restores it.

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -18,6 +18,7 @@ function renderSheet(snap: SnapState) {
     <AudioStoreProvider>
       <ChartSheet
         country={COUNTRY_KR}
+        countryCode="kr"
         snap={snap}
         onSnapChange={onSnapChange}
       />
@@ -80,6 +81,7 @@ describe("ChartSheet", () => {
       <AudioStoreProvider>
         <ChartSheet
           country={COUNTRY_KR}
+          countryCode="kr"
           snap="closed"
           onSnapChange={vi.fn()}
           currentTrackRank={rank}
@@ -91,6 +93,7 @@ describe("ChartSheet", () => {
       <AudioStoreProvider>
         <ChartSheet
           country={COUNTRY_KR}
+          countryCode="kr"
           snap="peek"
           onSnapChange={vi.fn()}
           currentTrackRank={rank}
@@ -111,6 +114,7 @@ describe("ChartSheet", () => {
       <AudioStoreProvider>
         <ChartSheet
           country={COUNTRY_KR}
+          countryCode="kr"
           snap="peek"
           onSnapChange={vi.fn()}
           currentTrackRank={rank}
@@ -124,6 +128,7 @@ describe("ChartSheet", () => {
       <AudioStoreProvider>
         <ChartSheet
           country={COUNTRY_KR}
+          countryCode="kr"
           snap="full"
           onSnapChange={vi.fn()}
           currentTrackRank={rank}
@@ -144,6 +149,7 @@ describe("ChartSheet", () => {
       <AudioStoreProvider>
         <ChartSheet
           country={COUNTRY_KR}
+          countryCode="kr"
           snap="closed"
           onSnapChange={vi.fn()}
           currentTrackRank={null}
@@ -155,6 +161,7 @@ describe("ChartSheet", () => {
       <AudioStoreProvider>
         <ChartSheet
           country={COUNTRY_KR}
+          countryCode="kr"
           snap="peek"
           onSnapChange={vi.fn()}
           currentTrackRank={null}

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -187,6 +187,42 @@ describe("ChartSheet", () => {
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });
 
+  test("scrolls currentTrack into view when scrollSignal increments while open", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    const rank = COUNTRY_KR.tracks[0].rank;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+          scrollSignal={0}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+          scrollSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+
   test("does not scroll when currentTrackRank is null", async () => {
     const scrollIntoViewMock = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoViewMock;

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -57,6 +57,20 @@ describe("ChartSheet", () => {
     expect(sheet.getAttribute("data-snap")).toBe("full");
   });
 
+  test("exposes data-snap='closed' when snap prop is closed", () => {
+    renderSheet("closed");
+
+    const sheet = screen.getByTestId("chart-sheet");
+    expect(sheet.getAttribute("data-snap")).toBe("closed");
+  });
+
+  test("exposes data-snap='hidden' when snap prop is hidden", () => {
+    renderSheet("hidden");
+
+    const sheet = screen.getByTestId("chart-sheet");
+    expect(sheet.getAttribute("data-snap")).toBe("hidden");
+  });
+
   test("fires onSnapChange with 'full' when handle clicked while peek", () => {
     const { onSnapChange } = renderSheet("peek");
 
@@ -139,6 +153,38 @@ describe("ChartSheet", () => {
     await new Promise<void>((r) => requestAnimationFrame(() => r()));
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  test("scrolls currentTrack into view when sheet transitions from hidden", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    const rank = COUNTRY_KR.tracks[2].rank;
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="hidden"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+        />
+      </AudioStoreProvider>,
+    );
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={rank}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });
 
   test("does not scroll when currentTrackRank is null", async () => {

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -188,6 +188,7 @@ export function ChartSheet({
               </Dialog.Title>
             </div>
             <ol
+              key={countryCode}
               ref={olRef}
               data-peek={(snap === "peek" && !isDragging) || undefined}
               className="min-h-0 flex-1 overflow-y-auto px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -135,7 +135,11 @@ export function ChartSheet({
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange} modal={false}>
       <Dialog.Portal>
-        <Dialog.Content asChild aria-describedby={undefined}>
+        <Dialog.Content
+          asChild
+          aria-describedby={undefined}
+          onInteractOutside={(e) => e.preventDefault()}
+        >
           <motion.div
             data-snap={snap}
             data-testid="chart-sheet"

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -17,6 +17,7 @@ export type SnapState = "closed" | "peek" | "full";
 
 export interface ChartSheetProps {
   country: Country;
+  countryCode: string;
   snap: SnapState;
   onSnapChange: (snap: SnapState) => void;
   currentTrackRank?: number | null;
@@ -63,6 +64,7 @@ function nextSnap(
 
 export function ChartSheet({
   country,
+  countryCode,
   snap,
   onSnapChange,
   currentTrackRank = null,
@@ -175,7 +177,11 @@ export function ChartSheet({
               className="min-h-0 flex-1 overflow-y-auto px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
             >
               {country.tracks.map((track) => (
-                <TrackRow key={track.rank} track={track} />
+                <TrackRow
+                  key={track.rank}
+                  track={track}
+                  countryCode={countryCode}
+                />
               ))}
             </ol>
           </motion.div>

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -41,11 +41,15 @@ const SNAP_Y: Record<SnapState, string> = {
 
 const SNAP_ORDER: SnapState[] = ["full", "peek", "closed", "hidden"];
 const VELOCITY_PROJECTION = 0.15;
-const MINI_PLAYER_HEIGHT_PX = 70;
+
+// Mirror MiniPlayer's rendered height: pt-3 (12px) + h-12 artwork (48px)
+// + pb-[max(env(safe-area-inset-bottom), 12px)]. Tracks the iOS safe-area
+// inset so the sheet doesn't sit under the mini on notched devices.
+const MINI_PLAYER_GAP = "calc(60px + max(env(safe-area-inset-bottom), 12px))";
 
 const SHEET_STYLE_WITH_MINI = {
-  bottom: MINI_PLAYER_HEIGHT_PX,
-  height: `calc(100dvh - ${MINI_PLAYER_HEIGHT_PX}px)`,
+  bottom: MINI_PLAYER_GAP,
+  height: `calc(100dvh - ${MINI_PLAYER_GAP})`,
 } as const;
 const SHEET_STYLE_NO_MINI = { bottom: 0, height: "100dvh" } as const;
 

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -22,6 +22,7 @@ export interface ChartSheetProps {
   onSnapChange: (snap: SnapState) => void;
   currentTrackRank?: number | null;
   hasMiniPlayer?: boolean;
+  scrollSignal?: number;
 }
 
 const SNAP_Y_PCT: Record<SnapState, number> = {
@@ -84,6 +85,7 @@ export function ChartSheet({
   onSnapChange,
   currentTrackRank = null,
   hasMiniPlayer = false,
+  scrollSignal = 0,
 }: ChartSheetProps) {
   const animationControls = useAnimationControls();
   const dragControls = useDragControls();
@@ -123,14 +125,17 @@ export function ChartSheet({
 
   const olRef = useRef<HTMLOListElement | null>(null);
   const prevSnapRef = useRef(snap);
+  const prevSignalRef = useRef(scrollSignal);
 
   useEffect(() => {
     const wasMin =
       prevSnapRef.current === "closed" || prevSnapRef.current === "hidden";
+    const signalChanged = prevSignalRef.current !== scrollSignal;
     prevSnapRef.current = snap;
+    prevSignalRef.current = scrollSignal;
     if (snap === "closed" || snap === "hidden") return;
     if (currentTrackRank === null) return;
-    if (!wasMin) return;
+    if (!wasMin && !signalChanged) return;
     // Defer one frame so the portal's content is in the DOM before query.
     const id = requestAnimationFrame(() => {
       const el = olRef.current?.querySelector<HTMLElement>(
@@ -142,7 +147,7 @@ export function ChartSheet({
       });
     });
     return () => cancelAnimationFrame(id);
-  }, [snap, currentTrackRank]);
+  }, [snap, currentTrackRank, scrollSignal]);
 
   return (
     <Dialog.Root open onOpenChange={handleOpenChange} modal={false}>

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -13,7 +13,7 @@ import type { Country } from "@/lib/chart-schema";
 
 import { TrackRow } from "./track-row";
 
-export type SnapState = "closed" | "peek" | "full";
+export type SnapState = "hidden" | "closed" | "peek" | "full";
 
 export interface ChartSheetProps {
   country: Country;
@@ -21,22 +21,23 @@ export interface ChartSheetProps {
   snap: SnapState;
   onSnapChange: (snap: SnapState) => void;
   currentTrackRank?: number | null;
-  canClose?: boolean;
 }
 
 const SNAP_Y_PCT: Record<SnapState, number> = {
   full: 0,
   peek: 65,
-  closed: 100,
+  closed: 90,
+  hidden: 100,
 };
 
 const SNAP_Y: Record<SnapState, string> = {
   full: `${SNAP_Y_PCT.full}%`,
   peek: `${SNAP_Y_PCT.peek}%`,
   closed: `${SNAP_Y_PCT.closed}%`,
+  hidden: `${SNAP_Y_PCT.hidden}%`,
 };
 
-const SNAP_ORDER: SnapState[] = ["full", "peek", "closed"];
+const SNAP_ORDER: SnapState[] = ["full", "peek", "closed", "hidden"];
 const VELOCITY_PROJECTION = 0.15;
 
 function nextSnap(
@@ -50,9 +51,15 @@ function nextSnap(
   const projected =
     SNAP_Y_PCT[current] + offsetPct + velocityPct * VELOCITY_PROJECTION;
 
+  // One-step transitions only — every snap is a required waypoint.
+  const idx = SNAP_ORDER.indexOf(current);
+  const candidates: SnapState[] = [current];
+  if (idx > 0) candidates.push(SNAP_ORDER[idx - 1]);
+  if (idx < SNAP_ORDER.length - 1) candidates.push(SNAP_ORDER[idx + 1]);
+
   let nearest: SnapState = current;
   let minDist = Infinity;
-  for (const s of SNAP_ORDER) {
+  for (const s of candidates) {
     const dist = Math.abs(SNAP_Y_PCT[s] - projected);
     if (dist < minDist) {
       minDist = dist;
@@ -68,9 +75,7 @@ export function ChartSheet({
   snap,
   onSnapChange,
   currentTrackRank = null,
-  canClose = true,
 }: ChartSheetProps) {
-  const open = snap !== "closed";
   const animationControls = useAnimationControls();
   const dragControls = useDragControls();
   const [isDragging, setIsDragging] = useState(false);
@@ -79,15 +84,13 @@ export function ChartSheet({
     void animationControls.start({ y: SNAP_Y[snap] });
   }, [snap, animationControls]);
 
+  // open is pinned true to keep motion.div mounted for hidden↔visible
+  // animation; Escape collapses to closed instead of unmounting.
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      if (!next && !canClose) {
-        void animationControls.start({ y: SNAP_Y[snap] });
-        return;
-      }
-      onSnapChange(next ? "peek" : "closed");
+      if (!next) onSnapChange("closed");
     },
-    [onSnapChange, canClose, snap, animationControls],
+    [onSnapChange],
   );
 
   const handleDragStart = useCallback(() => setIsDragging(true), []);
@@ -96,17 +99,13 @@ export function ChartSheet({
     (_event: unknown, info: PanInfo) => {
       setIsDragging(false);
       const next = nextSnap(snap, info.offset.y, info.velocity.y);
-      if (next === "closed" && !canClose) {
-        void animationControls.start({ y: SNAP_Y[snap] });
-        return;
-      }
       if (next === snap) {
         void animationControls.start({ y: SNAP_Y[snap] });
         return;
       }
       onSnapChange(next);
     },
-    [snap, onSnapChange, canClose, animationControls],
+    [snap, onSnapChange, animationControls],
   );
 
   const handleToggle = useCallback(() => {
@@ -117,11 +116,13 @@ export function ChartSheet({
   const prevSnapRef = useRef(snap);
 
   useEffect(() => {
-    const wasClosed = prevSnapRef.current === "closed";
+    const wasMin =
+      prevSnapRef.current === "closed" || prevSnapRef.current === "hidden";
     prevSnapRef.current = snap;
-    if (!wasClosed || snap === "closed" || currentTrackRank === null) return;
-    // Defer to next frame so Radix Dialog.Portal has fully mounted its content
-    // and refs inside the portal are populated before we query/scroll.
+    if (snap === "closed" || snap === "hidden") return;
+    if (currentTrackRank === null) return;
+    if (!wasMin) return;
+    // Defer one frame so the portal's content is in the DOM before query.
     const id = requestAnimationFrame(() => {
       const el = olRef.current?.querySelector<HTMLElement>(
         `[data-rank="${currentTrackRank}"]`,
@@ -135,7 +136,7 @@ export function ChartSheet({
   }, [snap, currentTrackRank]);
 
   return (
-    <Dialog.Root open={open} onOpenChange={handleOpenChange} modal={false}>
+    <Dialog.Root open onOpenChange={handleOpenChange} modal={false}>
       <Dialog.Portal>
         <Dialog.Content
           asChild
@@ -164,7 +165,7 @@ export function ChartSheet({
               <button
                 type="button"
                 onClick={handleToggle}
-                aria-label={snap === "peek" ? "Expand chart" : "Collapse chart"}
+                aria-label={snap === "full" ? "Collapse chart" : "Expand chart"}
                 className="bg-fg-1/15 rounded-pill mx-auto mt-3 mb-2 block h-1.5 w-12"
               />
               <Dialog.Title className="text-h3 px-6 pb-3 font-semibold">

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -21,6 +21,7 @@ export interface ChartSheetProps {
   snap: SnapState;
   onSnapChange: (snap: SnapState) => void;
   currentTrackRank?: number | null;
+  hasMiniPlayer?: boolean;
 }
 
 const SNAP_Y_PCT: Record<SnapState, number> = {
@@ -39,6 +40,13 @@ const SNAP_Y: Record<SnapState, string> = {
 
 const SNAP_ORDER: SnapState[] = ["full", "peek", "closed", "hidden"];
 const VELOCITY_PROJECTION = 0.15;
+const MINI_PLAYER_HEIGHT_PX = 70;
+
+const SHEET_STYLE_WITH_MINI = {
+  bottom: MINI_PLAYER_HEIGHT_PX,
+  height: `calc(100dvh - ${MINI_PLAYER_HEIGHT_PX}px)`,
+} as const;
+const SHEET_STYLE_NO_MINI = { bottom: 0, height: "100dvh" } as const;
 
 function nextSnap(
   current: SnapState,
@@ -75,6 +83,7 @@ export function ChartSheet({
   snap,
   onSnapChange,
   currentTrackRank = null,
+  hasMiniPlayer = false,
 }: ChartSheetProps) {
   const animationControls = useAnimationControls();
   const dragControls = useDragControls();
@@ -156,7 +165,8 @@ export function ChartSheet({
             transition={{ type: "spring", damping: 30, stiffness: 300 }}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
-            className="bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 bottom-0 flex h-[100dvh] flex-col rounded-t-2xl border-t"
+            style={hasMiniPlayer ? SHEET_STYLE_WITH_MINI : SHEET_STYLE_NO_MINI}
+            className="bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 flex flex-col rounded-t-2xl border-t"
           >
             <div
               onPointerDown={(e) => dragControls.start(e)}

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -96,7 +96,11 @@ describe("TrackRow", () => {
 
     expect(container.querySelector("[data-state]")).toBeNull();
 
-    store.setState({ currentTrack: track, isPlaying: true });
+    store.setState({
+      currentTrack: track,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
     rerender(
       <AudioStoreContext.Provider value={store}>
         <ul>
@@ -106,7 +110,11 @@ describe("TrackRow", () => {
     );
     expect(container.querySelector('[data-state="playing"]')).not.toBeNull();
 
-    store.setState({ currentTrack: track, isPlaying: false });
+    store.setState({
+      currentTrack: track,
+      isPlaying: false,
+      currentCountryCode: "kr",
+    });
     rerender(
       <AudioStoreContext.Provider value={store}>
         <ul>
@@ -116,7 +124,11 @@ describe("TrackRow", () => {
     );
     expect(container.querySelector('[data-state="paused"]')).not.toBeNull();
 
-    store.setState({ currentTrack: otherTrack, isPlaying: true });
+    store.setState({
+      currentTrack: otherTrack,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
     rerender(
       <AudioStoreContext.Provider value={store}>
         <ul>
@@ -124,6 +136,17 @@ describe("TrackRow", () => {
         </ul>
       </AudioStoreContext.Provider>,
     );
+    expect(container.querySelector("[data-state]")).toBeNull();
+  });
+
+  test("data-state idle when same previewUrl plays in a different country", () => {
+    const track = makeTrack();
+    const { container } = renderTrackRow(
+      track,
+      { currentTrack: track, isPlaying: true, currentCountryCode: "a" },
+      "b",
+    );
+
     expect(container.querySelector("[data-state]")).toBeNull();
   });
 

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -34,7 +34,11 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
   };
 }
 
-function renderTrackRow(track: Track, init?: Partial<AudioState>) {
+function renderTrackRow(
+  track: Track,
+  init?: Partial<AudioState>,
+  countryCode = "kr",
+) {
   const store = createAudioStore(() => makeMockAudio());
   if (init) {
     store.setState(init);
@@ -42,7 +46,7 @@ function renderTrackRow(track: Track, init?: Partial<AudioState>) {
   const utils = render(
     <AudioStoreContext.Provider value={store}>
       <ul>
-        <TrackRow track={track} />
+        <TrackRow track={track} countryCode={countryCode} />
       </ul>
     </AudioStoreContext.Provider>,
   );
@@ -72,6 +76,15 @@ describe("TrackRow", () => {
     expect(store.getState().isPlaying).toBe(true);
   });
 
+  test("clicking the row stores countryCode as source on the audio store", () => {
+    const track = makeTrack();
+    const { store } = renderTrackRow(track, undefined, "br");
+
+    fireEvent.click(screen.getByRole("button", { name: /preview/i }));
+
+    expect(store.getState().currentCountryCode).toBe("br");
+  });
+
   test("data-state reflects current vs idle, playing vs paused", () => {
     const track = makeTrack();
     const otherTrack = makeTrack({
@@ -87,7 +100,7 @@ describe("TrackRow", () => {
     rerender(
       <AudioStoreContext.Provider value={store}>
         <ul>
-          <TrackRow track={track} />
+          <TrackRow track={track} countryCode="kr" />
         </ul>
       </AudioStoreContext.Provider>,
     );
@@ -97,7 +110,7 @@ describe("TrackRow", () => {
     rerender(
       <AudioStoreContext.Provider value={store}>
         <ul>
-          <TrackRow track={track} />
+          <TrackRow track={track} countryCode="kr" />
         </ul>
       </AudioStoreContext.Provider>,
     );
@@ -107,7 +120,7 @@ describe("TrackRow", () => {
     rerender(
       <AudioStoreContext.Provider value={store}>
         <ul>
-          <TrackRow track={track} />
+          <TrackRow track={track} countryCode="kr" />
         </ul>
       </AudioStoreContext.Provider>,
     );

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -9,9 +9,10 @@ import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface TrackRowProps {
   track: Track;
+  countryCode: string;
 }
 
-export function TrackRow({ track }: TrackRowProps) {
+export function TrackRow({ track, countryCode }: TrackRowProps) {
   const isCurrent = useAudioStore(
     (s) => s.currentTrack?.previewUrl === track.previewUrl,
   );
@@ -36,7 +37,7 @@ export function TrackRow({ track }: TrackRowProps) {
       <button
         type="button"
         disabled={!hasPreview}
-        onClick={() => toggle(track)}
+        onClick={() => toggle(track, countryCode)}
         aria-label={`${isPlaying ? "Pause" : "Play"} preview of ${track.name} by ${track.artist}`}
         className="focus-visible:outline-aurora flex min-w-0 flex-1 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none"
       >

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -14,10 +14,15 @@ export interface TrackRowProps {
 
 export function TrackRow({ track, countryCode }: TrackRowProps) {
   const isCurrent = useAudioStore(
-    (s) => s.currentTrack?.previewUrl === track.previewUrl,
+    (s) =>
+      s.currentTrack?.previewUrl === track.previewUrl &&
+      s.currentCountryCode === countryCode,
   );
   const isPlaying = useAudioStore(
-    (s) => s.isPlaying && s.currentTrack?.previewUrl === track.previewUrl,
+    (s) =>
+      s.isPlaying &&
+      s.currentTrack?.previewUrl === track.previewUrl &&
+      s.currentCountryCode === countryCode,
   );
   const hasError = useAudioStore(
     (s) => s.lastError?.previewUrl === track.previewUrl,

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -35,7 +35,7 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 }
 
 function renderMiniPlayer(
-  props: { sheetClosed: boolean; onTap: () => void },
+  props: { onTap: () => void },
   init?: Partial<AudioState>,
 ) {
   const store = createAudioStore(() => makeMockAudio());
@@ -52,26 +52,24 @@ function renderMiniPlayer(
 
 describe("MiniPlayer", () => {
   test("renders nothing when currentTrack is null", () => {
-    const { container } = renderMiniPlayer({
-      sheetClosed: true,
-      onTap: vi.fn(),
-    });
+    const { container } = renderMiniPlayer({ onTap: vi.fn() });
 
     expect(container.firstChild).toBeNull();
   });
 
-  test("renders nothing when sheet is not closed even if currentTrack set", () => {
+  test("renders whenever currentTrack is set, regardless of sheet state", () => {
     const track = makeTrack();
 
     const { container } = renderMiniPlayer(
-      { sheetClosed: false, onTap: vi.fn() },
+      { onTap: vi.fn() },
       { currentTrack: track },
     );
 
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText(track.name)).toBeDefined();
   });
 
-  test("renders name, artist, artwork when currentTrack set and sheet closed", () => {
+  test("renders name, artist, artwork when currentTrack set", () => {
     const track = makeTrack({
       name: "Hot Track",
       artist: "Hot Artist",
@@ -79,7 +77,7 @@ describe("MiniPlayer", () => {
     });
 
     const { container } = renderMiniPlayer(
-      { sheetClosed: true, onTap: vi.fn() },
+      { onTap: vi.fn() },
       { currentTrack: track },
     );
 
@@ -93,7 +91,7 @@ describe("MiniPlayer", () => {
     const track = makeTrack();
     const onTap = vi.fn();
 
-    renderMiniPlayer({ sheetClosed: true, onTap }, { currentTrack: track });
+    renderMiniPlayer({ onTap }, { currentTrack: track });
 
     fireEvent.click(screen.getByRole("button", { name: /reopen chart/i }));
 
@@ -104,7 +102,7 @@ describe("MiniPlayer", () => {
     const track = makeTrack({ name: "Hot Track" });
 
     const { store } = renderMiniPlayer(
-      { sheetClosed: true, onTap: vi.fn() },
+      { onTap: vi.fn() },
       { currentTrack: track, isPlaying: false },
     );
 

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -5,19 +5,18 @@ import { PlayIcon } from "@/components/icons/play";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface MiniPlayerProps {
-  sheetClosed: boolean;
   onTap: () => void;
 }
 
-export function MiniPlayer({ sheetClosed, onTap }: MiniPlayerProps) {
+export function MiniPlayer({ onTap }: MiniPlayerProps) {
   const currentTrack = useAudioStore((s) => s.currentTrack);
   const isPlaying = useAudioStore((s) => s.isPlaying);
   const toggle = useAudioStore((s) => s.toggle);
 
-  if (currentTrack === null || !sheetClosed) return null;
+  if (currentTrack === null) return null;
 
   return (
-    <div className="bg-void border-fg-1/10 shadow-sheet fixed inset-x-0 bottom-0 border-t">
+    <div className="bg-void border-fg-1/10 shadow-sheet fixed inset-x-0 bottom-0 z-50 border-t">
       <div className="flex items-center gap-[14px] px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]">
         <button
           type="button"

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -40,11 +40,12 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 }
 
 describe("createAudioStore", () => {
-  test("initial state: no track, not playing", () => {
+  test("initial state: no track, not playing, no country", () => {
     const store = createAudioStore(() => makeMockAudio());
 
     expect(store.getState().currentTrack).toBeNull();
     expect(store.getState().isPlaying).toBe(false);
+    expect(store.getState().currentCountryCode).toBeNull();
   });
 
   test("toggle plays a new track", () => {
@@ -85,6 +86,47 @@ describe("createAudioStore", () => {
     expect(audio.src).toBe(trackB.previewUrl);
     expect(store.getState().currentTrack).toBe(trackB);
     expect(store.getState().isPlaying).toBe(true);
+  });
+
+  test("toggle on new track stores countryCode when provided", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    const track = makeTrack();
+
+    store.getState().toggle(track, "br");
+
+    expect(store.getState().currentCountryCode).toBe("br");
+  });
+
+  test("toggle on new track without countryCode sets currentCountryCode to null", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    const track = makeTrack();
+
+    store.getState().toggle(track);
+
+    expect(store.getState().currentCountryCode).toBeNull();
+  });
+
+  test("resume (toggle same track after pause) preserves countryCode", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack();
+    store.getState().toggle(track, "br");
+    store.getState().toggle(track); // pause
+    assert(store.getState().isPlaying === false, "arrange: paused");
+
+    store.getState().toggle(track); // resume without countryCode
+
+    expect(store.getState().currentCountryCode).toBe("br");
+    expect(store.getState().isPlaying).toBe(true);
+  });
+
+  test("stop clears currentCountryCode", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    store.getState().toggle(makeTrack(), "br");
+
+    store.getState().stop();
+
+    expect(store.getState().currentCountryCode).toBeNull();
   });
 
   test("stop clears currentTrack and isPlaying", () => {

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -27,10 +27,11 @@ export interface AudioError {
 
 export interface AudioState {
   currentTrack: Track | null;
+  currentCountryCode: string | null;
   isPlaying: boolean;
   lastError: AudioError | null;
   endedSignal: number;
-  toggle: (track: Track) => void;
+  toggle: (track: Track, countryCode?: string) => void;
   stop: () => void;
 }
 
@@ -70,10 +71,11 @@ export function createAudioStore(
 
     return {
       currentTrack: null,
+      currentCountryCode: null,
       isPlaying: false,
       lastError: null,
       endedSignal: 0,
-      toggle: (track) => {
+      toggle: (track, countryCode) => {
         const state = get();
         const a = getAudio();
         if (
@@ -86,12 +88,27 @@ export function createAudioStore(
         }
         a.src = track.previewUrl ?? "";
         void a.play();
-        set({ currentTrack: track, isPlaying: true, lastError: null });
+        const isNewTrack = state.currentTrack?.previewUrl !== track.previewUrl;
+        if (isNewTrack) {
+          set({
+            currentTrack: track,
+            currentCountryCode: countryCode ?? null,
+            isPlaying: true,
+            lastError: null,
+          });
+        } else {
+          set({ currentTrack: track, isPlaying: true, lastError: null });
+        }
       },
       stop: () => {
         const a = getAudio();
         a.pause();
-        set({ currentTrack: null, isPlaying: false, lastError: null });
+        set({
+          currentTrack: null,
+          currentCountryCode: null,
+          isPlaying: false,
+          lastError: null,
+        });
       },
     };
   });


### PR DESCRIPTION
Closes #49

## Summary

- Chart sheet has 4 snap states (hidden / closed-with-handle / peek / full); one-step transitions only
- Mini player stays visible whenever a track plays — sitting above the sheet, no longer coupled to sheet state
- Tap mini → navigate to the playing track's source country, open peek, scroll to its row
- Globe tap no longer dismisses the sheet; while hidden, globe tap restores it to peek
- Auto-advance follows the source country (not the visible one); track rows light up only on their source

## Test plan

- [x] Drag through 4 snap states — one-step transitions (peek → closed → hidden, no skips)
- [x] Track playing → mini visible in all 4 sheet states
- [x] Drag to hidden → tap globe → sheet returns to peek
- [x] Mini tap from a different country → navigate to source + peek + scroll to playing row
- [x] Same song charting in multiple countries → playing indicator only on source country row
- [x] Auto-advance: play country A, switch to B, wait for end → next song in A plays
- [x] Country change resets list scroll to top
- [x] Spacebar pause/resume still works
- [x] iOS Safari + iOS Chrome verify on physical device
