### PR TITLE
docs(context): pin global Phase numbering and V2/Phase 7 notation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,5 +9,5 @@ A sequential release scope: what's in scope when the project declares itself don
 _Avoid_: generation; milestone (a GitHub milestone tracks a Phase, not a Version); reserving V2 as a catch-all "someday" bucket.
 
 **Phase (`phase-1`, `phase-2`, …)**:
-A themed band of work on the path to a Version, tracked as a GitHub milestone and closed with an annotated git tag `phase-N`. A Phase bundles the several PRs that share one theme (e.g. `phase-4` = the 3D globe; `phase-5` = globe to sheet integration + V1 launch polish). It is not a single PR and not a time window. Multiple Phases compose into a Version (Phases 1 to 6 compose V1).
-_Avoid_: stage, iteration, sprint; equating a Phase with a single PR.
+A themed band of work on the path to a Version, tracked as a GitHub milestone and closed with an annotated git tag `phase-N`. A Phase bundles the several PRs that share one theme (e.g. `phase-4` = the 3D globe; `phase-5` = globe to sheet integration + V1 launch polish). It is not a single PR and not a time window. Multiple Phases compose into a Version (Phases 1 to 6 compose V1). Phase numbers run as one global counter that never resets across Versions; a Version opens at whatever the next number is (V2 opens at Phase 7). Scope a Phase to its Version with path notation, the container on the left: `V2/Phase 7`, read "Phase 7 within V2".
+_Avoid_: stage, iteration, sprint; equating a Phase with a single PR; resetting Phase numbers per Version; the `·` separator, which reads as two co-equal labels rather than containment.


### PR DESCRIPTION
## Why

The glossary said Phases compose into a Version but left two things implicit: whether Phase numbers reset per Version, and how to write a Phase scoped to its Version. This pins both so naming stops drifting as V2 work begins.

## What

- Phase numbers are one global counter that never resets across Versions (V2 opens at Phase 7).
- Canonical scoped form is the path notation `V2/Phase 7`, left-to-right mirroring container-to-contained.
- The `·` separator goes on the _Avoid_ line: it reads as two co-equal labels rather than containment.

## Test plan

Docs-only change to `CONTEXT.md`. Pre-commit ran prettier + typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Phase glossary entry with improved terminology guidance, Phase numbering conventions across versions, and updated best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->