### PR TITLE
Drag the chart sheet from the list, not just the handle

### DIFF
--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -6,10 +6,25 @@ import { AudioStoreProvider } from "@/providers/audio-store-provider";
 
 import { ChartSheet, type SnapState } from "./sheet";
 
+const { dragStart } = vi.hoisted(() => ({ dragStart: vi.fn() }));
+
+vi.mock("motion/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("motion/react")>();
+  return {
+    ...actual,
+    useDragControls: () => ({ start: dragStart, subscribe: () => () => {} }),
+  };
+});
+
+function setScrollTop(el: Element, value: number) {
+  Object.defineProperty(el, "scrollTop", { value, configurable: true });
+}
+
 const originalScrollIntoView = Element.prototype.scrollIntoView;
 
 afterEach(() => {
   Element.prototype.scrollIntoView = originalScrollIntoView;
+  dragStart.mockClear();
 });
 
 function renderSheet(snap: SnapState) {
@@ -254,5 +269,35 @@ describe("ChartSheet", () => {
     await new Promise<void>((r) => requestAnimationFrame(() => r()));
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  test("starts the sheet drag on pointer down in the list at the top", () => {
+    renderSheet("peek");
+    const list = screen.getByRole("list");
+    setScrollTop(list, 0);
+
+    fireEvent.pointerDown(list);
+
+    expect(dragStart).toHaveBeenCalledTimes(1);
+  });
+
+  test("yields to list scroll on pointer down when the list is scrolled", () => {
+    renderSheet("peek");
+    const list = screen.getByRole("list");
+    setScrollTop(list, 40);
+
+    fireEvent.pointerDown(list);
+
+    expect(dragStart).not.toHaveBeenCalled();
+  });
+
+  test("starts the sheet drag on pointer down outside the list", () => {
+    renderSheet("peek");
+    const list = screen.getByRole("list");
+    setScrollTop(list, 40);
+
+    fireEvent.pointerDown(screen.getByText(COUNTRY_KR.name));
+
+    expect(dragStart).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
   motion,
@@ -128,6 +134,18 @@ export function ChartSheet({
   }, [snap, onSnapChange]);
 
   const olRef = useRef<HTMLOListElement | null>(null);
+
+  // Drag starts from anywhere on the sheet, except yield to the list's
+  // native scroll while it's scrolled away from the top.
+  const handlePointerDown = useCallback(
+    (e: PointerEvent) => {
+      const ol = olRef.current;
+      if (ol && ol.contains(e.target as Node) && ol.scrollTop > 0) return;
+      dragControls.start(e);
+    },
+    [dragControls],
+  );
+
   const prevSnapRef = useRef(snap);
   const prevSignalRef = useRef(scrollSignal);
 
@@ -174,13 +192,11 @@ export function ChartSheet({
             transition={{ type: "spring", damping: 30, stiffness: 300 }}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
+            onPointerDown={handlePointerDown}
             style={hasMiniPlayer ? SHEET_STYLE_WITH_MINI : SHEET_STYLE_NO_MINI}
             className="bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 flex flex-col rounded-t-2xl border-t"
           >
-            <div
-              onPointerDown={(e) => dragControls.start(e)}
-              className="shrink-0 touch-none"
-            >
+            <div className="shrink-0 touch-none">
               <button
                 type="button"
                 onClick={handleToggle}


### PR DESCRIPTION
Refs #50 (partial — full-state body-drag deferred to V2)

## Summary

- Drag-start consolidated onto the sheet body: a pointer-down anywhere on the sheet can start the drag, not just the ~26px handle
- The list yields to native scroll when scrolled past the top; handle/header drag unchanged
- Tapping a track at the top still plays it — no regression (verified on device)

## Why this is partial (touch-action)

On touch, the browser commits a gesture to scroll-or-drag from the element's `touch-action` at touch-start, before JS sees movement — so `dragControls.start()` in a pointer handler can't reclaim a gesture the browser already gave to native scroll. Body-drag lands reliably only where the list doesn't need to scroll:

| Input | Behavior |
|---|---|
| Mouse (desktop pointer) | Body drag works in all states |
| Touch — peek | Body drag to expand/collapse (best-effort; list is short) |
| Touch — full | List keeps native scroll; body-drag-to-collapse → V2 |

Full-state body-drag needs direction-aware mid-gesture hand-off, deferred to V2.

## Verified (iPhone Chrome + desktop)

- [x] Handle/header drag works
- [x] Tap-to-play at list top intact (no regression)
- [x] Native list scroll intact
- [x] Desktop mouse: body drag works
- [~] Touch peek: body drag best-effort
- [ ] Touch full-state body-drag → V2

## Tests

- 3 unit tests pin the pointer-down delegation (the `scrollTop` gate)
