### PR TITLE
feat(og): per-country social cards via next/og

### DIFF
--- a/src/app/og/route.tsx
+++ b/src/app/og/route.tsx
@@ -1,0 +1,342 @@
+import { readFile } from "node:fs/promises";
+
+import { ImageResponse } from "next/og";
+
+import { countryByCode, validateCountryCode } from "@/lib/country-code";
+
+export const runtime = "nodejs";
+
+// Brand tokens (mirrors src/app/globals.css; inlined because next/og can't read CSS variables).
+const VOID = "#050608";
+const FG1 = "#f5f2ec";
+const FG2 = "#b8b5ae";
+const FG3 = "#6e6b66";
+const SUNRISE = "#ff6b47";
+
+const BACKGROUND =
+  "radial-gradient(ellipse 90% 90% at 72% 20%, rgba(20,23,32,0.35) 0%, rgba(20,23,32,0) 55%)," +
+  "radial-gradient(ellipse 130% 120% at 50% 118%, #11131b 0%, #0a0b10 42%, #050608 100%)";
+
+// Eyebrow: uppercase, tracked, one uniform dim color (code + dot + label all match).
+function eyebrowStyle(fontSize: number) {
+  return {
+    fontFamily: "Poppins",
+    fontWeight: 500,
+    fontSize,
+    letterSpacing: fontSize * 0.16,
+    color: FG3,
+  } as const;
+}
+
+// The flat-globe mark is inlined here as JSX rather than loaded from
+// public/logo-mark-flat.svg: next/og can only recolor and resize the mark when
+// it is written as inline SVG elements, and each card needs it in a different
+// color and size. The same shape also lives in public/logo-mark-flat.svg and
+// src/app/icon.svg (favicon); if the geometry or the sunrise pin changes, update
+// those copies too.
+
+// Small wordmark glyph: simplified flat globe, brighter (fg-2).
+function WordmarkGlyph({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 64 64" fill="none">
+      <circle
+        cx="32"
+        cy="32"
+        r="24"
+        stroke={FG2}
+        strokeWidth="1.6"
+        opacity="0.7"
+      />
+      <line
+        x1="8"
+        y1="32"
+        x2="56"
+        y2="32"
+        stroke={FG2}
+        strokeWidth="1.4"
+        opacity="0.5"
+      />
+      <ellipse
+        cx="32"
+        cy="32"
+        rx="7.4"
+        ry="24"
+        stroke={FG2}
+        strokeWidth="1.4"
+        opacity="0.3"
+      />
+      <circle cx="46.3" cy="23" r="4.5" fill={SUNRISE} />
+    </svg>
+  );
+}
+
+// Full flat-globe motif: circle + 3 lat lines + 2 lon ellipses + sunrise pin.
+function GlobeMark({ size, color }: { size: number; color: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 64 64" fill="none">
+      <circle
+        cx="32"
+        cy="32"
+        r="24"
+        stroke={color}
+        strokeWidth="1"
+        opacity="0.7"
+      />
+      <line
+        x1="9.751"
+        y1="23"
+        x2="54.249"
+        y2="23"
+        stroke={color}
+        strokeWidth="0.8"
+        opacity="0.24"
+      />
+      <line
+        x1="8"
+        y1="32"
+        x2="56"
+        y2="32"
+        stroke={color}
+        strokeWidth="0.8"
+        opacity="0.5"
+      />
+      <line
+        x1="9.751"
+        y1="41"
+        x2="54.249"
+        y2="41"
+        stroke={color}
+        strokeWidth="0.8"
+        opacity="0.24"
+      />
+      <ellipse
+        cx="32"
+        cy="32"
+        rx="17.836"
+        ry="24"
+        stroke={color}
+        strokeWidth="0.8"
+        opacity="0.32"
+      />
+      <ellipse
+        cx="32"
+        cy="32"
+        rx="7.416"
+        ry="24"
+        stroke={color}
+        strokeWidth="0.8"
+        opacity="0.22"
+      />
+      <circle cx="46.3" cy="23" r="7" fill={SUNRISE} opacity="0.22" />
+      <circle cx="46.3" cy="23" r="3.4" fill={SUNRISE} />
+    </svg>
+  );
+}
+
+function Wordmark({ glyph, text }: { glyph: number; text: number }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: glyph * 0.46 }}>
+      <WordmarkGlyph size={glyph} />
+      <div
+        style={{
+          fontFamily: "Poppins",
+          fontWeight: 500,
+          fontSize: text,
+          letterSpacing: text * 0.14,
+          color: FG2,
+        }}
+      >
+        SOUNDS ABROAD
+      </div>
+    </div>
+  );
+}
+
+function CountryName({
+  lines,
+  fontSize,
+}: {
+  lines: string[];
+  fontSize: number;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      {lines.map((line, i) => (
+        <div
+          key={i}
+          style={{
+            fontFamily: "Instrument Serif",
+            fontStyle: "italic",
+            fontSize,
+            lineHeight: 0.95,
+            color: FG1,
+          }}
+        >
+          {line}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Footer({ fontSize }: { fontSize: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        fontFamily: "Poppins",
+        fontWeight: 500,
+        fontSize,
+      }}
+    >
+      <div style={{ color: FG3 }}>Charts from&nbsp;</div>
+      <div style={{ color: FG2 }}>Apple Music</div>
+      <div style={{ color: FG3 }}>, updated daily</div>
+    </div>
+  );
+}
+
+function Landscape({
+  nameLines,
+  eyebrow,
+  nameSize,
+}: {
+  nameLines: string[];
+  eyebrow: string;
+  nameSize: number;
+}) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        padding: "78px 80px",
+        backgroundColor: VOID,
+        backgroundImage: BACKGROUND,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -40,
+          right: -150,
+          display: "flex",
+          opacity: 0.55,
+        }}
+      >
+        <GlobeMark size={660} color={FG3} />
+      </div>
+      <Wordmark glyph={30} text={24} />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          justifyContent: "center",
+        }}
+      >
+        <div style={{ ...eyebrowStyle(28), marginBottom: 14 }}>{eyebrow}</div>
+        <CountryName lines={nameLines} fontSize={nameSize} />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+        <div
+          style={{
+            width: 96,
+            height: 4,
+            backgroundColor: SUNRISE,
+            borderRadius: 4,
+          }}
+        />
+        <Footer fontSize={22} />
+      </div>
+    </div>
+  );
+}
+
+function Square({
+  nameLines,
+  eyebrow,
+  nameSize,
+}: {
+  nameLines: string[];
+  eyebrow: string;
+  nameSize: number;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "space-between",
+        textAlign: "center",
+        width: "100%",
+        height: "100%",
+        padding: "56px 84px",
+        backgroundColor: VOID,
+        backgroundImage: BACKGROUND,
+        overflow: "hidden",
+      }}
+    >
+      <Wordmark glyph={44} text={30} />
+      <div style={{ display: "flex", opacity: 0.55 }}>
+        <GlobeMark size={480} color={FG3} />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 18,
+          marginTop: -84,
+        }}
+      >
+        <CountryName lines={nameLines} fontSize={nameSize} />
+        <div style={eyebrowStyle(30)}>{eyebrow}</div>
+      </div>
+      <Footer fontSize={24} />
+    </div>
+  );
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const code = validateCountryCode(searchParams.get("cc"));
+  const entry = code ? countryByCode(code) : undefined;
+  const square = searchParams.get("shape") === "square";
+
+  const nameLines = entry ? [entry.name] : ["What the world", "is playing"];
+  const eyebrow = entry
+    ? `${entry.code.toUpperCase()} · TOP 25`
+    : "TRENDING WORLDWIDE";
+  const nameSize = entry ? (square ? 170 : 150) : square ? 112 : 104;
+
+  const [poppins, instrument] = await Promise.all([
+    readFile(new URL("../fonts/Poppins-Medium.ttf", import.meta.url)),
+    readFile(new URL("../fonts/InstrumentSerif-Italic.ttf", import.meta.url)),
+  ]);
+
+  const element = square ? (
+    <Square nameLines={nameLines} eyebrow={eyebrow} nameSize={nameSize} />
+  ) : (
+    <Landscape nameLines={nameLines} eyebrow={eyebrow} nameSize={nameSize} />
+  );
+
+  return new ImageResponse(element, {
+    width: 1200,
+    height: square ? 1200 : 630,
+    fonts: [
+      { name: "Poppins", data: poppins, weight: 500, style: "normal" },
+      {
+        name: "Instrument Serif",
+        data: instrument,
+        weight: 400,
+        style: "italic",
+      },
+    ],
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,7 @@ export async function generateMetadata({
     title,
     description,
     openGraph: {
+      type: "website",
       title,
       description,
       images: [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,52 @@
+import type { Metadata } from "next";
 import { connection } from "next/server";
 
 import { fetchCharts } from "@/lib/charts-client";
+import { countryByCode, validateCountryCode } from "@/lib/country-code";
 import { randomCountryCode } from "@/lib/landing-code";
 
 import { ChartScreen } from "./chart-screen";
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}): Promise<Metadata> {
+  const { cc } = await searchParams;
+  const code = validateCountryCode(typeof cc === "string" ? cc : null);
+  const entry = code ? countryByCode(code) : undefined;
+
+  const title = entry
+    ? `${entry.name} — Top 25 on Sounds Abroad`
+    : "Sounds Abroad — World music discovery";
+  const description = entry
+    ? `What ${entry.name} is listening to right now. Charts from Apple Music, updated daily.`
+    : "Explore trending music around the world, on a 3D globe.";
+
+  const query = code ? `?cc=${code}` : "";
+  const landscape = `/og${query}`;
+  const squareSep = code ? "&" : "?";
+  const square = `/og${query}${squareSep}shape=square`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [
+        { url: landscape, width: 1200, height: 630 },
+        { url: square, width: 1200, height: 1200 },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [landscape],
+    },
+  };
+}
 
 export default async function Home() {
   const url = process.env.CHARTS_BLOB_URL;

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -7,6 +7,7 @@ import { Canvas, useThree } from "@react-three/fiber";
 import { PerspectiveCamera } from "three";
 
 import { COUNTRIES } from "@/lib/countries";
+import { validateCountryCode } from "@/lib/country-code";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 
 import { cameraForViewport } from "./camera-fit";
@@ -16,14 +17,7 @@ import { CountryPins } from "./country-pins";
 import { StarBackdrop } from "./star-backdrop";
 import { useCameraArc } from "./use-camera-arc";
 
-const ALL_CODES = COUNTRIES.map((c) => c.code);
 const ISO_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c.isoNum]));
-
-function validateCode(raw: string | null): string | null {
-  if (raw === null) return null;
-  const lower = raw.toLowerCase();
-  return ALL_CODES.includes(lower) ? lower : null;
-}
 
 function CountryLayers({
   hoveredIsoNum,
@@ -47,7 +41,7 @@ function CountryLayers({
 
 function SceneContent() {
   const searchParams = useSearchParams();
-  const selectedCode = validateCode(searchParams.get("cc"));
+  const selectedCode = validateCountryCode(searchParams.get("cc"));
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =

--- a/src/lib/country-code.test.ts
+++ b/src/lib/country-code.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+
+import { countryByCode, validateCountryCode } from "./country-code";
+
+describe("validateCountryCode", () => {
+  test("returns null for a missing value", () => {
+    const result = validateCountryCode(null);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns the canonical lowercase code for a known country", () => {
+    const result = validateCountryCode("kr");
+
+    expect(result).toBe("kr");
+  });
+
+  test("lowercases an uppercase code", () => {
+    const result = validateCountryCode("KR");
+
+    expect(result).toBe("kr");
+  });
+
+  test("returns null for an unknown code", () => {
+    const result = validateCountryCode("zz");
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects a code outside a caller-supplied set", () => {
+    const result = validateCountryCode("kr", new Set(["us", "br"]));
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("countryByCode", () => {
+  test("returns the entry for a known code", () => {
+    const result = countryByCode("kr");
+
+    expect(result?.name).toBe("South Korea");
+  });
+
+  test("returns undefined for an unknown code", () => {
+    const result = countryByCode("zz");
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/country-code.ts
+++ b/src/lib/country-code.ts
@@ -1,0 +1,24 @@
+import { COUNTRIES, type CountryEntry } from "./countries";
+
+const BY_CODE: ReadonlyMap<string, CountryEntry> = new Map(
+  COUNTRIES.map((c) => [c.code, c]),
+);
+
+const ALL_CODES: ReadonlySet<string> = new Set(BY_CODE.keys());
+
+// Normalize a raw ?cc= value to its canonical lowercase code, or null when it
+// is missing or not a known country. Defaults to the full country set; callers
+// with a narrower source (the codes present in a given chart payload) pass their
+// own set.
+export function validateCountryCode(
+  raw: string | null,
+  validCodes: ReadonlySet<string> = ALL_CODES,
+): string | null {
+  if (raw === null) return null;
+  const lower = raw.toLowerCase();
+  return validCodes.has(lower) ? lower : null;
+}
+
+export function countryByCode(code: string): CountryEntry | undefined {
+  return BY_CODE.get(code);
+}


### PR DESCRIPTION
## What

Per-country Open Graph cards rendered at runtime by `next/og`, plus a default card for the bare root, wired into the page metadata so shared links unfurl with the country name, its Top 25, and the brand globe.

- `GET /og?cc=XX` renders a 1200x630 landscape card; `&shape=square` renders 1200x1200 (for WhatsApp / center-crop contexts).
- Missing or invalid `cc` falls back to the default card ("What the world is playing" / "Trending worldwide").
- `generateMetadata` in `page.tsx` sets `openGraph.images` (landscape + square) and `twitter` (`summary_large_image`); `metadataBase` resolves them to absolute URLs.
- New shared `validateCountryCode` / `countryByCode` in `src/lib/country-code.ts`, reused by the globe scene (which dropped its duplicate validator).

## Design

Matches the converged card design: uppercase `KR · TOP 25` eyebrow in one uniform dim tone, italic Instrument Serif country name, faint flat-globe, sunrise pin (and a sunrise rule on the landscape card). WebGL does not render in `next/og`, so the globe is the flat-mark motif. That mark is inlined as JSX because `next/og` can only recolor and resize it inline; the same shape also lives in `public/logo-mark-flat.svg` and `src/app/icon.svg`, noted in a code comment so the copies stay in sync.

## Verification

- lint, typecheck, 198 tests, and a production build all green.
- Rendered the real PNGs (kr / jp / default, landscape + square) and confirmed they match the approved mock.
- Card-validator check (opengraph.xyz) is pending the prod deploy, since it needs the live URL.

Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic Open Graph image cards with country-specific branding to enhance social media link sharing capabilities
  * Automatic metadata generation for improved search engine visibility and better social media preview cards

* **Refactor**
  * Improved country code validation logic for greater consistency across the application

* **Tests**
  * Added test coverage for country code validation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->