### PR TITLE
chore: release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## v1.1.0 — Audio depth

### Added
- Mini-player volume slider with a mute toggle, driven by a Web Audio `GainNode` so it works on iOS, where `HTMLMediaElement.volume` is read-only. #84 (ADR-0006)

### Security
- Next.js upgraded to 16.2.9 for security patches. #87

### Internal
- Roadmap model: GitHub milestones are semver Versions, not Phases (ADR-0005). #86, #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->