### PR TITLE
fix(crawl): resilient per-country crawl — retry + carry-forward last-good

### DIFF
--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       SITE_URL: https://sounds-abroad.vercel.app
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      CHARTS_BLOB_URL: ${{ secrets.CHARTS_BLOB_URL }}
       REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
 

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -3,16 +3,25 @@ import * as Sentry from "@sentry/node";
 
 import { COUNTRIES } from "../../src/lib/countries";
 
-import { fetchAppleRss } from "./apple-rss";
+import { AppleRssError, fetchAppleRss } from "./apple-rss";
 import { lookupTrack } from "./itunes-lookup";
+import { fetchPublishedCharts } from "./published-charts";
+import { withRetry } from "./retry";
 import { triggerRevalidate } from "./revalidate-trigger";
-import { crawlAll } from "./run";
+import { crawlAll, summarizeValidity } from "./run";
 import { createThrottle } from "./throttle";
 import { uploadCharts } from "./upload-blob";
 
 if (!process.env.BLOB_READ_WRITE_TOKEN) {
   throw new Error("BLOB_READ_WRITE_TOKEN missing.");
 }
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// Public URL of the last published payload, read back for carry-forward.
+// Absent locally → carry-forward skipped.
+const previousUrl = process.env.CHARTS_BLOB_URL;
 
 // Short-lived process: must flush before exit so the monitor check-in + the
 // charts:published message actually reach Sentry. withMonitor returning is not
@@ -23,22 +32,43 @@ try {
     async () => {
       const result = await crawlAll({
         countries: COUNTRIES,
-        fetchRss: fetchAppleRss,
+        fetchRss: (cc) =>
+          withRetry(() => fetchAppleRss(cc), {
+            retries: 2,
+            backoffMs: 500,
+            sleep,
+            shouldRetry: (err) => err instanceof AppleRssError,
+          }),
         lookupTrack,
         throttle: createThrottle(),
         uploadCharts,
         triggerRevalidate,
+        fetchPrevious: previousUrl
+          ? () => fetchPublishedCharts(previousUrl)
+          : undefined,
       });
-      const countries = Object.values(result.chartFile.countries);
+
+      const summary = summarizeValidity(result.chartFile);
       Sentry.captureMessage("charts:published", {
         level: "info",
         extra: {
           run_id: process.env.GITHUB_RUN_ID,
-          country_count: countries.length,
-          valid_count: countries.filter((c) => c.valid).length,
+          country_count: summary.total,
+          valid_count: summary.validCount,
           blob_url: result.url,
         },
       });
+      if (summary.invalidCodes.length > 0) {
+        Sentry.captureMessage("charts:degraded", {
+          level: "warning",
+          extra: {
+            run_id: process.env.GITHUB_RUN_ID,
+            invalid_codes: summary.invalidCodes,
+            valid_count: summary.validCount,
+            country_count: summary.total,
+          },
+        });
+      }
     },
     {
       schedule: { type: "crontab", value: "17 4,11,16,22 * * *" },

--- a/scripts/crawl/published-charts.test.ts
+++ b/scripts/crawl/published-charts.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+
+import type { ChartFile } from "../../src/lib/chart-schema";
+
+import { fetchPublishedCharts } from "./published-charts";
+
+const URL = "https://blob/charts/v1/charts.json";
+
+function validChartFile(): ChartFile {
+  return {
+    lastUpdated: "2026-05-14T12:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "song",
+            artist: "artist",
+            previewUrl: "https://preview/1.m4a",
+            artworkUrl: "https://art/1/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/song",
+          },
+        ],
+      },
+    },
+  };
+}
+
+function fakeFetch(response: {
+  ok?: boolean;
+  status?: number;
+  body: string;
+}): typeof fetch {
+  return (async () =>
+    new Response(response.body, {
+      status: response.status ?? (response.ok === false ? 500 : 200),
+    })) as typeof fetch;
+}
+
+test("returns the parsed payload on a valid response", async () => {
+  const chartFile = validChartFile();
+
+  const result = await fetchPublishedCharts(
+    URL,
+    fakeFetch({ body: JSON.stringify(chartFile) }),
+  );
+
+  expect(result).toEqual(chartFile);
+});
+
+test("returns null on a non-OK response", async () => {
+  const result = await fetchPublishedCharts(
+    URL,
+    fakeFetch({ ok: false, status: 404, body: "Not Found" }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns null on invalid JSON", async () => {
+  const result = await fetchPublishedCharts(
+    URL,
+    fakeFetch({ body: "<html>nope</html>" }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns null on schema mismatch", async () => {
+  const result = await fetchPublishedCharts(
+    URL,
+    fakeFetch({ body: JSON.stringify({ lastUpdated: "nope", countries: 5 }) }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns null when fetch rejects", async () => {
+  const failingFetch: typeof fetch = (async () => {
+    throw new TypeError("network down");
+  }) as typeof fetch;
+
+  const result = await fetchPublishedCharts(URL, failingFetch);
+
+  expect(result).toBeNull();
+});

--- a/scripts/crawl/published-charts.ts
+++ b/scripts/crawl/published-charts.ts
@@ -1,0 +1,21 @@
+import { ChartFileSchema, type ChartFile } from "../../src/lib/chart-schema";
+
+/**
+ * Reads the last published payload so a failed crawl can carry forward
+ * last-good data. Degrades to null on any failure — carry-forward is
+ * best-effort and must never abort the crawl.
+ */
+export async function fetchPublishedCharts(
+  url: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<ChartFile | null> {
+  try {
+    const res = await fetchImpl(url);
+    if (!res.ok) return null;
+    const json: unknown = await res.json();
+    const parsed = ChartFileSchema.safeParse(json);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/crawl/retry.test.ts
+++ b/scripts/crawl/retry.test.ts
@@ -1,0 +1,80 @@
+import { expect, test, vi } from "vitest";
+
+import { withRetry, type RetryOptions } from "./retry";
+
+function makeOptions(overrides: Partial<RetryOptions> = {}): RetryOptions {
+  return {
+    retries: 2,
+    backoffMs: 10,
+    sleep: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+test("withRetry returns the first result without sleeping when fn succeeds", async () => {
+  const fn = vi.fn(async () => "ok");
+  const options = makeOptions();
+
+  const result = await withRetry(fn, options);
+
+  expect(result).toBe("ok");
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(options.sleep).not.toHaveBeenCalled();
+});
+
+test("withRetry retries a transient failure and returns the eventual success", async () => {
+  const fn = vi
+    .fn<() => Promise<string>>()
+    .mockRejectedValueOnce(new Error("transient"))
+    .mockResolvedValueOnce("ok");
+  const options = makeOptions();
+
+  const result = await withRetry(fn, options);
+
+  expect(result).toBe("ok");
+  expect(fn).toHaveBeenCalledTimes(2);
+  expect(options.sleep).toHaveBeenCalledTimes(1);
+});
+
+test("withRetry throws the last error after exhausting every attempt", async () => {
+  const lastError = new Error("attempt 3");
+  const fn = vi
+    .fn<() => Promise<string>>()
+    .mockRejectedValueOnce(new Error("attempt 1"))
+    .mockRejectedValueOnce(new Error("attempt 2"))
+    .mockRejectedValueOnce(lastError);
+  const options = makeOptions({ retries: 2 });
+
+  const promise = withRetry(fn, options);
+
+  await expect(promise).rejects.toBe(lastError);
+  expect(fn).toHaveBeenCalledTimes(3);
+  expect(options.sleep).toHaveBeenCalledTimes(2);
+});
+
+test("withRetry does not retry when shouldRetry rejects the error", async () => {
+  const permanent = new Error("permanent");
+  const fn = vi.fn<() => Promise<string>>().mockRejectedValue(permanent);
+  const options = makeOptions({ shouldRetry: () => false });
+
+  const promise = withRetry(fn, options);
+
+  await expect(promise).rejects.toBe(permanent);
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(options.sleep).not.toHaveBeenCalled();
+});
+
+test("withRetry backs off exponentially from backoffMs between attempts", async () => {
+  const fn = vi
+    .fn<() => Promise<string>>()
+    .mockRejectedValueOnce(new Error("1"))
+    .mockRejectedValueOnce(new Error("2"))
+    .mockResolvedValueOnce("ok");
+  const sleep = vi.fn(async () => {});
+  const options = makeOptions({ retries: 2, backoffMs: 100, sleep });
+
+  await withRetry(fn, options);
+
+  expect(sleep).toHaveBeenNthCalledWith(1, 100);
+  expect(sleep).toHaveBeenNthCalledWith(2, 200);
+});

--- a/scripts/crawl/retry.ts
+++ b/scripts/crawl/retry.ts
@@ -1,0 +1,27 @@
+export interface RetryOptions {
+  /** Extra attempts after the first (total tries = retries + 1). */
+  retries: number;
+  /** Base backoff, doubling each retry: backoffMs, 2×, 4×… */
+  backoffMs: number;
+  sleep: (ms: number) => Promise<void>;
+  /** Gates which errors retry; defaults to retrying all. */
+  shouldRetry?: (err: unknown) => boolean;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+): Promise<T> {
+  const shouldRetry = options.shouldRetry ?? (() => true);
+  let attempt = 0;
+
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= options.retries || !shouldRetry(err)) throw err;
+      await options.sleep(options.backoffMs * 2 ** attempt);
+      attempt += 1;
+    }
+  }
+}

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -1,6 +1,10 @@
 import { expect, test, vi } from "vitest";
 
-import { ChartFileSchema } from "../../src/lib/chart-schema";
+import {
+  ChartFileSchema,
+  type ChartFile,
+  type Country,
+} from "../../src/lib/chart-schema";
 import type { CountryEntry } from "../../src/lib/countries";
 
 import { AppleRssError, type AppleRssTrack } from "./apple-rss";
@@ -8,6 +12,7 @@ import { ItunesLookupError, type LookupResult } from "./itunes-lookup";
 import {
   crawlAll,
   crawlCountry,
+  summarizeValidity,
   type CrawlAllDeps,
   type CrawlCountryDeps,
 } from "./run";
@@ -188,6 +193,7 @@ function fakeRssFor(cc: string): AppleRssTrack[] {
 function makeCrawlAllDeps(input: {
   countries: readonly CountryEntry[];
   fetchRss?: (cc: string) => Promise<AppleRssTrack[]>;
+  fetchPrevious?: () => Promise<ChartFile | null>;
 }): CrawlAllDeps {
   return {
     countries: input.countries,
@@ -198,8 +204,56 @@ function makeCrawlAllDeps(input: {
     throttle: async (fn) => fn(),
     uploadCharts: vi.fn(async () => BLOB_URL),
     triggerRevalidate: vi.fn(async () => {}),
+    fetchPrevious: input.fetchPrevious,
     now: () => FROZEN_NOW,
   };
+}
+
+const KR: CountryEntry = {
+  code: "kr",
+  name: "South Korea",
+  region: "Asia",
+  lat: 37.5683,
+  lon: 126.9978,
+  isoNum: 410,
+};
+const NG: CountryEntry = {
+  code: "ng",
+  name: "Nigeria",
+  region: "Africa",
+  lat: 9.0853,
+  lon: 7.5314,
+  isoNum: 566,
+};
+
+function priorCountry(name: string, trackCount: number): Country {
+  return {
+    name,
+    valid: true,
+    tracks: Array.from({ length: trackCount }, (_, i) => ({
+      rank: i + 1,
+      name: `prior song ${i + 1}`,
+      artist: `prior artist ${i + 1}`,
+      previewUrl: `https://prior/preview/${i + 1}.m4a`,
+      artworkUrl: `https://prior/art/${i + 1}/600x600bb.jpg`,
+      appleUrl: `https://music.apple.com/prior/${i + 1}`,
+      spotifySearchUrl: `https://open.spotify.com/search/prior${i + 1}`,
+    })),
+  };
+}
+
+function previousChartFile(countries: ChartFile["countries"]): ChartFile {
+  return { lastUpdated: "2026-05-14T12:00:00.000Z", countries };
+}
+
+function failRssFor(
+  failingCode: string,
+): (cc: string) => Promise<AppleRssTrack[]> {
+  return vi.fn(async (cc: string) => {
+    if (cc === failingCode)
+      throw new AppleRssError(cc, "500 Internal Server Error");
+    return fakeRssFor(cc);
+  });
 }
 
 test("crawlAll assembles a valid ChartFile, uploads once, and revalidates once", async () => {
@@ -277,4 +331,77 @@ test("crawlAll publishes whatever succeeded when one country's RSS fails", async
   expect(result.chartFile.countries[failingCode].tracks).toEqual([]);
   expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
   expect(deps.triggerRevalidate).toHaveBeenCalledTimes(1);
+});
+
+test("crawlAll carries forward the previous entry when a country fails but prior data exists", async () => {
+  const priorNg = priorCountry(NG.name, 3);
+  const fetchPrevious = vi.fn(async () => previousChartFile({ ng: priorNg }));
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    fetchRss: failRssFor(NG.code),
+    fetchPrevious,
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng).toEqual(priorNg);
+  expect(result.chartFile.countries.kr.valid).toBe(true);
+});
+
+test("crawlAll keeps a failed country invalid when fetchPrevious returns null", async () => {
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    fetchRss: failRssFor(NG.code),
+    fetchPrevious: vi.fn(async () => null),
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng.valid).toBe(false);
+  expect(result.chartFile.countries.ng.tracks).toEqual([]);
+});
+
+test("crawlAll keeps a failed country invalid when the previous payload lacks it", async () => {
+  const fetchPrevious = vi.fn(async () =>
+    previousChartFile({ kr: priorCountry(KR.name, 2) }),
+  );
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    fetchRss: failRssFor(NG.code),
+    fetchPrevious,
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng.valid).toBe(false);
+  expect(result.chartFile.countries.ng.tracks).toEqual([]);
+});
+
+test("crawlAll does not carry forward a previous entry that was itself empty", async () => {
+  const emptyPriorNg: Country = { name: NG.name, valid: false, tracks: [] };
+  const fetchPrevious = vi.fn(async () =>
+    previousChartFile({ ng: emptyPriorNg }),
+  );
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    fetchRss: failRssFor(NG.code),
+    fetchPrevious,
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng.valid).toBe(false);
+  expect(result.chartFile.countries.ng.tracks).toEqual([]);
+});
+
+test("summarizeValidity reports total, valid count, and the invalid codes", async () => {
+  const chartFile = previousChartFile({
+    kr: priorCountry("South Korea", 2),
+    ng: { name: "Nigeria", valid: false, tracks: [] },
+    us: priorCountry("United States", 1),
+  });
+
+  const summary = summarizeValidity(chartFile);
+
+  expect(summary).toEqual({ total: 3, validCount: 2, invalidCodes: ["ng"] });
 });

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -25,12 +25,31 @@ export interface CrawlAllDeps {
   throttle: Throttle;
   uploadCharts: (chartFile: ChartFile) => Promise<string>;
   triggerRevalidate: () => Promise<void>;
+  // Source for carrying forward a country that fails this run. Must resolve
+  // null (never reject) when unavailable, which skips carry-forward.
+  fetchPrevious?: () => Promise<ChartFile | null>;
   now?: () => Date;
 }
 
 export interface CrawlAllResult {
   url: string;
   chartFile: ChartFile;
+}
+
+export interface ValiditySummary {
+  total: number;
+  validCount: number;
+  invalidCodes: string[];
+}
+
+export function summarizeValidity(chartFile: ChartFile): ValiditySummary {
+  const entries = Object.entries(chartFile.countries);
+  const invalidCodes = entries.filter(([, c]) => !c.valid).map(([cc]) => cc);
+  return {
+    total: entries.length,
+    validCount: entries.length - invalidCodes.length,
+    invalidCodes,
+  };
 }
 
 function spotifySearchUrl(name: string, artist: string): string {
@@ -93,6 +112,8 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
     `[crawl] starting all-countries crawl (${countries.length} countries)...`,
   );
 
+  const previous = deps.fetchPrevious ? await deps.fetchPrevious() : null;
+
   const countriesMap: ChartFile["countries"] = {};
   for (const entry of countries) {
     const { cc, country } = await crawlCountry({
@@ -102,6 +123,17 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
       lookupTrack,
       throttle,
     });
+
+    // Carry forward only genuine prior data, never an earlier empty entry.
+    const prior = previous?.countries[cc];
+    if (!country.valid && prior?.valid && prior.tracks.length > 0) {
+      countriesMap[cc] = prior;
+      console.log(
+        `[crawl ${cc}] crawl failed — carried forward last-good (${prior.tracks.length} tracks)`,
+      );
+      continue;
+    }
+
     countriesMap[cc] = country;
     console.log(
       `[crawl ${cc}] ${country.tracks.length} tracks (valid=${country.valid})`,


### PR DESCRIPTION
## What

Make the daily chart crawl resilient to transient Apple RSS failures, so a single Apple 500 (or a momentary incomplete feed) no longer ships a country empty until the next clean crawl.

## Why

Auditing the live payload found Singapore empty (`valid:false`, 0 tracks); the next crawl emptied the UK instead — log: `[crawl gb] RSS failed: Apple RSS returned 500 Internal Server Error`. Both feeds were healthy minutes later. The crawler rebuilds the payload from scratch each run with no retry and no carry-forward, so roughly one country is empty in production at any time, the victim rotating each crawl — breaking the 40-country promise.

## Changes

- **Retry** — new `withRetry` retries transient RSS errors with exponential backoff (gated to `AppleRssError`).
- **Carry-forward** — `crawlAll` reuses the last published valid entry when a country still fails after retries; a fresh country with no prior data and a total failure stays `valid:false` without crashing.
- **Degraded warning** — emits a `charts:degraded` Sentry warning when any country is invalid (previously shipped silently under a green run).
- **`fetchPublishedCharts`** — reads the prior payload, degrading to `null` on any failure so carry-forward never aborts the crawl.
- Wire `CHARTS_BLOB_URL` into the cron workflow env (secret already configured).

## Verify

- New unit tests: retry 5, published-charts 5, crawlAll/summarizeValidity 9. Full suite 150/150.
- Local CI matrix green: format, lint, typecheck, test, build.
- Post-merge: `workflow_dispatch` the cron to confirm carry-forward + the degraded path live.

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart data carry-forward when current fetch fails for specific regions
  * Enhanced error reporting with validity summaries and degraded state warnings

* **Bug Fixes**
  * Automatic retry mechanism with exponential backoff for transient failures

* **Tests**
  * Added test coverage for retry logic and data recovery scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->