### PR TITLE
feat(sheet): full-state body-drag-to-collapse via scroll/drag hand-off

### DIFF
--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -33,13 +33,26 @@ function renderSheet(snap: SnapState) {
 
 // Drag the body with a mouse pointer: press, cross the threshold, drag, release.
 // The first move both crosses the threshold and baselines the drag at that
-// point, so a second move supplies the actual travel. (Touch drag relies on
-// non-passive listeners and layout jsdom doesn't model; it is device-verified.)
+// point, so a second move supplies the actual travel.
 function dragBody(target: Element, fromY: number, toY: number) {
   fireEvent.pointerDown(target, { clientY: fromY, pointerType: "mouse" });
   fireEvent.pointerMove(window, { clientY: fromY + (toY > fromY ? 6 : -6) });
   fireEvent.pointerMove(window, { clientY: toY });
   fireEvent.pointerUp(window);
+}
+
+// The touch handlers are attached natively (non-passive), so dispatch raw touch
+// events. jsdom models neither native scroll nor layout, but the hand-off branch
+// (list at scrollTop <= 0 while still pulling down) is plain logic: scrollTop is
+// mocked via setScrollTop and height falls back to window.innerHeight. The real
+// scroll and the gesture feel are device-verified.
+function dispatchTouch(target: Element, type: string, clientY: number) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "touches", {
+    value: [{ clientY }],
+    configurable: true,
+  });
+  target.dispatchEvent(event);
 }
 
 describe("ChartSheet", () => {
@@ -305,6 +318,31 @@ describe("ChartSheet", () => {
       pointerType: "mouse",
     });
     fireEvent.pointerUp(window);
+
+    expect(onSnapChange).not.toHaveBeenCalled();
+  });
+
+  test("hands off to a collapse when the full list is dragged down from the top", () => {
+    const { onSnapChange } = renderSheet("full");
+    const list = screen.getByRole("list");
+    setScrollTop(list, 0);
+
+    dispatchTouch(list, "touchstart", 300);
+    dispatchTouch(list, "touchmove", 340);
+    dispatchTouch(list, "touchmove", 700);
+    dispatchTouch(list, "touchend", 700);
+
+    expect(onSnapChange).toHaveBeenCalledWith("peek");
+  });
+
+  test("does not hand off while the full list is still scrolled", () => {
+    const { onSnapChange } = renderSheet("full");
+    const list = screen.getByRole("list");
+    setScrollTop(list, 80);
+
+    dispatchTouch(list, "touchstart", 300);
+    dispatchTouch(list, "touchmove", 340);
+    dispatchTouch(list, "touchend", 340);
 
     expect(onSnapChange).not.toHaveBeenCalled();
   });

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -6,16 +6,6 @@ import { AudioStoreProvider } from "@/providers/audio-store-provider";
 
 import { ChartSheet, type SnapState } from "./sheet";
 
-const { dragStart } = vi.hoisted(() => ({ dragStart: vi.fn() }));
-
-vi.mock("motion/react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("motion/react")>();
-  return {
-    ...actual,
-    useDragControls: () => ({ start: dragStart, subscribe: () => () => {} }),
-  };
-});
-
 function setScrollTop(el: Element, value: number) {
   Object.defineProperty(el, "scrollTop", { value, configurable: true });
 }
@@ -24,7 +14,6 @@ const originalScrollIntoView = Element.prototype.scrollIntoView;
 
 afterEach(() => {
   Element.prototype.scrollIntoView = originalScrollIntoView;
-  dragStart.mockClear();
 });
 
 function renderSheet(snap: SnapState) {
@@ -40,6 +29,17 @@ function renderSheet(snap: SnapState) {
     </AudioStoreProvider>,
   );
   return { ...utils, onSnapChange };
+}
+
+// Drag the body with a mouse pointer: press, cross the threshold, drag, release.
+// The first move both crosses the threshold and baselines the drag at that
+// point, so a second move supplies the actual travel. (Touch drag relies on
+// non-passive listeners and layout jsdom doesn't model; it is device-verified.)
+function dragBody(target: Element, fromY: number, toY: number) {
+  fireEvent.pointerDown(target, { clientY: fromY, pointerType: "mouse" });
+  fireEvent.pointerMove(window, { clientY: fromY + (toY > fromY ? 6 : -6) });
+  fireEvent.pointerMove(window, { clientY: toY });
+  fireEvent.pointerUp(window);
 }
 
 describe("ChartSheet", () => {
@@ -271,33 +271,41 @@ describe("ChartSheet", () => {
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 
-  test("starts the sheet drag on pointer down in the list at the top", () => {
-    renderSheet("peek");
-    const list = screen.getByRole("list");
-    setScrollTop(list, 0);
+  test("expands to full when the body is dragged up from peek", () => {
+    const { onSnapChange } = renderSheet("peek");
 
-    fireEvent.pointerDown(list);
+    dragBody(screen.getByTestId("chart-sheet"), 500, 150);
 
-    expect(dragStart).toHaveBeenCalledTimes(1);
+    expect(onSnapChange).toHaveBeenCalledWith("full");
+  });
+
+  test("collapses toward closed when the body is dragged down from peek", () => {
+    const { onSnapChange } = renderSheet("peek");
+
+    dragBody(screen.getByTestId("chart-sheet"), 500, 850);
+
+    expect(onSnapChange).toHaveBeenCalledWith("closed");
   });
 
   test("yields to list scroll on pointer down when the list is scrolled", () => {
-    renderSheet("peek");
+    const { onSnapChange } = renderSheet("peek");
     const list = screen.getByRole("list");
     setScrollTop(list, 40);
 
-    fireEvent.pointerDown(list);
+    fireEvent.pointerDown(list, { clientY: 500, pointerType: "mouse" });
 
-    expect(dragStart).not.toHaveBeenCalled();
+    expect(onSnapChange).not.toHaveBeenCalled();
   });
 
-  test("starts the sheet drag on pointer down outside the list", () => {
-    renderSheet("peek");
-    const list = screen.getByRole("list");
-    setScrollTop(list, 40);
+  test("does not change snap on a tap below the drag threshold", () => {
+    const { onSnapChange } = renderSheet("peek");
 
-    fireEvent.pointerDown(screen.getByText(COUNTRY_KR.name));
+    fireEvent.pointerDown(screen.getByTestId("chart-sheet"), {
+      clientY: 500,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerUp(window);
 
-    expect(dragStart).toHaveBeenCalledTimes(1);
+    expect(onSnapChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -282,6 +282,18 @@ export function ChartSheet({
     didMountRef.current = true;
   }, [snap, hasMiniPlayer, applySnap]);
 
+  // The transform is in px, so it does not track height changes on its own.
+  // Re-place the sheet at its current snap when the viewport resizes (rotation,
+  // desktop resize) so the partial snaps do not drift; no animation, and never
+  // while a drag owns the transform.
+  useEffect(() => {
+    const onResize = () => {
+      if (!draggingRef.current) applySnap(snapRef.current, false);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [applySnap]);
+
   // Touch controller. Attached imperatively so touchmove is non-passive and can
   // preventDefault to interrupt native scroll at the hand-off boundary.
   useEffect(() => {

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -1,19 +1,13 @@
 "use client";
 
 import {
-  type PointerEvent,
+  type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import {
-  motion,
-  type PanInfo,
-  useAnimationControls,
-  useDragControls,
-} from "motion/react";
 
 import type { Country } from "@/lib/chart-schema";
 
@@ -31,6 +25,9 @@ export interface ChartSheetProps {
   scrollSignal?: number;
 }
 
+// translateY as a fraction of the sheet's own height at each snap: full shows
+// all of it, hidden pushes it fully below the viewport, peek leaves ~35% (the
+// height the <ol> max-height clamp is tuned to).
 const SNAP_Y_PCT: Record<SnapState, number> = {
   full: 0,
   peek: 65,
@@ -46,7 +43,14 @@ const SNAP_Y: Record<SnapState, string> = {
 };
 
 const SNAP_ORDER: SnapState[] = ["full", "peek", "closed", "hidden"];
-const VELOCITY_PROJECTION = 0.15;
+
+// Pointer travel (px) before a press becomes a drag, so a tap on the handle
+// toggles cleanly instead of flickering the list clamp.
+const DRAG_THRESHOLD_PX = 4;
+// Release velocity (px/ms) projected this many ms ahead to pick the settle
+// target, so a fast flick carries past the nearest stop.
+const VELOCITY_PROJECTION_MS = 120;
+const SETTLE_TRANSITION = "transform 0.34s cubic-bezier(0.22, 1, 0.36, 1)";
 
 // Mirror MiniPlayer's rendered height: pt-3 (12px) + h-12 artwork (48px)
 // + pb-[max(env(safe-area-inset-bottom), 12px)]. Tracks the iOS safe-area
@@ -59,18 +63,14 @@ const SHEET_STYLE_WITH_MINI = {
 } as const;
 const SHEET_STYLE_NO_MINI = { bottom: 0, height: "100dvh" } as const;
 
+// Nearest snap to a projected position, restricted to one step from the current
+// snap so every stop is a required waypoint (a drag can't skip peek).
 function nextSnap(
   current: SnapState,
-  offsetY: number,
-  velocityY: number,
+  projectedPx: number,
+  height: number,
 ): SnapState {
-  const vh = window.innerHeight;
-  const offsetPct = (offsetY / vh) * 100;
-  const velocityPct = (velocityY / vh) * 100;
-  const projected =
-    SNAP_Y_PCT[current] + offsetPct + velocityPct * VELOCITY_PROJECTION;
-
-  // One-step transitions only — every snap is a required waypoint.
+  const projectedPct = (projectedPx / height) * 100;
   const idx = SNAP_ORDER.indexOf(current);
   const candidates: SnapState[] = [current];
   if (idx > 0) candidates.push(SNAP_ORDER[idx - 1]);
@@ -79,7 +79,7 @@ function nextSnap(
   let nearest: SnapState = current;
   let minDist = Infinity;
   for (const s of candidates) {
-    const dist = Math.abs(SNAP_Y_PCT[s] - projected);
+    const dist = Math.abs(SNAP_Y_PCT[s] - projectedPct);
     if (dist < minDist) {
       minDist = dist;
       nearest = s;
@@ -97,53 +97,290 @@ export function ChartSheet({
   hasMiniPlayer = false,
   scrollSignal = 0,
 }: ChartSheetProps) {
-  const animationControls = useAnimationControls();
-  const dragControls = useDragControls();
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+  const olRef = useRef<HTMLOListElement | null>(null);
+
+  // Lifts the peek max-height clamp so the list fills the sheet while it's
+  // dragged; only toggled at gesture start/end, never per frame.
   const [isDragging, setIsDragging] = useState(false);
 
-  useEffect(() => {
-    void animationControls.start({ y: SNAP_Y[snap] });
-  }, [snap, animationControls]);
+  // Mount-time snap, captured once. React writes this transform for SSR/first
+  // paint and never reconciles it (it never changes across renders), so the
+  // gesture and settle code own the transform imperatively from then on. Do not
+  // change this to SNAP_Y[snap]: a per-render value would make React rewrite the
+  // transform every render and fight the imperative writes.
+  const [initialSnap] = useState(snap);
 
-  // open is pinned true to keep motion.div mounted for hidden↔visible
-  // animation; Escape collapses to closed instead of unmounting.
-  const handleOpenChange = useCallback(
-    (next: boolean) => {
-      if (!next) onSnapChange("closed");
-    },
-    [onSnapChange],
+  // Transient gesture state — refs so per-frame updates never re-render.
+  const curYRef = useRef(0); // current translateY (px)
+  const heightRef = useRef(0); // sheet height (px), cached at drag start
+  const pressedRef = useRef(false); // pointer down, drag not yet committed
+  const draggingRef = useRef(false); // committed to driving the sheet
+  const canHandoffRef = useRef(false); // gesture began in the scrolled list at full
+  const startYRef = useRef(0); // pointer Y at press (threshold reference)
+  const baseYRef = useRef(0); // pointer Y at the drag baseline
+  const baseTransRef = useRef(0); // translateY at the drag baseline
+  const lastYRef = useRef(0);
+  const lastTRef = useRef(0);
+  const velRef = useRef(0);
+
+  // Kept in refs so the long-lived touch listeners read the latest value
+  // without re-attaching when the prop or snap changes.
+  const snapRef = useRef(snap);
+  useEffect(() => {
+    snapRef.current = snap;
+  }, [snap]);
+  const onSnapChangeRef = useRef(onSnapChange);
+  useEffect(() => {
+    onSnapChangeRef.current = onSnapChange;
+  }, [onSnapChange]);
+
+  const sheetHeight = useCallback(
+    () => sheetRef.current?.offsetHeight || window.innerHeight,
+    [],
   );
 
-  const handleDragStart = useCallback(() => setIsDragging(true), []);
+  const snapPx = useCallback(
+    (s: SnapState) => (SNAP_Y_PCT[s] / 100) * sheetHeight(),
+    [sheetHeight],
+  );
 
-  const handleDragEnd = useCallback(
-    (_event: unknown, info: PanInfo) => {
-      setIsDragging(false);
-      const next = nextSnap(snap, info.offset.y, info.velocity.y);
-      if (next === snap) {
-        void animationControls.start({ y: SNAP_Y[snap] });
+  // Drive the transform directly on the node. A MotionValue binding did not
+  // apply reliably mid-gesture on iOS; direct writes also keep per-frame
+  // updates off the React render path.
+  const setY = useCallback((px: number) => {
+    curYRef.current = px;
+    const el = sheetRef.current;
+    if (el) el.style.transform = `translateY(${px}px)`;
+  }, []);
+
+  const applySnap = useCallback(
+    (s: SnapState, animate: boolean) => {
+      const el = sheetRef.current;
+      if (el) el.style.transition = animate ? SETTLE_TRANSITION : "none";
+      setY(snapPx(s));
+    },
+    [setY, snapPx],
+  );
+
+  // Rubber-band past the top (full) and bottom (hidden) edges.
+  const withResistance = useCallback((px: number) => {
+    const max = heightRef.current;
+    if (px < 0) return px * 0.25;
+    if (px > max) return max + (px - max) * 0.25;
+    return px;
+  }, []);
+
+  const trackVelocity = useCallback((y: number, t: number) => {
+    const dt = t - lastTRef.current;
+    if (dt > 0) velRef.current = (y - lastYRef.current) / dt;
+    lastYRef.current = y;
+    lastTRef.current = t;
+  }, []);
+
+  // Live translateY in px, read from the rendered matrix so grabbing the sheet
+  // mid-settle picks up its actual position instead of the snap target.
+  const readCurrentY = useCallback((): number => {
+    const el = sheetRef.current;
+    if (!el || typeof DOMMatrixReadOnly === "undefined") return curYRef.current;
+    const transform = getComputedStyle(el).transform;
+    if (!transform || transform === "none") return curYRef.current;
+    try {
+      return new DOMMatrixReadOnly(transform).m42;
+    } catch {
+      return curYRef.current;
+    }
+  }, []);
+
+  const moveDrag = useCallback(
+    (pointerY: number) => {
+      setY(
+        withResistance(baseTransRef.current + (pointerY - baseYRef.current)),
+      );
+    },
+    [setY, withResistance],
+  );
+
+  // Commit a press to a drag: freeze the sheet at its current position and
+  // baseline the gesture there so it tracks the finger without jumping.
+  const commitDrag = useCallback(
+    (pointerY: number) => {
+      const el = sheetRef.current;
+      const currentY = readCurrentY();
+      if (el) el.style.transition = "none";
+      heightRef.current = el?.offsetHeight || window.innerHeight;
+      baseYRef.current = pointerY;
+      baseTransRef.current = currentY;
+      setY(currentY);
+      pressedRef.current = false;
+      draggingRef.current = true;
+      document.body.style.userSelect = "none";
+      setIsDragging(true);
+    },
+    [readCurrentY, setY],
+  );
+
+  const endDrag = useCallback(() => {
+    const projected = curYRef.current + velRef.current * VELOCITY_PROJECTION_MS;
+    const next = nextSnap(snapRef.current, projected, heightRef.current);
+    draggingRef.current = false;
+    canHandoffRef.current = false;
+    setIsDragging(false);
+    if (next === snapRef.current) {
+      // Same snap: no prop change to drive the settle effect, so settle here.
+      applySnap(next, true);
+    } else {
+      onSnapChangeRef.current(next);
+    }
+  }, [applySnap]);
+
+  // Per-move handler shared by touch and pointer. Returns true once the gesture
+  // owns the move so the caller can preventDefault.
+  const dragMove = useCallback(
+    (pointerY: number, t: number): boolean => {
+      trackVelocity(pointerY, t);
+      if (draggingRef.current) {
+        moveDrag(pointerY);
+        return true;
+      }
+      if (
+        pressedRef.current &&
+        Math.abs(pointerY - startYRef.current) > DRAG_THRESHOLD_PX
+      ) {
+        commitDrag(pointerY);
+        moveDrag(pointerY);
+        return true;
+      }
+      return false;
+    },
+    [trackVelocity, moveDrag, commitDrag],
+  );
+
+  // Arm a press as a drag candidate (threshold decides if it becomes a drag).
+  const armPress = useCallback((pointerY: number, t: number) => {
+    startYRef.current = pointerY;
+    lastYRef.current = pointerY;
+    lastTRef.current = t;
+    velRef.current = 0;
+    pressedRef.current = true;
+    draggingRef.current = false;
+  }, []);
+
+  const endGesture = useCallback(() => {
+    document.body.style.userSelect = "";
+    pressedRef.current = false;
+    if (draggingRef.current) endDrag();
+    else canHandoffRef.current = false;
+  }, [endDrag]);
+
+  // Settle to the current snap on prop change, and re-place when the mini-player
+  // toggles the sheet height. The first run jumps without a transition so the
+  // server-rendered position isn't animated on mount.
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    applySnap(snap, didMountRef.current);
+    didMountRef.current = true;
+  }, [snap, hasMiniPlayer, applySnap]);
+
+  // Touch controller. Attached imperatively so touchmove is non-passive and can
+  // preventDefault to interrupt native scroll at the hand-off boundary.
+  useEffect(() => {
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+
+    const onTouchStart = (e: TouchEvent) => {
+      // Ignore secondary touches while a gesture is already active so a stray
+      // second finger can't reset an in-progress drag.
+      if (pressedRef.current || draggingRef.current || canHandoffRef.current) {
         return;
       }
-      onSnapChange(next);
+      const t = e.touches[0];
+      if (
+        snapRef.current === "full" &&
+        olRef.current?.contains(e.target as Node)
+      ) {
+        // Full + list: let it scroll natively and watch for the hand-off, so a
+        // downward pull past the top continues into a sheet collapse.
+        lastYRef.current = t.clientY;
+        lastTRef.current = e.timeStamp;
+        velRef.current = 0;
+        canHandoffRef.current = true;
+        pressedRef.current = false;
+        draggingRef.current = false;
+      } else {
+        armPress(t.clientY, e.timeStamp);
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      const cy = e.touches[0].clientY;
+      // Native scroll phase: take the gesture over once the list is at the top
+      // and the finger is still pulling down. The baseline reset in commitDrag
+      // keeps the sheet from jumping.
+      if (canHandoffRef.current && !draggingRef.current) {
+        const pullingDown = cy - lastYRef.current > 0;
+        trackVelocity(cy, e.timeStamp);
+        const list = olRef.current;
+        if ((!list || list.scrollTop <= 0) && pullingDown) {
+          commitDrag(cy);
+          e.preventDefault();
+          moveDrag(cy);
+        }
+        return;
+      }
+      if (dragMove(cy, e.timeStamp)) e.preventDefault();
+    };
+
+    const onTouchEnd = () => endGesture();
+
+    sheet.addEventListener("touchstart", onTouchStart, { passive: true });
+    sheet.addEventListener("touchmove", onTouchMove, { passive: false });
+    sheet.addEventListener("touchend", onTouchEnd, { passive: true });
+    sheet.addEventListener("touchcancel", onTouchEnd, { passive: true });
+    return () => {
+      sheet.removeEventListener("touchstart", onTouchStart);
+      sheet.removeEventListener("touchmove", onTouchMove);
+      sheet.removeEventListener("touchend", onTouchEnd);
+      sheet.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [armPress, commitDrag, dragMove, moveDrag, trackVelocity, endGesture]);
+
+  // Pointer (mouse/pen) drag for desktop, where there's no native touch scroll
+  // to hand off from. Touch goes through the listeners above. Window listeners
+  // with no pointer capture so a tap still fires the handle button's click.
+  const handlePointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      if (e.pointerType === "touch") return;
+      const list = olRef.current;
+      if (list && list.contains(e.target as Node) && list.scrollTop > 0) return;
+      armPress(e.clientY, e.timeStamp);
+      const onMove = (ev: PointerEvent) => {
+        dragMove(ev.clientY, ev.timeStamp);
+      };
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+        endGesture();
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
     },
-    [snap, onSnapChange, animationControls],
+    [armPress, dragMove, endGesture],
   );
 
   const handleToggle = useCallback(() => {
     onSnapChange(snap === "peek" ? "full" : "peek");
   }, [snap, onSnapChange]);
 
-  const olRef = useRef<HTMLOListElement | null>(null);
-
-  // Drag starts from anywhere on the sheet, except yield to the list's
-  // native scroll while it's scrolled away from the top.
-  const handlePointerDown = useCallback(
-    (e: PointerEvent) => {
-      const ol = olRef.current;
-      if (ol && ol.contains(e.target as Node) && ol.scrollTop > 0) return;
-      dragControls.start(e);
+  // open is pinned true to keep the sheet mounted for hidden<->visible
+  // animation; Escape collapses to closed instead of unmounting.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) onSnapChange("closed");
     },
-    [dragControls],
+    [onSnapChange],
   );
 
   const prevSnapRef = useRef(snap);
@@ -183,22 +420,17 @@ export function ChartSheet({
         aria-describedby={undefined}
         onInteractOutside={(e) => e.preventDefault()}
       >
-        <motion.div
+        <div
+          ref={sheetRef}
           data-snap={snap}
           data-testid="chart-sheet"
-          drag="y"
-          dragListener={false}
-          dragControls={dragControls}
-          dragMomentum={false}
-          dragElastic={0.2}
-          initial={{ y: SNAP_Y[snap] }}
-          animate={animationControls}
-          transition={{ type: "spring", damping: 30, stiffness: 300 }}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
           onPointerDown={handlePointerDown}
-          style={hasMiniPlayer ? SHEET_STYLE_WITH_MINI : SHEET_STYLE_NO_MINI}
-          className="bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 flex flex-col rounded-t-2xl border-t"
+          style={{
+            ...(hasMiniPlayer ? SHEET_STYLE_WITH_MINI : SHEET_STYLE_NO_MINI),
+            transform: `translateY(${SNAP_Y[initialSnap]})`,
+            willChange: "transform",
+          }}
+          className="group bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 flex flex-col rounded-t-2xl border-t"
         >
           <div className="shrink-0 touch-none">
             <button
@@ -211,11 +443,14 @@ export function ChartSheet({
               {country.name}
             </Dialog.Title>
           </div>
+          {/* Native list scroll is enabled only at full (touch-pan-y); at the
+              partial snaps a vertical drag drives the sheet instead, so the list
+              is touch-none there. */}
           <ol
             key={countryCode}
             ref={olRef}
             data-peek={(snap === "peek" && !isDragging) || undefined}
-            className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
+            className="min-h-0 flex-1 touch-none overflow-y-auto overscroll-y-contain px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] group-data-[snap=full]:touch-pan-y data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
           >
             {country.tracks.map((track) => (
               <TrackRow
@@ -225,7 +460,7 @@ export function ChartSheet({
               />
             ))}
           </ol>
-        </motion.div>
+        </div>
       </Dialog.Content>
     </Dialog.Root>
   );


### PR DESCRIPTION
## Summary

At `full`, dragging the scrolled list body down now scrolls it to the top and continues into a sheet collapse in one continuous finger motion, instead of needing a second touch. Replaces motion's `drag`/`dragControls` with a hand-rolled direct-transform controller across all four snaps (full/peek/closed/hidden).

## Behavior

- **Touch:** a non-passive `touchmove` listener watches the gesture. At `full` the list scrolls natively; once at the top, a continued downward pull hands off to a sheet drag (baseline reset, no jump). Release settles to the nearest snap by velocity projection, one step at a time.
- **Peek and below:** a body drag moves the sheet (up expands, down collapses); the list is not independently touch-scrollable there. This matches the locked iOS Google Maps target in #53 ("expands first, then scrolls once full").
- **Desktop:** mouse/pen drag is preserved (the issue notes it already worked) via a separate pointer path; the wheel still scrolls the list.

## Implementation notes

- Transform is driven directly on the node (`style.transform`); a MotionValue binding did not apply reliably mid-gesture on iOS. Per-frame gesture state lives in refs (no re-render); only gesture start/end touch React state.
- Settle is a CSS transition. The mini-player offset, `data-[peek]` clamp, `overscroll-y-contain` (from #81), scroll-into-view, and the Radix `Dialog` wrapper are all preserved.
- A 4px threshold keeps a handle tap from flickering the list clamp; a guard ignores secondary touches mid-drag.

## Verification

- Device-tested on iOS (Chrome) against the checklist in #53: the hand-off, peek↔full, full→closed, mini-player present and absent, rubber-band, no pull-to-refresh, and scroll-into-view all clear.
- Local: typecheck, lint, format, 199 tests, and build green.

## Tests

Replaced the `dragControls`-mock tests (that mechanism is gone) with pointer-drag tests for the desktop path. The touch hand-off is device-verified, since non-passive listeners and layout are not modeled in jsdom.

Closes #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sheet drag gesture tests with improved threshold assertions and snap-transition validation

* **Refactor**
  * Reimplemented sheet drag mechanics for enhanced gesture responsiveness
  * Improved threshold detection and snap behavior for both touch and pointer input
  * Better integration with list scrolling interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->