### PR TITLE
feat(globe): size the globe consistently across aspect ratios

### DIFF
--- a/src/components/globe/camera-fit.test.ts
+++ b/src/components/globe/camera-fit.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+
+import { cameraForViewport } from "./camera-fit";
+
+const BASE_FOV = 45;
+const BASE_DISTANCE = 3.5;
+
+function shorterDimensionFill(aspect: number): number {
+  const { fov, distance } = cameraForViewport(aspect);
+  const halfExtent =
+    distance * Math.tan((fov / 2) * (Math.PI / 180)) * Math.min(1, aspect);
+  return 1 / halfExtent;
+}
+
+test("cameraForViewport narrows the FOV on a wide-and-short viewport", () => {
+  const { fov, distance } = cameraForViewport(2);
+
+  expect(fov).toBeLessThan(BASE_FOV);
+  expect(distance).toBe(BASE_DISTANCE);
+});
+
+test("cameraForViewport clamps a tall viewport to the base FOV", () => {
+  const { fov, distance } = cameraForViewport(0.46);
+
+  expect(fov).toBe(BASE_FOV);
+  expect(distance).toBe(BASE_DISTANCE);
+});
+
+test("cameraForViewport holds the base distance at every aspect", () => {
+  for (const aspect of [0.4, 0.8, 1, 1.6, 2.4]) {
+    expect(cameraForViewport(aspect).distance).toBe(BASE_DISTANCE);
+  }
+});
+
+test.each([0.85, 1, 1.5, 2, 3])(
+  "cameraForViewport fills ~85%% of the shorter dimension at aspect %s",
+  (aspect) => {
+    expect(shorterDimensionFill(aspect)).toBeCloseTo(0.85, 2);
+  },
+);
+
+test("cameraForViewport never widens past the base FOV", () => {
+  for (const aspect of [0.2, 0.46, 0.81, 1, 2]) {
+    expect(cameraForViewport(aspect).fov).toBeLessThanOrEqual(BASE_FOV);
+  }
+});

--- a/src/components/globe/camera-fit.test.ts
+++ b/src/components/globe/camera-fit.test.ts
@@ -44,3 +44,20 @@ test("cameraForViewport never widens past the base FOV", () => {
     expect(cameraForViewport(aspect).fov).toBeLessThanOrEqual(BASE_FOV);
   }
 });
+
+test("cameraForViewport returns the base for a non-positive or NaN aspect", () => {
+  for (const aspect of [0, -1, NaN]) {
+    expect(cameraForViewport(aspect)).toEqual({
+      fov: BASE_FOV,
+      distance: BASE_DISTANCE,
+    });
+  }
+});
+
+test("cameraForViewport stays finite for a degenerate Infinity aspect", () => {
+  const { fov, distance } = cameraForViewport(Infinity);
+
+  expect(Number.isFinite(fov)).toBe(true);
+  expect(fov).toBeLessThanOrEqual(BASE_FOV);
+  expect(distance).toBe(BASE_DISTANCE);
+});

--- a/src/components/globe/camera-fit.ts
+++ b/src/components/globe/camera-fit.ts
@@ -1,0 +1,29 @@
+// Globe sphere radius; the camera sits at BASE_DISTANCE on +z looking at it.
+const SPHERE_RADIUS = 1;
+const BASE_DISTANCE = 3.5;
+const BASE_FOV_DEG = 45;
+// Fraction of the shorter viewport dimension the globe fills on wide/short views.
+const TARGET_FILL = 0.85;
+
+const RAD_TO_DEG = 180 / Math.PI;
+
+export interface CameraFit {
+  fov: number;
+  distance: number;
+}
+
+/**
+ * FOV for a viewport aspect (width / height); distance is held constant so the
+ * camera-arc and OrbitControls are unaffected. A PerspectiveCamera fits its FOV
+ * vertically, so wide/short viewports narrow it to fill TARGET_FILL of the height;
+ * tall viewports clamp to the base FOV so the portrait globe never shrinks.
+ */
+export function cameraForViewport(aspect: number): CameraFit {
+  if (!(aspect > 0)) return { fov: BASE_FOV_DEG, distance: BASE_DISTANCE };
+
+  const shorter = Math.min(1, aspect);
+  const halfTanTarget = SPHERE_RADIUS / (BASE_DISTANCE * TARGET_FILL * shorter);
+  const fitFov = 2 * Math.atan(halfTanTarget) * RAD_TO_DEG;
+
+  return { fov: Math.min(BASE_FOV_DEG, fitFov), distance: BASE_DISTANCE };
+}

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { Suspense, use, useCallback, useState } from "react";
+import { Suspense, use, useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { OrbitControls } from "@react-three/drei";
-import { Canvas } from "@react-three/fiber";
+import { Canvas, useThree } from "@react-three/fiber";
+import { PerspectiveCamera } from "three";
 
 import { COUNTRIES } from "@/lib/countries";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 
+import { cameraForViewport } from "./camera-fit";
 import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
@@ -104,6 +106,23 @@ function SceneContent() {
   );
 }
 
+// Keeps the globe a consistent size across aspect ratios on resize.
+// The FOV math lives in camera-fit.ts.
+function AspectCameraFit() {
+  const width = useThree((s) => s.size.width);
+  const height = useThree((s) => s.size.height);
+  const get = useThree((s) => s.get);
+
+  useEffect(() => {
+    const camera = get().camera;
+    if (!(camera instanceof PerspectiveCamera)) return;
+    camera.fov = cameraForViewport(width / height).fov;
+    camera.updateProjectionMatrix();
+  }, [get, width, height]);
+
+  return null;
+}
+
 export function GlobeScene() {
   return (
     <Canvas
@@ -111,6 +130,7 @@ export function GlobeScene() {
       dpr={[1, 2]}
       gl={{ antialias: true }}
     >
+      <AspectCameraFit />
       <SceneContent />
     </Canvas>
   );


### PR DESCRIPTION
Closes #64

## What

The hero globe looked small with large side margins on landscape phones and md (~768-1024px) widths: a `PerspectiveCamera` fits its FOV vertically, so the globe tracked viewport height regardless of width. This makes the camera FOV aspect-aware.

- New pure `cameraForViewport(aspect)` (`camera-fit.ts`): narrows the FOV on wide/short viewports so the globe fills ~85% of the shorter (height) dimension, and clamps tall viewports to the base 45 degree FOV. Distance is held at 3.5, so the camera-arc and OrbitControls are untouched.
- `AspectCameraFit` leaf in `globe-scene.tsx`: subscribes to the canvas width/height and sets `camera.fov` on resize via R3F's imperative `get()` accessor (touches only FOV, never position).
- 9 unit tests for the pure function.

## Approach (C, decided in grill)

"85% of the shorter side on every orientation" was dropped: in portrait the shorter side is the narrow width, which would shrink the globe (about 630px to 330px) on a screen that already looks right. So the rule is enlarge wide/short and md only; tall/portrait keeps today's framing via the FOV clamp. AC reworded on the issue accordingly.

## Verification

Local matrix green: typecheck, lint, test (188, +9), build. Visually checked in headless Chrome at portrait (393x852), landscape (852x393), and md (900x700): landscape/md globe now fills ~85% of height (prominent, no longer small-with-margins), portrait unchanged, KR focus + pins + auto-rotate intact, no console errors.
