### PR TITLE
feat(player): scroll long track titles past the edge

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,12 +142,19 @@
     animation-play-state: paused;
   }
 
+  /* Idle: truncate with an ellipsis, matching the rest of the list. When the
+     marquee is active the title fills its viewport and spills out to scroll,
+     clipped by the overflow-hidden wrapper. */
   .marquee-track {
-    display: inline-block;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .marquee-track[data-marquee] {
+    overflow: visible;
+    text-overflow: clip;
     will-change: transform;
     animation: marquee-scroll var(--marquee-duration, 6s) linear infinite;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,6 +141,16 @@
   .eq[data-paused] span {
     animation-play-state: paused;
   }
+
+  .marquee-track {
+    display: inline-block;
+    white-space: nowrap;
+  }
+
+  .marquee-track[data-marquee] {
+    will-change: transform;
+    animation: marquee-scroll var(--marquee-duration, 6s) linear infinite;
+  }
 }
 
 @keyframes eq {
@@ -164,6 +174,23 @@
   }
 }
 
+/* Hold at the start, scroll to the end, hold, scroll back. The held edges give
+   the eye time to read both ends; the distance is supplied per element. */
+@keyframes marquee-scroll {
+  0%,
+  8% {
+    transform: translateX(0);
+  }
+  46%,
+  54% {
+    transform: translateX(calc(-1 * var(--marquee-distance, 0px)));
+  }
+  92%,
+  100% {
+    transform: translateX(0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .eq,
   .eq span {
@@ -171,5 +198,9 @@
   }
   .eq span {
     transform: scaleY(0.7);
+  }
+  .marquee-track[data-marquee] {
+    animation: none;
+    transform: none;
   }
 }

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useState } from "react";
+
 import { AppleMusicIcon } from "@/components/icons/apple-music";
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
 import { SpotifyIcon } from "@/components/icons/spotify";
+import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import type { Track } from "@/lib/chart-schema";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
@@ -33,11 +36,24 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
   const hasPreview = track.previewUrl !== null;
   const state = isCurrent ? (isPlaying ? "playing" : "paused") : undefined;
 
+  // The current track always scrolls; a hovered row scrolls on pointer devices.
+  const [hovered, setHovered] = useState(false);
+  const {
+    ref: titleRef,
+    active: titleScrolling,
+    style: titleStyle,
+  } = useOverflowMarquee<HTMLSpanElement>({
+    enabled: isCurrent || hovered,
+    text: track.name,
+  });
+
   return (
     <li
       data-rank={track.rank}
       data-state={state}
       data-disabled={!hasPreview || undefined}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex items-center gap-[14px] rounded-[14px] px-3 py-2.5 transition-colors duration-200 data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
     >
       <button
@@ -69,7 +85,15 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
               isCurrent ? "text-sunrise" : "text-fg-1"
             }`}
           >
-            <span className="truncate">{track.name}</span>
+            <span ref={titleRef} className="block min-w-0 overflow-hidden">
+              <span
+                className="marquee-track"
+                data-marquee={titleScrolling || undefined}
+                style={titleStyle}
+              >
+                {track.name}
+              </span>
+            </span>
             {isCurrent && (
               <span
                 className="eq shrink-0"

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -85,8 +85,9 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
               isCurrent ? "text-sunrise" : "text-fg-1"
             }`}
           >
-            <span ref={titleRef} className="block min-w-0 overflow-hidden">
+            <span className="block min-w-0 overflow-hidden">
               <span
+                ref={titleRef}
                 className="marquee-track"
                 data-marquee={titleScrolling || undefined}
                 style={titleStyle}

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -2,6 +2,7 @@
 
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
+import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface MiniPlayerProps {
@@ -12,6 +13,16 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
   const currentTrack = useAudioStore((s) => s.currentTrack);
   const isPlaying = useAudioStore((s) => s.isPlaying);
   const toggle = useAudioStore((s) => s.toggle);
+
+  // The now-playing title is always the current track, so it always scrolls.
+  const {
+    ref: titleRef,
+    active: titleScrolling,
+    style: titleStyle,
+  } = useOverflowMarquee<HTMLSpanElement>({
+    enabled: currentTrack !== null,
+    text: currentTrack?.name,
+  });
 
   if (currentTrack === null) return null;
 
@@ -31,7 +42,15 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
           />
           <div className="min-w-0 flex-1">
             <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
-              <span className="truncate">{currentTrack.name}</span>
+              <span ref={titleRef} className="block min-w-0 overflow-hidden">
+                <span
+                  className="marquee-track"
+                  data-marquee={titleScrolling || undefined}
+                  style={titleStyle}
+                >
+                  {currentTrack.name}
+                </span>
+              </span>
               <span
                 className="eq shrink-0"
                 data-paused={!isPlaying || undefined}

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -42,8 +42,9 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
           />
           <div className="min-w-0 flex-1">
             <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
-              <span ref={titleRef} className="block min-w-0 overflow-hidden">
+              <span className="block min-w-0 overflow-hidden">
                 <span
+                  ref={titleRef}
                   className="marquee-track"
                   data-marquee={titleScrolling || undefined}
                   style={titleStyle}

--- a/src/components/use-overflow-marquee.test.tsx
+++ b/src/components/use-overflow-marquee.test.tsx
@@ -40,12 +40,17 @@ function sizeElement(el: Element, scrollWidth: number, clientWidth: number) {
 }
 
 function Harness({ enabled }: { enabled: boolean }) {
-  const { ref, active } = useOverflowMarquee<HTMLSpanElement>({
+  const { ref, active, style } = useOverflowMarquee<HTMLSpanElement>({
     enabled,
     text: "title",
   });
   return (
-    <span data-testid="viewport" ref={ref} data-active={active || undefined} />
+    <span
+      data-testid="viewport"
+      ref={ref}
+      data-active={active || undefined}
+      style={style}
+    />
   );
 }
 
@@ -101,5 +106,23 @@ describe("useOverflowMarquee", () => {
     const el = measureWith(220, 150, false);
 
     expect(el.getAttribute("data-active")).toBeNull();
+  });
+
+  test("exposes the overflow distance and a distance-scaled duration when active", () => {
+    stubEnvironment();
+
+    const el = measureWith(400, 150);
+
+    expect(el.style.getPropertyValue("--marquee-distance")).toBe("250px");
+    expect(el.style.getPropertyValue("--marquee-duration")).toBe("11250ms");
+  });
+
+  test("floors the duration so small overflows do not scroll frantically", () => {
+    stubEnvironment();
+
+    const el = measureWith(220, 150);
+
+    expect(el.style.getPropertyValue("--marquee-distance")).toBe("70px");
+    expect(el.style.getPropertyValue("--marquee-duration")).toBe("4000ms");
   });
 });

--- a/src/components/use-overflow-marquee.test.tsx
+++ b/src/components/use-overflow-marquee.test.tsx
@@ -1,0 +1,105 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { useOverflowMarquee } from "./use-overflow-marquee";
+
+let resizeCallback: (() => void) | null = null;
+
+class MockResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = () => callback([], this as unknown as ResizeObserver);
+  }
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+function stubEnvironment({ reducedMotion = false } = {}) {
+  resizeCallback = null;
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query: string) =>
+      ({
+        matches: query.includes("reduce") ? reducedMotion : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList,
+  );
+}
+
+function sizeElement(el: Element, scrollWidth: number, clientWidth: number) {
+  Object.defineProperty(el, "scrollWidth", {
+    configurable: true,
+    value: scrollWidth,
+  });
+  Object.defineProperty(el, "clientWidth", {
+    configurable: true,
+    value: clientWidth,
+  });
+}
+
+function Harness({ enabled }: { enabled: boolean }) {
+  const { ref, active } = useOverflowMarquee<HTMLSpanElement>({
+    enabled,
+    text: "title",
+  });
+  return (
+    <span data-testid="viewport" ref={ref} data-active={active || undefined} />
+  );
+}
+
+function measureWith(scrollWidth: number, clientWidth: number, enabled = true) {
+  const { getByTestId } = render(<Harness enabled={enabled} />);
+  const el = getByTestId("viewport");
+  sizeElement(el, scrollWidth, clientWidth);
+  act(() => resizeCallback?.());
+  return el;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("useOverflowMarquee", () => {
+  test("activates when content overflows its container", () => {
+    stubEnvironment();
+
+    const el = measureWith(220, 150);
+
+    expect(el.getAttribute("data-active")).toBe("true");
+  });
+
+  test("stays inactive when content exactly fits", () => {
+    stubEnvironment();
+
+    const el = measureWith(150, 150);
+
+    expect(el.getAttribute("data-active")).toBeNull();
+  });
+
+  test("stays inactive when content is narrower than its container", () => {
+    stubEnvironment();
+
+    const el = measureWith(100, 150);
+
+    expect(el.getAttribute("data-active")).toBeNull();
+  });
+
+  test("stays inactive under prefers-reduced-motion even when overflowing", () => {
+    stubEnvironment({ reducedMotion: true });
+
+    const el = measureWith(220, 150);
+
+    expect(el.getAttribute("data-active")).toBeNull();
+  });
+
+  test("stays inactive when disabled even when overflowing", () => {
+    stubEnvironment();
+
+    const el = measureWith(220, 150, false);
+
+    expect(el.getAttribute("data-active")).toBeNull();
+  });
+});

--- a/src/components/use-overflow-marquee.ts
+++ b/src/components/use-overflow-marquee.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  type CSSProperties,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+// Scroll pacing: duration scales with the overflow distance so the title moves
+// at a roughly constant speed no matter how far it has to travel.
+const MS_PER_PX = 45;
+const MIN_DURATION_MS = 4000;
+
+function subscribeReducedMotion(onChange: () => void) {
+  const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getReducedMotion() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export interface UseOverflowMarqueeOptions {
+  // Restrict scrolling to the moments the spec allows (current track, hover).
+  enabled: boolean;
+  // Re-measure when the rendered text changes without a box-size change.
+  text?: string;
+}
+
+export interface OverflowMarquee<T extends HTMLElement> {
+  // Attach to the clipping viewport whose overflow drives the marquee.
+  ref: RefObject<T | null>;
+  active: boolean;
+  // CSS custom properties for the keyframe; undefined while inactive.
+  style: CSSProperties | undefined;
+}
+
+export function useOverflowMarquee<T extends HTMLElement = HTMLSpanElement>({
+  enabled,
+  text,
+}: UseOverflowMarqueeOptions): OverflowMarquee<T> {
+  const ref = useRef<T>(null);
+  const [distance, setDistance] = useState(0);
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotion,
+    () => false,
+  );
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !enabled) {
+      setDistance(0);
+      return;
+    }
+    const measure = () => {
+      const overflow = el.scrollWidth - el.clientWidth;
+      setDistance(overflow > 0 ? overflow : 0);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enabled, text]);
+
+  const active = enabled && distance > 0 && !reducedMotion;
+  const style: CSSProperties | undefined = active
+    ? ({
+        "--marquee-distance": `${distance}px`,
+        "--marquee-duration": `${Math.max(MIN_DURATION_MS, Math.round(distance * MS_PER_PX))}ms`,
+      } as CSSProperties)
+    : undefined;
+
+  return { ref, active, style };
+}


### PR DESCRIPTION
## What

Long track titles that overflow now scroll so `feat.`/collab suffixes can be read in full, instead of truncating.

- Only the **current track's row** and the **mini-player now-playing title** scroll.
- On desktop, **hovering any row** scrolls that row's overflowing title.
- Non-overflowing titles and `prefers-reduced-motion` stay static.

A `useOverflowMarquee` hook detects overflow (`scrollWidth > clientWidth` via `ResizeObserver`, re-measuring on title change) and drives a CSS keyframe translate; pacing scales with the overflow distance.

## Acceptance criteria

- [x] The playing track's row title scrolls when it overflows
- [x] The mini-player now-playing title scrolls when it overflows
- [x] On desktop, hovering a row scrolls that row's overflowing title
- [x] Non-overflowing titles do not animate
- [x] `prefers-reduced-motion` disables the animation
- [x] Unit tests: overflow -> active, equal/under -> inactive, reduced-motion disables
- [x] build + lint + typecheck + test green

## Testing

`useOverflowMarquee` unit-tested with mocked `ResizeObserver` + `matchMedia`: overflow activates, equal/under stays inactive, reduced-motion and disabled both suppress. Full local matrix green (format, lint, typecheck, 184 tests, production build against a charts fixture).

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track titles now automatically scroll when they exceed available space, improving readability for longer track names. Scrolling activates on hover in track lists and displays while tracks play in the mini player. Respects user accessibility preferences.

* **Tests**
  * Added comprehensive test coverage for marquee scrolling functionality, including overflow detection, animation timing, and accessibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->