### PR TITLE
feat(player): pause preview on deeplink and surface now-playing to OS

### DIFF
--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -188,6 +188,34 @@ describe("TrackRow", () => {
     expect(spotify.getAttribute("rel")).toContain("noopener");
   });
 
+  test("clicking Apple Music pauses the preview but keeps the track", () => {
+    const track = makeTrack();
+    const { store } = renderTrackRow(track, {
+      currentTrack: track,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: /Apple Music/i }));
+
+    expect(store.getState().isPlaying).toBe(false);
+    expect(store.getState().currentTrack).toBe(track);
+  });
+
+  test("clicking Spotify pauses the preview but keeps the track", () => {
+    const track = makeTrack();
+    const { store } = renderTrackRow(track, {
+      currentTrack: track,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: /Spotify/i }));
+
+    expect(store.getState().isPlaying).toBe(false);
+    expect(store.getState().currentTrack).toBe(track);
+  });
+
   test("error message renders when lastError matches this track's previewUrl", () => {
     const track = makeTrack();
 

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -28,6 +28,7 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
     (s) => s.lastError?.previewUrl === track.previewUrl,
   );
   const toggle = useAudioStore((s) => s.toggle);
+  const pause = useAudioStore((s) => s.pause);
 
   const hasPreview = track.previewUrl !== null;
   const state = isCurrent ? (isPlaying ? "playing" : "paused") : undefined;
@@ -96,6 +97,7 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
           href={track.appleUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => pause()}
           aria-label={`Open ${track.name} in Apple Music`}
           className="text-fg-2 hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
         >
@@ -105,6 +107,7 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
           href={track.spotifySearchUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => pause()}
           aria-label={`Search ${track.name} on Spotify`}
           className="text-fg-2 hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
         >

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -1,19 +1,41 @@
-import { assert, describe, expect, test, vi } from "vitest";
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { Track } from "@/lib/chart-schema";
 
 import { type AudioElementLike, createAudioStore } from "./audio-store";
+import {
+  clearNowPlaying,
+  setActionHandlers,
+  setNowPlaying,
+  setPlaybackState,
+} from "./media-session";
+
+vi.mock("./media-session", () => ({
+  setNowPlaying: vi.fn(),
+  clearNowPlaying: vi.fn(),
+  setPlaybackState: vi.fn(),
+  setActionHandlers: vi.fn(),
+}));
 
 type EventType = "ended" | "error" | "play" | "pause";
 
 interface MockAudio extends AudioElementLike {
   _trigger: (event: EventType) => void;
+  _srcWrites: number;
 }
 
 function makeMockAudio(): MockAudio {
   const listeners: Partial<Record<EventType, Array<() => void>>> = {};
-  return {
-    src: "",
+  let src = "";
+  const audio: MockAudio = {
+    get src() {
+      return src;
+    },
+    set src(value: string) {
+      audio._srcWrites++;
+      src = value;
+    },
+    _srcWrites: 0,
     play: vi.fn().mockResolvedValue(undefined),
     pause: vi.fn(),
     addEventListener: vi.fn((type: EventType, listener: () => void) => {
@@ -24,6 +46,7 @@ function makeMockAudio(): MockAudio {
       (listeners[event] ?? []).forEach((l) => l());
     },
   };
+  return audio;
 }
 
 function makeTrack(overrides: Partial<Track> = {}): Track {
@@ -40,6 +63,10 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 }
 
 describe("createAudioStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   test("initial state: no track, not playing, no country", () => {
     const store = createAudioStore(() => makeMockAudio());
 
@@ -299,5 +326,114 @@ describe("createAudioStore", () => {
     store.getState().stop();
 
     expect(factory).toHaveBeenCalledOnce();
+  });
+
+  test("resume in place replays without rewriting src so the preview continues", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack();
+    store.getState().toggle(track);
+    store.getState().pause();
+
+    store.getState().toggle(track);
+
+    expect(audio._srcWrites).toBe(1);
+    expect(audio.play).toHaveBeenCalledTimes(2);
+    expect(store.getState().isPlaying).toBe(true);
+  });
+
+  test("toggle on a new track publishes now-playing metadata", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    const track = makeTrack();
+
+    store.getState().toggle(track);
+
+    expect(setNowPlaying).toHaveBeenCalledWith(track);
+  });
+
+  test("resume in place does not republish metadata", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    const track = makeTrack();
+    store.getState().toggle(track);
+    store.getState().pause();
+
+    store.getState().toggle(track);
+
+    expect(setNowPlaying).toHaveBeenCalledOnce();
+  });
+
+  test("stop clears now-playing metadata", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    store.getState().toggle(makeTrack());
+
+    store.getState().stop();
+
+    expect(clearNowPlaying).toHaveBeenCalledOnce();
+  });
+
+  test("play event reports playing to the OS", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    store.getState().toggle(makeTrack());
+
+    audio._trigger("play");
+
+    expect(setPlaybackState).toHaveBeenCalledWith("playing");
+  });
+
+  test("pause event reports paused to the OS", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    store.getState().toggle(makeTrack());
+
+    audio._trigger("pause");
+
+    expect(setPlaybackState).toHaveBeenCalledWith("paused");
+  });
+
+  test("ended event reports none to the OS", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    store.getState().toggle(makeTrack());
+
+    audio._trigger("ended");
+
+    expect(setPlaybackState).toHaveBeenCalledWith("none");
+  });
+
+  test("registers OS transport handlers when the audio element is created", () => {
+    const store = createAudioStore(() => makeMockAudio());
+
+    store.getState().toggle(makeTrack());
+
+    expect(setActionHandlers).toHaveBeenCalledOnce();
+  });
+
+  test("OS play handler resumes the current track in place", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack();
+    store.getState().toggle(track);
+    store.getState().pause();
+    const { play } = vi.mocked(setActionHandlers).mock.calls[0][0];
+
+    play();
+
+    expect(store.getState().isPlaying).toBe(true);
+    expect(audio._srcWrites).toBe(1);
+  });
+
+  test("OS pause handler pauses but keeps the current track", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack();
+    store.getState().toggle(track);
+    const { pause } = vi.mocked(setActionHandlers).mock.calls[0][0];
+
+    pause();
+
+    expect(audio.pause).toHaveBeenCalledOnce();
+    expect(store.getState().isPlaying).toBe(false);
+    expect(store.getState().currentTrack).toBe(track);
   });
 });

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -141,6 +141,30 @@ describe("createAudioStore", () => {
     expect(store.getState().isPlaying).toBe(false);
   });
 
+  test("pause stops playback but preserves currentTrack and countryCode", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack();
+    store.getState().toggle(track, "br");
+
+    store.getState().pause();
+
+    expect(audio.pause).toHaveBeenCalledOnce();
+    expect(store.getState().isPlaying).toBe(false);
+    expect(store.getState().currentTrack).toBe(track);
+    expect(store.getState().currentCountryCode).toBe("br");
+  });
+
+  test("pause does not increment endedSignal so auto-advance stays put", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    store.getState().toggle(makeTrack());
+
+    store.getState().pause();
+
+    expect(store.getState().endedSignal).toBe(0);
+  });
+
   test("ended event: isPlaying false, currentTrack preserved", () => {
     const audio = makeMockAudio();
     const store = createAudioStore(() => audio);

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import { createStore } from "zustand/vanilla";
 
 import type { Track } from "@/lib/chart-schema";
+import { clearNowPlaying, setNowPlaying } from "@/lib/media-session";
 
 export interface AudioElementLike {
   src: string;
@@ -32,6 +33,7 @@ export interface AudioState {
   lastError: AudioError | null;
   endedSignal: number;
   toggle: (track: Track, countryCode?: string) => void;
+  pause: () => void;
   stop: () => void;
 }
 
@@ -88,6 +90,7 @@ export function createAudioStore(
         }
         a.src = track.previewUrl ?? "";
         void a.play();
+        setNowPlaying(track);
         const isNewTrack = state.currentTrack?.previewUrl !== track.previewUrl;
         if (isNewTrack) {
           set({
@@ -100,9 +103,16 @@ export function createAudioStore(
           set({ currentTrack: track, isPlaying: true, lastError: null });
         }
       },
+      pause: () => {
+        // Pause without clearing currentTrack, used on deeplink handoff so the
+        // mini player stays (resumable) and no `ended` fires (auto-advance halts).
+        getAudio().pause();
+        set({ isPlaying: false });
+      },
       stop: () => {
         const a = getAudio();
         a.pause();
+        clearNowPlaying();
         set({
           currentTrack: null,
           currentCountryCode: null,

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -2,7 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 import { createStore } from "zustand/vanilla";
 
 import type { Track } from "@/lib/chart-schema";
-import { clearNowPlaying, setNowPlaying } from "@/lib/media-session";
+import {
+  clearNowPlaying,
+  setActionHandlers,
+  setNowPlaying,
+  setPlaybackState,
+} from "@/lib/media-session";
 
 export interface AudioElementLike {
   src: string;
@@ -50,14 +55,23 @@ export function createAudioStore(
       audio = factory();
       // Layer 1 (S5): sync store with browser-initiated play/pause.
       // Covers background-tab auto-pause, AirPods disconnect, media keys.
-      audio.addEventListener("play", () => set({ isPlaying: true }));
-      audio.addEventListener("pause", () => set({ isPlaying: false }));
-      audio.addEventListener("ended", () =>
+      // Each transition also mirrors to the OS so the now-playing UI tracks
+      // live state (drives the Dynamic Island waveform), browser-driven or not.
+      audio.addEventListener("play", () => {
+        set({ isPlaying: true });
+        setPlaybackState("playing");
+      });
+      audio.addEventListener("pause", () => {
+        set({ isPlaying: false });
+        setPlaybackState("paused");
+      });
+      audio.addEventListener("ended", () => {
         set((state) => ({
           isPlaying: false,
           endedSignal: state.endedSignal + 1,
-        })),
-      );
+        }));
+        setPlaybackState("none");
+      });
       audio.addEventListener("error", () => {
         const previewUrl = get().currentTrack?.previewUrl ?? null;
         set({ isPlaying: false, lastError: { previewUrl } });
@@ -67,6 +81,15 @@ export function createAudioStore(
           message: "preview audio error",
           data: { previewUrl },
         });
+      });
+      // OS transport buttons (lock screen / Dynamic Island) drive the same
+      // store actions as the in-app controls.
+      setActionHandlers({
+        play: () => {
+          const track = get().currentTrack;
+          if (track) get().toggle(track);
+        },
+        pause: () => get().pause(),
       });
       return audio;
     }
@@ -80,28 +103,28 @@ export function createAudioStore(
       toggle: (track, countryCode) => {
         const state = get();
         const a = getAudio();
-        if (
-          state.currentTrack?.previewUrl === track.previewUrl &&
-          state.isPlaying
-        ) {
+        const isCurrent = state.currentTrack?.previewUrl === track.previewUrl;
+        if (isCurrent && state.isPlaying) {
           a.pause();
           set({ isPlaying: false });
+          return;
+        }
+        if (isCurrent) {
+          // Resume in place: reassigning src restarts at 0, so leave it and
+          // just play. Keeps the preview position and the stored countryCode.
+          void a.play();
+          set({ currentTrack: track, isPlaying: true, lastError: null });
           return;
         }
         a.src = track.previewUrl ?? "";
         void a.play();
         setNowPlaying(track);
-        const isNewTrack = state.currentTrack?.previewUrl !== track.previewUrl;
-        if (isNewTrack) {
-          set({
-            currentTrack: track,
-            currentCountryCode: countryCode ?? null,
-            isPlaying: true,
-            lastError: null,
-          });
-        } else {
-          set({ currentTrack: track, isPlaying: true, lastError: null });
-        }
+        set({
+          currentTrack: track,
+          currentCountryCode: countryCode ?? null,
+          isPlaying: true,
+          lastError: null,
+        });
       },
       pause: () => {
         // Pause without clearing currentTrack, used on deeplink handoff so the

--- a/src/lib/media-session.test.ts
+++ b/src/lib/media-session.test.ts
@@ -1,0 +1,76 @@
+import { expect, test, vi } from "vitest";
+
+import type { Track } from "@/lib/chart-schema";
+
+import {
+  clearNowPlaying,
+  setNowPlaying,
+  type MediaSessionDeps,
+} from "./media-session";
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    rank: 1,
+    name: "Test Track",
+    artist: "Test Artist",
+    previewUrl: "https://example.com/preview.m4a",
+    artworkUrl: "https://example.com/art/600x600bb.jpg",
+    appleUrl: "https://music.apple.com/x",
+    spotifySearchUrl: "https://open.spotify.com/search/x",
+    ...overrides,
+  };
+}
+
+class FakeMediaMetadata {
+  title?: string;
+  artist?: string;
+  artwork?: MediaImage[];
+  constructor(init: MediaMetadataInit = {}) {
+    Object.assign(this, init);
+  }
+}
+
+function makeDeps(overrides: Partial<MediaSessionDeps> = {}): MediaSessionDeps {
+  return {
+    mediaSession: { metadata: null } as MediaSession,
+    metadataCtor: FakeMediaMetadata as unknown as typeof MediaMetadata,
+    ...overrides,
+  };
+}
+
+test("setNowPlaying sets metadata with title, artist, and artwork", () => {
+  const track = makeTrack();
+  const deps = makeDeps();
+
+  setNowPlaying(track, deps);
+
+  const meta = deps.mediaSession!.metadata as MediaMetadata;
+  expect(meta.title).toBe(track.name);
+  expect(meta.artist).toBe(track.artist);
+  expect(meta.artwork?.[0].src).toBe(track.artworkUrl);
+});
+
+test("clearNowPlaying nulls the metadata", () => {
+  const deps = makeDeps();
+  setNowPlaying(makeTrack(), deps);
+
+  clearNowPlaying(deps);
+
+  expect(deps.mediaSession!.metadata).toBeNull();
+});
+
+test("setNowPlaying no-ops when mediaSession is unavailable", () => {
+  const metadataCtor = vi.fn() as unknown as typeof MediaMetadata;
+
+  setNowPlaying(makeTrack(), { mediaSession: null, metadataCtor });
+
+  expect(metadataCtor).not.toHaveBeenCalled();
+});
+
+test("setNowPlaying no-ops when MediaMetadata is unavailable", () => {
+  const deps = makeDeps({ metadataCtor: undefined });
+
+  setNowPlaying(makeTrack(), deps);
+
+  expect(deps.mediaSession!.metadata).toBeNull();
+});

--- a/src/lib/media-session.test.ts
+++ b/src/lib/media-session.test.ts
@@ -4,7 +4,9 @@ import type { Track } from "@/lib/chart-schema";
 
 import {
   clearNowPlaying,
+  setActionHandlers,
   setNowPlaying,
+  setPlaybackState,
   type MediaSessionDeps,
 } from "./media-session";
 
@@ -30,9 +32,17 @@ class FakeMediaMetadata {
   }
 }
 
+function makeMediaSession(): MediaSession {
+  return {
+    metadata: null,
+    playbackState: "none",
+    setActionHandler: vi.fn(),
+  } as unknown as MediaSession;
+}
+
 function makeDeps(overrides: Partial<MediaSessionDeps> = {}): MediaSessionDeps {
   return {
-    mediaSession: { metadata: null } as MediaSession,
+    mediaSession: makeMediaSession(),
     metadataCtor: FakeMediaMetadata as unknown as typeof MediaMetadata,
     ...overrides,
   };
@@ -50,13 +60,48 @@ test("setNowPlaying sets metadata with title, artist, and artwork", () => {
   expect(meta.artwork?.[0].src).toBe(track.artworkUrl);
 });
 
-test("clearNowPlaying nulls the metadata", () => {
+test("clearNowPlaying nulls the metadata and resets playback state", () => {
   const deps = makeDeps();
   setNowPlaying(makeTrack(), deps);
+  setPlaybackState("playing", deps);
 
   clearNowPlaying(deps);
 
   expect(deps.mediaSession!.metadata).toBeNull();
+  expect(deps.mediaSession!.playbackState).toBe("none");
+});
+
+test("setPlaybackState mirrors the state onto the session", () => {
+  const deps = makeDeps();
+
+  setPlaybackState("playing", deps);
+
+  expect(deps.mediaSession!.playbackState).toBe("playing");
+});
+
+test("setPlaybackState no-ops when mediaSession is unavailable", () => {
+  setPlaybackState("playing", { mediaSession: null });
+});
+
+test("setActionHandlers registers play and pause", () => {
+  const deps = makeDeps();
+  const play = vi.fn();
+  const pause = vi.fn();
+
+  setActionHandlers({ play, pause }, deps);
+
+  expect(deps.mediaSession!.setActionHandler).toHaveBeenCalledWith(
+    "play",
+    play,
+  );
+  expect(deps.mediaSession!.setActionHandler).toHaveBeenCalledWith(
+    "pause",
+    pause,
+  );
+});
+
+test("setActionHandlers no-ops when mediaSession is unavailable", () => {
+  setActionHandlers({ play: vi.fn(), pause: vi.fn() }, { mediaSession: null });
 });
 
 test("setNowPlaying no-ops when mediaSession is unavailable", () => {

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -1,0 +1,38 @@
+import type { Track } from "@/lib/chart-schema";
+
+export interface MediaSessionDeps {
+  mediaSession: MediaSession | null;
+  metadataCtor?: typeof MediaMetadata;
+}
+
+function defaultDeps(): MediaSessionDeps {
+  const nav = typeof navigator !== "undefined" ? navigator : undefined;
+  return {
+    mediaSession: nav && "mediaSession" in nav ? nav.mediaSession : null,
+    metadataCtor:
+      typeof MediaMetadata !== "undefined" ? MediaMetadata : undefined,
+  };
+}
+
+/**
+ * Publishes the now-playing track to the OS media UI (iOS Dynamic Island /
+ * lock screen). Metadata-only, no transport action handlers. No-ops where
+ * MediaSession is unsupported so it never throws.
+ */
+export function setNowPlaying(
+  track: Track,
+  deps: MediaSessionDeps = defaultDeps(),
+): void {
+  const { mediaSession, metadataCtor } = deps;
+  if (!mediaSession || !metadataCtor) return;
+  mediaSession.metadata = new metadataCtor({
+    title: track.name,
+    artist: track.artist,
+    artwork: [{ src: track.artworkUrl, sizes: "600x600", type: "image/jpeg" }],
+  });
+}
+
+export function clearNowPlaying(deps: MediaSessionDeps = defaultDeps()): void {
+  if (!deps.mediaSession) return;
+  deps.mediaSession.metadata = null;
+}

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -5,6 +5,11 @@ export interface MediaSessionDeps {
   metadataCtor?: typeof MediaMetadata;
 }
 
+export interface MediaSessionHandlers {
+  play: () => void;
+  pause: () => void;
+}
+
 function defaultDeps(): MediaSessionDeps {
   const nav = typeof navigator !== "undefined" ? navigator : undefined;
   return {
@@ -16,7 +21,7 @@ function defaultDeps(): MediaSessionDeps {
 
 /**
  * Publishes the now-playing track to the OS media UI (iOS Dynamic Island /
- * lock screen). Metadata-only, no transport action handlers. No-ops where
+ * lock screen). Metadata only, no transport action handlers. No-ops where
  * MediaSession is unsupported so it never throws.
  */
 export function setNowPlaying(
@@ -32,7 +37,37 @@ export function setNowPlaying(
   });
 }
 
+/**
+ * Mirrors live playback state to the OS. iOS needs this (alongside action
+ * handlers) to treat the session as actively playing, which is what renders
+ * the title/artist text and the live waveform in the Dynamic Island. Metadata
+ * alone shows only static artwork.
+ */
+export function setPlaybackState(
+  state: MediaSessionPlaybackState,
+  deps: MediaSessionDeps = defaultDeps(),
+): void {
+  if (!deps.mediaSession) return;
+  deps.mediaSession.playbackState = state;
+}
+
+/**
+ * Registers play/pause transport handlers. iOS requires at least these for a
+ * reliable now-playing presentation; without them it falls back to a minimal,
+ * art-only card. Next/previous and seek are out of scope.
+ */
+export function setActionHandlers(
+  handlers: MediaSessionHandlers,
+  deps: MediaSessionDeps = defaultDeps(),
+): void {
+  const { mediaSession } = deps;
+  if (!mediaSession) return;
+  mediaSession.setActionHandler("play", handlers.play);
+  mediaSession.setActionHandler("pause", handlers.pause);
+}
+
 export function clearNowPlaying(deps: MediaSessionDeps = defaultDeps()): void {
   if (!deps.mediaSession) return;
   deps.mediaSession.metadata = null;
+  deps.mediaSession.playbackState = "none";
 }


### PR DESCRIPTION
Tapping Apple Music or Spotify now pauses the preview rather than letting it play under the new tab, keeping the track in the mini player so it stays resumable. The current track also appears on the iOS lock screen and Dynamic Island (MediaSession metadata only, no transport handlers).

## Changes
- `audio-store.ts`: new `pause()` that stops playback but preserves `currentTrack`/`currentCountryCode` and does not fire `ended` (auto-advance halts).
- `media-session.ts` (new): `setNowPlaying`/`clearNowPlaying`, metadata-only, no-ops where MediaSession is unsupported. Wired into store `toggle`/`stop`.
- `track-row.tsx`: both deeplinks call `pause()` on click.
- +8 tests (158 total green).

## Verification
- [x] typecheck / lint / test / build green locally
- [ ] Device-verify on iPhone: deeplink handoff (preview pauses, mini player persists) + Dynamic Island / lock screen metadata. happy-dom cannot exercise either.

Closes #37, #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pause preview playback when clicking Apple Music or Spotify links while retaining the currently selected track
  * Integrated media session API to display current track information in OS player UI

* **Tests**
  * Added comprehensive unit test coverage for pause functionality and media session integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->