### PR TITLE
docs: add CONTEXT.md domain glossary with Roadmap terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+# Context
+
+Domain glossary for Sounds Abroad. Each term has one project-specific meaning; the _Avoid_ line lists words that blur it. Use these terms as defined when naming concepts in issues, plans, tests, and reviews.
+
+## Roadmap
+
+**Version (V1, V2, V2.1, …)**:
+A sequential release scope: what's in scope when the project declares itself done for that release. V1 = the first public launch of the music-discovery app, the scope captured in the V1 handoff doc and delivered across Phases 1 to 6 (there is no single "V1 PRD" issue; the per-Phase PRDs roll up to it). V2 = the post-launch backlog of candidate refinements (full-state sheet body-drag, EQ bars, MediaSession transport controls, lakes overlay). Point releases (V2.1, …) carry follow-on fixes. Architecturally divergent paths (toolchain in ADR 0001, public-repo + cron baseline in ADR 0002) are not a Version by themselves; they are decided in ADRs and land in whichever Version adopts them.
+_Avoid_: generation; milestone (a GitHub milestone tracks a Phase, not a Version); reserving V2 as a catch-all "someday" bucket.
+
+**Phase (`phase-1`, `phase-2`, …)**:
+A themed band of work on the path to a Version, tracked as a GitHub milestone and closed with an annotated git tag `phase-N`. A Phase bundles the several PRs that share one theme (e.g. `phase-4` = the 3D globe; `phase-5` = globe to sheet integration + V1 launch polish). It is not a single PR and not a time window. Multiple Phases compose into a Version (Phases 1 to 6 compose V1).
+_Avoid_: stage, iteration, sprint; equating a Phase with a single PR.


### PR DESCRIPTION
Adds `CONTEXT.md`, the project's domain glossary (the lazily-created file referenced in `docs/agents/domain.md`).

Defines the two Roadmap terms that kept blurring:
- **Version** (V1, V2, …) — a release scope. V1 = the first public launch across Phases 1 to 6; there is no single "V1 PRD" issue (per-Phase PRDs roll up to the V1 handoff doc).
- **Phase** (`phase-1`, …) — a themed band of work tracked as a GitHub milestone, closed with a `phase-N` tag.

Each term carries an `_Avoid_` line for synonyms that blur it. The load-bearing rule: **a GitHub milestone tracks a Phase, not a Version** — which is why the V2 milestone was just retired in favour of a `v2` label on #53/#38.

Docs-only; no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added domain glossary for Sounds Abroad project with terminology guidelines and reference list.
  * Introduced roadmap section detailing version semantics (release types and variant paths) and phase semantics (milestone tracking and release tagging).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->