### PR TITLE
feat(globe): load the chart before the 3D globe

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
-import { Suspense } from "react";
 import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 
-import { GlobeScene } from "@/components/globe/globe-scene";
+import { GlobeMount } from "@/components/globe/globe-mount";
 
 import "./globals.css";
 
@@ -80,9 +79,7 @@ export default function RootLayout({
     >
       <body className="bg-void flex min-h-full flex-col">
         <div className="fixed inset-0">
-          <Suspense fallback={null}>
-            <GlobeScene />
-          </Suspense>
+          <GlobeMount />
         </div>
         {children}
       </body>

--- a/src/components/globe/globe-mount.tsx
+++ b/src/components/globe/globe-mount.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Defer the Three.js/R3F bundle so it stops competing with the chart for the
+// main thread on load. The WebGL canvas is client-only, so ssr:false keeps it
+// out of the server render. This wrapper exists to hold the dynamic(ssr:false)
+// seam, which is not allowed inside the Server Component layout.
+const GlobeScene = dynamic(
+  () => import("./globe-scene").then((m) => m.GlobeScene),
+  { ssr: false },
+);
+
+export function GlobeMount() {
+  return <GlobeScene />;
+}

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -124,11 +124,18 @@ function AspectCameraFit() {
 }
 
 export function GlobeScene() {
+  // Fade in once the renderer exists, so the globe arrives over the dark
+  // background instead of popping in when its chunk finishes loading.
+  const [ready, setReady] = useState(false);
   return (
     <Canvas
       camera={{ fov: 45, position: [0, 0, 3.5] }}
       dpr={[1, 2]}
       gl={{ antialias: true }}
+      onCreated={() => setReady(true)}
+      className={`transition-opacity duration-700 ease-out ${
+        ready ? "opacity-100" : "opacity-0"
+      }`}
     >
       <AspectCameraFit />
       <SceneContent />


### PR DESCRIPTION
Part of #69. The split lands here, but #69's `LCP <= 2.5s` gate is **not** met by deferring the globe alone (see the performance-evidence comment below). Server-rendering the chart, which is what actually clears the gate, is tracked in #74. #69 stays open until that lands and re-baselines under 2.5s.

## What

Code-splits `GlobeScene` via `next/dynamic` (`ssr:false`) behind a small client wrapper (`globe-mount.tsx`), so the heavy Three.js/R3F bundle no longer competes with the chart for the main thread on load. The globe fades in over the dark background (700ms, no placeholder) once its renderer is created.

`dynamic(ssr:false)` can't live in the Server Component layout, so the wrapper holds that seam and `layout.tsx` just renders `<GlobeMount/>`.

## Verified locally

- typecheck / lint / test (197) / `build` green; `/` stays static.
- **0 `<canvas>` in the SSR HTML** — the globe is no longer server-rendered.
- Screenshot confirms globe + chart both render at the end state (globe faded in over the dark background).

## Premise correction (affects the LCP gate)

The issue/PRD assumed *"the chart is already server-rendered, so deferring the globe flips LCP to the server-painted track list."* That isn't true of the current code:

- `ChartScreen` calls `useSearchParams()`, which renders its whole Suspense subtree as the `null` fallback on the server. The chart sheet markup (`track-row`, `shadow-sheet`, `data-snap`) is **absent** from the rendered DOM — it's client-rendered. Both the globe and the chart are client-side.
- Bare `/` also client-redirects (`router.replace(/?cc=xx)` in an effect).

The split is still correct and necessary (it pulls the heaviest client chunk out of the hydration path), but LCP after the split is the *client-rendered* chart, not a server-painted element. Closing that is #74.

## Re-baseline result

Measured on the Vercel preview (Chrome DevTools, Mobile, 3-run median): Performance 56, LCP 8.1s — versus production (pre-split) Performance 62, LCP 18.4s. A controlled local A/B (fixed `/?cc=pl`, headless, delta only) showed the split cutting LCP 20.4s -> 13.0s and Performance 33 -> 69. So the split roughly halves LCP but does not reach the 2.5s gate on its own, because the LCP element is the client-rendered chart. Full evidence is in the performance comment.
