### PR TITLE
fix(sheet): contain overscroll so drag-down collapses instead of refreshing

### DIFF
--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -215,7 +215,7 @@ export function ChartSheet({
             key={countryCode}
             ref={olRef}
             data-peek={(snap === "peek" && !isDragging) || undefined}
-            className="min-h-0 flex-1 overflow-y-auto px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
+            className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
           >
             {country.tracks.map((track) => (
               <TrackRow


### PR DESCRIPTION
Found at V1 launch smoke (2026-06-08): with the sheet expanded, dragging the track list down from the top fired the browser's pull-to-refresh instead of collapsing the sheet.

## Fix
`overscroll-y-contain` on the sheet scroll container (`<ol>`). At the scroller's top boundary the overscroll stays contained to the sheet instead of chaining up to the document, so a downward drag no longer becomes pull-to-refresh. Scoped to the sheet rather than an app-wide `overscroll-behavior: none`.

## Verify (mobile gesture, not headless)
On the preview: expand the sheet to full, drag the list down from the top. It should collapse the sheet, not reload the page.

## Out of scope
The Spotify logged-out deeplink issue from the same smoke is filed as #80 (V2).