### PR TITLE
feat(player): add a volume slider with mute toggle

### DIFF
--- a/docs/adr/0006-web-audio-graph-for-volume.md
+++ b/docs/adr/0006-web-audio-graph-for-volume.md
@@ -1,0 +1,49 @@
+# ADR-0006: Web Audio graph for volume control
+
+**Status:** Accepted (2026-06-13)
+
+## Context
+
+v1.1.0 adds a volume slider to the mini player (#84). The obvious binding, `HTMLMediaElement.volume`, is a dead control on the platform that matters most. On iOS, Apple reserves the audio level to the hardware buttons: per the Safari HTML5 Audio and Video Guide, the volume property "is not settable in JavaScript" and reading it "always returns 1." A slider wired to `element.volume` would silently no-op on every iPhone.
+
+Options weighed for a cross-platform volume control:
+
+- **`HTMLMediaElement.volume`** — one line and honored on desktop, but inert on iOS. Rejected: it fails the primary target.
+- **Web Audio `GainNode`** — route the `<audio>` element through an `AudioContext` and scale output with a gain node, which iOS honors. Chosen.
+
+## Decision
+
+Volume drives a Web Audio `GainNode`. The browser engine (`src/lib/audio-engine.ts`) builds one graph at construction:
+
+```
+new Audio() → AudioContext → createMediaElementSource → GainNode → destination
+```
+
+- The element gets `crossOrigin = "anonymous"` before `src`, so a cross-origin preview flows through Web Audio without the silent-output penalty.
+- `createMediaElementSource` is once-per-element, so the source binds to the element here; a track switch reassigns `element.src` and never re-wires the graph.
+- `setVolume(value)` writes `gain.gain.value`; the store's `volume` (default 1, range 0–1, no amplification above 1) stays the source of truth.
+- `context.resume()` is folded into `play()`: a suspended context is silence once the element is routed through it, and iOS only starts audio inside a play gesture.
+
+**Mute is `gain → 0`**, and the slider restores the last audible level on unmute (`muted === (volume === 0)`). It reuses the working gain path instead of `element.muted`, which carries the same iOS read-only doubt once the element is routed through `createMediaElementSource`.
+
+### Why a factory seam over Web Audio in the store
+
+jsdom has no `AudioContext`, so constructing the graph inside the store would break its unit tests under Vitest. The graph sits behind an `AudioEngine` interface built by `createBrowserAudioEngine`, and `createAudioStore(factory)` injects a fake in tests, extending the DI factory of ADR-0003. The store stays pure and environment-agnostic; only the browser implementation touches Web Audio.
+
+## Consequences
+
+**Positive**
+
+- Volume works on iOS, the one platform `element.volume` silently drops.
+- The graph has room to grow: a visualizer's analyser node splices into the same `source → gain → destination` chain.
+- The `AudioEngine` seam keeps store tests off Web Audio, needing only a small hand-rolled fake.
+
+**Negative**
+
+- An `AudioContext` per engine is heavier than a bare element and is bound by the browser's gesture-to-start rule, handled by resuming inside `play()`.
+- Volume lives in two synced places, the store's `volume` and the node's `gain.value`, reconciled only through `setVolume`. A future direct write to either would desync them.
+
+**Neutral**
+
+- The range is fixed at 0–1; Web Audio could amplify above 1, but that is out of scope.
+- The seam reuses ADR-0003's DI factory, so it adds no new test pattern.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,6 +158,46 @@
     will-change: transform;
     animation: marquee-scroll var(--marquee-duration, 6s) linear infinite;
   }
+
+  /* Mini-player volume. Filled portion tracks --vol-fill (set per render); the
+     thumb is a warm-white dot. Native range so keyboard + a11y come for free. */
+  .volume-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    border-radius: var(--radius-pill);
+    background: linear-gradient(
+      to right,
+      var(--color-fg-1) var(--vol-fill, 100%),
+      rgba(245, 242, 236, 0.16) var(--vol-fill, 100%)
+    );
+    cursor: pointer;
+  }
+
+  .volume-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-fg-1);
+    box-shadow:
+      0 0 0 4px rgba(245, 242, 236, 0.05),
+      0 1px 2px rgba(0, 0, 0, 0.5);
+  }
+
+  .volume-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border: none;
+    border-radius: 50%;
+    background: var(--color-fg-1);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  }
+
+  .volume-slider:focus-visible {
+    outline: 2px solid var(--color-aurora);
+    outline-offset: 4px;
+  }
 }
 
 @keyframes eq {

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -1,21 +1,19 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
-import {
-  type AudioElementLike,
-  type AudioState,
-  createAudioStore,
-} from "@/lib/audio-store";
+import type { AudioEngine } from "@/lib/audio-engine";
+import { type AudioState, createAudioStore } from "@/lib/audio-store";
 import type { Track } from "@/lib/chart-schema";
 import { AudioStoreContext } from "@/providers/audio-store-provider";
 
 import { TrackRow } from "./track-row";
 
-function makeMockAudio(): AudioElementLike {
+function makeMockAudio(): AudioEngine {
   return {
     src: "",
     play: vi.fn().mockResolvedValue(undefined),
     pause: vi.fn(),
+    setVolume: vi.fn(),
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
   };

--- a/src/components/icons/volume-mute.tsx
+++ b/src/components/icons/volume-mute.tsx
@@ -1,0 +1,21 @@
+import type { SVGProps } from "react";
+
+export function VolumeMuteIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M11 5 6 9H2v6h4l5 4z" />
+      <path d="m22 9-6 6" />
+      <path d="m16 9 6 6" />
+    </svg>
+  );
+}

--- a/src/components/icons/volume.tsx
+++ b/src/components/icons/volume.tsx
@@ -1,0 +1,21 @@
+import type { SVGProps } from "react";
+
+export function VolumeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M11 5 6 9H2v6h4l5 4z" />
+      <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+      <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+    </svg>
+  );
+}

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -1,21 +1,19 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
-import {
-  type AudioElementLike,
-  type AudioState,
-  createAudioStore,
-} from "@/lib/audio-store";
+import type { AudioEngine } from "@/lib/audio-engine";
+import { type AudioState, createAudioStore } from "@/lib/audio-store";
 import type { Track } from "@/lib/chart-schema";
 import { AudioStoreContext } from "@/providers/audio-store-provider";
 
 import { MiniPlayer } from "./mini-player";
 
-function makeMockAudio(): AudioElementLike {
+function makeMockAudio(): AudioEngine {
   return {
     src: "",
     play: vi.fn().mockResolvedValue(undefined),
     pause: vi.fn(),
+    setVolume: vi.fn(),
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
   };
@@ -116,5 +114,11 @@ describe("MiniPlayer", () => {
     expect(
       screen.getByRole("button", { name: /pause preview of Hot Track/i }),
     ).toBeDefined();
+  });
+
+  test("renders the volume control", () => {
+    renderMiniPlayer({ onTap: vi.fn() }, { currentTrack: makeTrack() });
+
+    expect(screen.getByRole("button", { name: /volume/i })).toBeDefined();
   });
 });

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -3,6 +3,7 @@
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
 import { useOverflowMarquee } from "@/components/use-overflow-marquee";
+import { VolumeControl } from "@/components/volume-control";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface MiniPlayerProps {
@@ -67,6 +68,7 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
             </p>
           </div>
         </button>
+        <VolumeControl />
         <button
           type="button"
           onClick={() => toggle(currentTrack)}

--- a/src/components/volume-control.test.tsx
+++ b/src/components/volume-control.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { AudioEngine } from "@/lib/audio-engine";
+import { type AudioState, createAudioStore } from "@/lib/audio-store";
+import { AudioStoreContext } from "@/providers/audio-store-provider";
+
+import { VolumeControl } from "./volume-control";
+
+function makeMockAudio(): AudioEngine {
+  return {
+    src: "",
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    setVolume: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+}
+
+function renderVolumeControl(init?: Partial<AudioState>) {
+  const store = createAudioStore(() => makeMockAudio());
+  if (init) {
+    store.setState(init);
+  }
+  const utils = render(
+    <AudioStoreContext.Provider value={store}>
+      <VolumeControl />
+    </AudioStoreContext.Provider>,
+  );
+  return { ...utils, store };
+}
+
+describe("VolumeControl", () => {
+  test("renders the trigger and keeps the slider hidden until opened", () => {
+    renderVolumeControl();
+
+    expect(screen.getByRole("button", { name: /volume/i })).toBeDefined();
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  test("clicking the trigger reveals the slider", () => {
+    renderVolumeControl();
+
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    expect(screen.getByRole("slider")).toBeDefined();
+    expect(
+      screen
+        .getByRole("button", { name: /volume/i })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
+  test("the slider reflects the stored volume", () => {
+    renderVolumeControl({ volume: 0.5 });
+
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    expect((screen.getByRole("slider") as HTMLInputElement).value).toBe("0.5");
+  });
+
+  test("dragging the slider drives the volume", () => {
+    const { store } = renderVolumeControl({ volume: 1 });
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "0.3" } });
+
+    expect(store.getState().volume).toBe(0.3);
+  });
+
+  test("Escape closes the popover", () => {
+    renderVolumeControl();
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  test("a tap outside closes the popover", () => {
+    renderVolumeControl();
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  test("a second trigger tap closes the popover", () => {
+    renderVolumeControl();
+    const trigger = screen.getByRole("button", { name: /volume/i });
+    fireEvent.click(trigger);
+
+    fireEvent.click(trigger);
+
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  test("the popover includes a mute toggle", () => {
+    renderVolumeControl();
+
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    expect(screen.getByRole("button", { name: "Mute" })).toBeDefined();
+  });
+
+  test("muting drops the volume to zero", () => {
+    const { store } = renderVolumeControl({ volume: 0.6 });
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Mute" }));
+
+    expect(store.getState().volume).toBe(0);
+  });
+
+  test("unmuting restores the level held before muting", () => {
+    const { store } = renderVolumeControl({ volume: 0.6 });
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Mute" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Unmute" }));
+
+    expect(store.getState().volume).toBe(0.6);
+  });
+});

--- a/src/components/volume-control.tsx
+++ b/src/components/volume-control.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { type CSSProperties, useEffect, useRef, useState } from "react";
+
+import { VolumeIcon } from "@/components/icons/volume";
+import { VolumeMuteIcon } from "@/components/icons/volume-mute";
+import { useAudioStore } from "@/providers/audio-store-provider";
+
+export function VolumeControl() {
+  const volume = useAudioStore((s) => s.volume);
+  const setVolume = useAudioStore((s) => s.setVolume);
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const sliderRef = useRef<HTMLInputElement>(null);
+  // The level to come back to on unmute; tracks the last audible volume.
+  const lastAudibleRef = useRef(volume || 1);
+
+  // While open, dismiss on an outside tap or Escape; Escape returns focus to the
+  // trigger. Opening focuses the slider so arrow keys adjust it immediately.
+  useEffect(() => {
+    if (!open) return;
+    sliderRef.current?.focus();
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!wrapperRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    }
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  // Mute is gain 0 (the verified path), restoring the prior level on unmute.
+  const muted = volume === 0;
+  const percent = Math.round(volume * 100);
+  const Icon = muted ? VolumeMuteIcon : VolumeIcon;
+
+  // The sole path that writes volume; keeps lastAudibleRef in step.
+  function applyVolume(value: number) {
+    if (value > 0) lastAudibleRef.current = value;
+    setVolume(value);
+  }
+
+  function toggleMute() {
+    applyVolume(muted ? lastAudibleRef.current : 0);
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative shrink-0">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((isOpen) => !isOpen)}
+        aria-label="Volume"
+        aria-expanded={open}
+        aria-controls="mini-player-volume"
+        className={`focus-visible:outline-aurora flex h-10 w-10 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] ${
+          open
+            ? "bg-orbit text-fg-1"
+            : "text-fg-2 hover:bg-orbit hover:text-fg-1"
+        }`}
+      >
+        <Icon className="h-[18px] w-[18px]" />
+      </button>
+      {open ? (
+        <div
+          id="mini-player-volume"
+          className="border-fg-1/10 bg-atmos absolute right-0 bottom-[calc(100%+8px)] z-10 flex w-44 items-center gap-2.5 rounded-xl border px-3 py-2.5 shadow-md"
+        >
+          <button
+            type="button"
+            onClick={toggleMute}
+            aria-label={muted ? "Unmute" : "Mute"}
+            aria-pressed={muted}
+            className="text-fg-2 hover:text-fg-1 focus-visible:outline-aurora flex h-8 w-8 shrink-0 items-center justify-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+          <input
+            ref={sliderRef}
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={volume}
+            onChange={(event) => applyVolume(event.target.valueAsNumber)}
+            aria-label="Volume"
+            aria-valuetext={`${percent}%`}
+            className="volume-slider w-full"
+            style={{ "--vol-fill": `${percent}%` } as CSSProperties}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -1,0 +1,60 @@
+export type AudioEventType = "ended" | "error" | "play" | "pause";
+
+/**
+ * The audio output the store drives. A seam: the store stays pure and
+ * testable while the real implementation owns the browser Web Audio graph.
+ */
+export interface AudioEngine {
+  src: string;
+  play(): Promise<void>;
+  pause(): void;
+  setVolume(value: number): void;
+  addEventListener(type: AudioEventType, listener: () => void): void;
+  removeEventListener(type: AudioEventType, listener: () => void): void;
+}
+
+export type AudioEngineFactory = () => AudioEngine;
+
+/**
+ * Volume drives a Web Audio GainNode, not HTMLMediaElement.volume: iOS WebKit
+ * treats element volume as read-only (hardware-only), so routing the element
+ * through an AudioContext is the only cross-platform path. The graph is
+ * element -> source -> gain -> destination; later taps (an analyser) splice
+ * into the same chain.
+ */
+export function createBrowserAudioEngine(): AudioEngine {
+  const element = new Audio();
+  // Anonymous CORS lets the cross-origin preview flow through Web Audio without
+  // a silent-output penalty; it must be set before src.
+  element.crossOrigin = "anonymous";
+
+  const context = new AudioContext();
+  // createMediaElementSource is once-per-element; tying it to this element here
+  // means a track switch (reassigning element.src) never re-wires the graph.
+  const source = context.createMediaElementSource(element);
+  const gain = context.createGain();
+  source.connect(gain).connect(context.destination);
+
+  return {
+    get src() {
+      return element.src;
+    },
+    set src(value: string) {
+      element.src = value;
+    },
+    play: async () => {
+      // Once routed through the context, a suspended context means silence.
+      // Resume inside the play gesture (iOS only starts audio on a gesture).
+      if (context.state === "suspended") await context.resume();
+      await element.play();
+    },
+    pause: () => element.pause(),
+    setVolume: (value) => {
+      gain.gain.value = value;
+    },
+    addEventListener: (type, listener) =>
+      element.addEventListener(type, listener),
+    removeEventListener: (type, listener) =>
+      element.removeEventListener(type, listener),
+  };
+}

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -2,7 +2,8 @@ import { assert, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { Track } from "@/lib/chart-schema";
 
-import { type AudioElementLike, createAudioStore } from "./audio-store";
+import type { AudioEngine } from "./audio-engine";
+import { createAudioStore } from "./audio-store";
 import {
   clearNowPlaying,
   setActionHandlers,
@@ -19,7 +20,7 @@ vi.mock("./media-session", () => ({
 
 type EventType = "ended" | "error" | "play" | "pause";
 
-interface MockAudio extends AudioElementLike {
+interface MockAudio extends AudioEngine {
   _trigger: (event: EventType) => void;
   _srcWrites: number;
 }
@@ -38,6 +39,7 @@ function makeMockAudio(): MockAudio {
     _srcWrites: 0,
     play: vi.fn().mockResolvedValue(undefined),
     pause: vi.fn(),
+    setVolume: vi.fn(),
     addEventListener: vi.fn((type: EventType, listener: () => void) => {
       (listeners[type] ??= []).push(listener);
     }),
@@ -73,6 +75,40 @@ describe("createAudioStore", () => {
     expect(store.getState().currentTrack).toBeNull();
     expect(store.getState().isPlaying).toBe(false);
     expect(store.getState().currentCountryCode).toBeNull();
+  });
+
+  test("initial volume is full", () => {
+    const store = createAudioStore(() => makeMockAudio());
+
+    expect(store.getState().volume).toBe(1);
+  });
+
+  test("setVolume updates the volume state", () => {
+    const store = createAudioStore(() => makeMockAudio());
+
+    store.getState().setVolume(0.4);
+
+    expect(store.getState().volume).toBe(0.4);
+  });
+
+  test("setVolume drives the audio engine gain", () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+
+    store.getState().setVolume(0.4);
+
+    expect(audio.setVolume).toHaveBeenCalledWith(0.4);
+  });
+
+  test("volume holds across a track switch", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    store.getState().setVolume(0.3);
+
+    store
+      .getState()
+      .toggle(makeTrack({ previewUrl: "https://example.com/next.m4a" }));
+
+    expect(store.getState().volume).toBe(0.3);
   });
 
   test("toggle plays a new track", () => {

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -42,7 +42,7 @@ export function createAudioStore(
     function getEngine(): AudioEngine {
       if (engine) return engine;
       engine = factory();
-      // Layer 1 (S5): sync store with browser-initiated play/pause.
+      // Layer 1: sync store with browser-initiated play/pause.
       // Covers background-tab auto-pause, AirPods disconnect, media keys.
       // Each transition also mirrors to the OS so the now-playing UI tracks
       // live state (drives the Dynamic Island waveform), browser-driven or not.

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -1,6 +1,11 @@
 import * as Sentry from "@sentry/nextjs";
 import { createStore } from "zustand/vanilla";
 
+import {
+  type AudioEngine,
+  type AudioEngineFactory,
+  createBrowserAudioEngine,
+} from "@/lib/audio-engine";
 import type { Track } from "@/lib/chart-schema";
 import {
   clearNowPlaying,
@@ -8,24 +13,6 @@ import {
   setNowPlaying,
   setPlaybackState,
 } from "@/lib/media-session";
-
-export interface AudioElementLike {
-  src: string;
-  play(): Promise<void>;
-  pause(): void;
-  addEventListener(
-    type: "ended" | "error" | "play" | "pause",
-    listener: () => void,
-  ): void;
-  removeEventListener(
-    type: "ended" | "error" | "play" | "pause",
-    listener: () => void,
-  ): void;
-}
-
-export type AudioElementFactory = () => AudioElementLike;
-
-const defaultAudioFactory: AudioElementFactory = () => new Audio();
 
 export interface AudioError {
   previewUrl: string | null;
@@ -35,9 +22,11 @@ export interface AudioState {
   currentTrack: Track | null;
   currentCountryCode: string | null;
   isPlaying: boolean;
+  volume: number;
   lastError: AudioError | null;
   endedSignal: number;
   toggle: (track: Track, countryCode?: string) => void;
+  setVolume: (value: number) => void;
   pause: () => void;
   stop: () => void;
 }
@@ -45,34 +34,34 @@ export interface AudioState {
 export type AudioStoreApi = ReturnType<typeof createAudioStore>;
 
 export function createAudioStore(
-  factory: AudioElementFactory = defaultAudioFactory,
+  factory: AudioEngineFactory = createBrowserAudioEngine,
 ) {
-  let audio: AudioElementLike | null = null;
+  let engine: AudioEngine | null = null;
 
   return createStore<AudioState>()((set, get) => {
-    function getAudio(): AudioElementLike {
-      if (audio) return audio;
-      audio = factory();
+    function getEngine(): AudioEngine {
+      if (engine) return engine;
+      engine = factory();
       // Layer 1 (S5): sync store with browser-initiated play/pause.
       // Covers background-tab auto-pause, AirPods disconnect, media keys.
       // Each transition also mirrors to the OS so the now-playing UI tracks
       // live state (drives the Dynamic Island waveform), browser-driven or not.
-      audio.addEventListener("play", () => {
+      engine.addEventListener("play", () => {
         set({ isPlaying: true });
         setPlaybackState("playing");
       });
-      audio.addEventListener("pause", () => {
+      engine.addEventListener("pause", () => {
         set({ isPlaying: false });
         setPlaybackState("paused");
       });
-      audio.addEventListener("ended", () => {
+      engine.addEventListener("ended", () => {
         set((state) => ({
           isPlaying: false,
           endedSignal: state.endedSignal + 1,
         }));
         setPlaybackState("none");
       });
-      audio.addEventListener("error", () => {
+      engine.addEventListener("error", () => {
         const previewUrl = get().currentTrack?.previewUrl ?? null;
         set({ isPlaying: false, lastError: { previewUrl } });
         Sentry.addBreadcrumb({
@@ -91,18 +80,19 @@ export function createAudioStore(
         },
         pause: () => get().pause(),
       });
-      return audio;
+      return engine;
     }
 
     return {
       currentTrack: null,
       currentCountryCode: null,
       isPlaying: false,
+      volume: 1,
       lastError: null,
       endedSignal: 0,
       toggle: (track, countryCode) => {
         const state = get();
-        const a = getAudio();
+        const a = getEngine();
         const isCurrent = state.currentTrack?.previewUrl === track.previewUrl;
         if (isCurrent && state.isPlaying) {
           a.pause();
@@ -126,14 +116,18 @@ export function createAudioStore(
           lastError: null,
         });
       },
+      setVolume: (value) => {
+        getEngine().setVolume(value);
+        set({ volume: value });
+      },
       pause: () => {
         // Pause without clearing currentTrack, used on deeplink handoff so the
         // mini player stays (resumable) and no `ended` fires (auto-advance halts).
-        getAudio().pause();
+        getEngine().pause();
         set({ isPlaying: false });
       },
       stop: () => {
-        const a = getAudio();
+        const a = getEngine();
         a.pause();
         clearNowPlaying();
         set({


### PR DESCRIPTION
## Summary

Adds a volume control to the mini player: a speaker button opens a popover with a slider and a mute toggle. Volume drives a Web Audio `GainNode`, not `HTMLMediaElement.volume`, which iOS treats as read-only (returns 1, not settable). The `<audio>` element is routed `AudioContext → createMediaElementSource → GainNode → destination`, created once per element so a track switch never re-wires the graph. Rationale in **ADR-0006**.

Mute is `gain → 0` with restore of the last audible level, reusing the verified gain path rather than the untrustworthy `element.muted`. Range is 0–1 (no boost above 1). The graph leaves a seam for #38's AnalyserNode to tap the same chain.

Closes #84

## Acceptance criteria

- [x] Slider changes loudness on desktop AND iOS Safari — GainNode path; iOS leg device-verified on the #84 probe (2026-06-08), and this build uses that mechanism
- [x] `createMediaElementSource` runs once per element — built at construction; a track switch only reassigns `element.src`
- [x] Volume holds across track changes — `volume` is store state on the one persistent graph
- [x] No regression to play/pause, MediaSession, autoplay-on-tap — covered by the store suite; `context.resume()` folded into `play()`
- [x] Graph seam for #38's AnalyserNode — `source → gain → destination`

## Test plan

- `pnpm typecheck` — clean
- `pnpm exec vitest run` — 216 passing (10 VolumeControl + store volume tests)
- `pnpm lint` / `pnpm build` — clean / OK
- iOS GainNode loudness path: #84 device probe, 2026-06-08 (not re-tested on this build)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added volume slider control to the mini-player for adjusting playback volume
  * Mute/unmute button included for quick audio toggle
  * Volume control now fully functional on iOS and other platforms (previously unavailable)
  * Visual volume indicator displays current level with dedicated mute icon

* **Documentation**
  * Architecture decision documented for volume control implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->