### PR TITLE
fix(crawl): stop false cron-outage alerts from GitHub dispatch delay

### DIFF
--- a/docs/adr/0002-public-repo-for-actions-budget.md
+++ b/docs/adr/0002-public-repo-for-actions-budget.md
@@ -36,6 +36,7 @@ Make the repository **public** at `github.com/taewanu/sounds-abroad`.
 
 - All future commits and code are public from day one — no private experimentation in this repo.
 - Any leaked secret has a wider blast radius (mitigated by gitignored `.env*` + GitHub Secrets, but still a real risk).
+- GitHub's scheduled-dispatch delay is unbounded (observed p100 ~120min over ~10 days), so timing-based monitor alerting is noisy. Mitigated by a wide `charts-crawl` checkinMargin (150min, kept under the 300min tightest slot gap). The longer-term fix is to alert on the data-quality signal (`charts:degraded`) rather than slot timing.
 
 **Reversal cost**
 

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -73,9 +73,12 @@ try {
     {
       schedule: { type: "crontab", value: "17 4,11,16,22 * * *" },
       timezone: "UTC",
-      // Observed GHA dispatch delays up to 60min post-:17 (n=2, #26).
-      // 90 = observed ceiling + 30min buffer.
-      checkinMargin: 90,
+      // GHA scheduled-dispatch delay is unbounded; observed p100 ~120min
+      // over ~10 days. 150 = observed max + buffer, kept under the 300min
+      // tightest slot gap so per-slot check-in windows stay disjoint.
+      checkinMargin: 150,
+      // Clocks from the in-progress check-in, not the slot, so dispatch
+      // delay never eats into it. Sized to the ~50min crawl runtime.
       maxRuntime: 90,
     },
   );


### PR DESCRIPTION
## Problem

The `charts-crawl` Sentry monitor was flagging successful crawl runs as missed check-ins. Over the last ~10 days, GitHub's scheduled-workflow dispatch landed up to ~120min after the `:17` slot, past the 90min `checkinMargin`, so Sentry marked the slot missed before the late (but successful) check-in arrived. Measured rate: ~23% of slots, last occurrence ~1h before this PR.

The crawl itself never failed; this was an observability false positive that would pollute Sentry's signal at launch.

## Change

- `checkinMargin` 90 → 150 in `scripts/crawl/cron.ts`. 150 clears the observed p100 (~120min) with buffer and stays under the 300min tightest inter-slot gap, so per-slot check-in windows stay disjoint. `maxRuntime` left at 90 (it clocks from the in-progress check-in, so dispatch delay never eats into it).
- ADR-0002: record that GHA dispatch delay is unbounded and note the longer-term fix (alert on the `charts:degraded` data-quality signal rather than slot timing).

## Notes

- The margin is upserted to Sentry on each crawl run, so 150 takes effect after merge once one `cron-crawl` run executes (or a manual dispatch).
- Margin tuning mitigates but cannot eliminate the class: GHA dispatch delay has no upper bound. The data-quality signal is the real long-term alert.

Refs #51 (Phase 5 AC: cron monitor reports Okay).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of background crawling operations by adjusting timing parameters to better accommodate system scheduling variations and reduce false alerting in monitoring systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->