### PR TITLE
feat(crawl): retry transient per-track preview lookups

### DIFF
--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -5,6 +5,7 @@ import { COUNTRIES } from "../../src/lib/countries";
 
 import { AppleRssError, fetchAppleRss } from "./apple-rss";
 import { lookupTrack } from "./itunes-lookup";
+import { withLookupRetry } from "./lookup-retry";
 import { fetchPublishedCharts } from "./published-charts";
 import { withRetry } from "./retry";
 import { triggerRevalidate } from "./revalidate-trigger";
@@ -39,7 +40,7 @@ try {
             sleep,
             shouldRetry: (err) => err instanceof AppleRssError,
           }),
-        lookupTrack,
+        lookupTrack: withLookupRetry(lookupTrack, { sleep }),
         throttle: createThrottle(),
         uploadCharts,
         triggerRevalidate,

--- a/scripts/crawl/lookup-retry.test.ts
+++ b/scripts/crawl/lookup-retry.test.ts
@@ -1,0 +1,77 @@
+import { expect, test, vi } from "vitest";
+
+import {
+  ItunesLookupError,
+  type ItunesLookupErrorKind,
+  type LookupResult,
+} from "./itunes-lookup";
+import { withLookupRetry } from "./lookup-retry";
+
+function lookupError(kind: ItunesLookupErrorKind): ItunesLookupError {
+  return new ItunesLookupError("1", "kr", kind, kind);
+}
+
+function resolved(id: string): LookupResult {
+  return { id, previewUrl: `https://preview/${id}.m4a` };
+}
+
+test("withLookupRetry resolves the first success without sleeping", async () => {
+  const lookup = vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
+    async (id) => resolved(id),
+  );
+  const sleep = vi.fn(async () => {});
+
+  const result = await withLookupRetry(lookup, { sleep })("1", "kr");
+
+  expect(result).toEqual(resolved("1"));
+  expect(lookup).toHaveBeenCalledTimes(1);
+  expect(sleep).not.toHaveBeenCalled();
+});
+
+test.each(["network", "http"] as const)(
+  "withLookupRetry retries the transient %s failure and returns the eventual success",
+  async (kind) => {
+    const lookup = vi
+      .fn<(id: string, cc: string) => Promise<LookupResult>>()
+      .mockRejectedValueOnce(lookupError(kind))
+      .mockResolvedValueOnce(resolved("1"));
+    const sleep = vi.fn(async () => {});
+
+    const result = await withLookupRetry(lookup, { sleep })("1", "kr");
+
+    expect(result).toEqual(resolved("1"));
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  },
+);
+
+test.each(["miss", "shape", "json"] as const)(
+  "withLookupRetry does not retry the non-transient %s failure",
+  async (kind) => {
+    const error = lookupError(kind);
+    const lookup = vi
+      .fn<(id: string, cc: string) => Promise<LookupResult>>()
+      .mockRejectedValue(error);
+    const sleep = vi.fn(async () => {});
+
+    const promise = withLookupRetry(lookup, { sleep })("1", "kr");
+
+    await expect(promise).rejects.toBe(error);
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  },
+);
+
+test("withLookupRetry throws the transient error after exhausting every attempt", async () => {
+  const error = lookupError("http");
+  const lookup = vi
+    .fn<(id: string, cc: string) => Promise<LookupResult>>()
+    .mockRejectedValue(error);
+  const sleep = vi.fn(async () => {});
+
+  const promise = withLookupRetry(lookup, { sleep, retries: 2 })("1", "kr");
+
+  await expect(promise).rejects.toBe(error);
+  expect(lookup).toHaveBeenCalledTimes(3);
+  expect(sleep).toHaveBeenCalledTimes(2);
+});

--- a/scripts/crawl/lookup-retry.ts
+++ b/scripts/crawl/lookup-retry.ts
@@ -1,0 +1,43 @@
+import {
+  ItunesLookupError,
+  type ItunesLookupErrorKind,
+  type LookupResult,
+} from "./itunes-lookup";
+import { withRetry } from "./retry";
+
+// Lookup failures worth retrying: the request never completed (network) or the
+// server returned non-2xx (http). A returned-but-wrong payload (json/shape/miss)
+// will not change on an immediate retry, so those propagate unretried and the
+// track resolves to a null preview until the next scheduled crawl.
+const TRANSIENT_KINDS: ReadonlySet<ItunesLookupErrorKind> = new Set([
+  "network",
+  "http",
+]);
+
+function isTransientLookupError(err: unknown): boolean {
+  return err instanceof ItunesLookupError && TRANSIENT_KINDS.has(err.kind);
+}
+
+export interface LookupRetryOptions {
+  sleep: (ms: number) => Promise<void>;
+  retries?: number;
+  backoffMs?: number;
+}
+
+/**
+ * Wraps a per-track lookup so transient failures retry with backoff, mirroring
+ * the RSS retry wiring. Drops into the `lookupTrack` dependency slot.
+ */
+export function withLookupRetry(
+  lookup: (id: string, cc: string) => Promise<LookupResult>,
+  options: LookupRetryOptions,
+): (id: string, cc: string) => Promise<LookupResult> {
+  const { sleep, retries = 2, backoffMs = 500 } = options;
+  return (id, cc) =>
+    withRetry(() => lookup(id, cc), {
+      retries,
+      backoffMs,
+      sleep,
+      shouldRetry: isTransientLookupError,
+    });
+}


### PR DESCRIPTION
Closes #66

## What

A transient network/HTTP blip on the per-track iTunes lookup previously shipped the track with `previewUrl: null` on the first failure (the per-track lookup had no retry; #54 added retry to RSS only). This wraps the lookup in the existing `withRetry`, gated to transient kinds, mirroring the RSS wrap.

- `withLookupRetry(lookup, { sleep })`: new composition helper. `shouldRetry` fires only for `network`/`http` kinds. `miss`/`shape`/`json` pass through unretried, since an immediate retry can't fix an asset-propagation "shape" miss (those self-heal on the next scheduled crawl).
- Wired into `cron.ts` (production) only, symmetric with the RSS retry. `main.ts` local dry-run keeps the bare lookup. `crawlCountry` stays pure.
- 7 unit tests (DI lookup + sleep, fixture style from `retry.test.ts`).

## Review notes

- **"Exhausted retries resolve to previewUrl: null"** holds by composition: `withLookupRetry` throws the `ItunesLookupError` on exhaustion (tested here), and `crawlCountry` already maps that to `null` (existing `run.test.ts`). No standalone end-to-end test was added for it.
- **`http` retries every non-2xx**, including 4xx. The error kind doesn't carry the status code, so 5xx vs 4xx isn't distinguished. Bounded cost (2 wasted retries then null); worth a follow-up only if logs show a sticky 4xx.

## Verification

Local CI matrix green: typecheck, lint, test (179, +7), build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry mechanism for track lookups during crawling operations, with configurable retry attempts and backoff intervals for transient network and HTTP failures.

* **Tests**
  * Added comprehensive test coverage for retry logic, including successful lookups, transient failures, non-transient errors, and retry exhaustion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->