### PR TITLE
feat(schema): add nullable commentary field for the context card

### DIFF
--- a/src/lib/__fixtures__/charts.json
+++ b/src/lib/__fixtures__/charts.json
@@ -12,7 +12,17 @@
           "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/kr-01.m4a",
           "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/kr-01.jpg/600x600bb.jpg",
           "appleUrl": "https://music.apple.com/kr/album/example-album/1700000001?i=1700000002",
-          "spotifySearchUrl": "https://open.spotify.com/search/%EC%86%8C%EB%AC%B8%EC%9D%98%20%EB%82%99%EC%9B%90%20%EC%95%85%EB%AE%A4"
+          "spotifySearchUrl": "https://open.spotify.com/search/%EC%86%8C%EB%AC%B8%EC%9D%98%20%EB%82%99%EC%9B%90%20%EC%95%85%EB%AE%A4",
+          "commentary": {
+            "lead": "A new entry climbing fast this week.",
+            "detail": "Short context about the track's rise.",
+            "tag": "new entry",
+            "sources": [
+              "https://example.com/source-a",
+              "https://example.com/source-b"
+            ],
+            "generatedAt": "2026-04-25T03:00:00Z"
+          }
         },
         {
           "rank": 2,
@@ -45,7 +55,12 @@
           "previewUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioFixture/v1/us-01.m4a",
           "artworkUrl": "https://is1-ssl.mzstatic.com/image/thumb/Fixture/us-01.jpg/600x600bb.jpg",
           "appleUrl": "https://music.apple.com/us/album/example-album/1700000101?i=1700000102",
-          "spotifySearchUrl": "https://open.spotify.com/search/Espresso%20Sabrina%20Carpenter"
+          "spotifySearchUrl": "https://open.spotify.com/search/Espresso%20Sabrina%20Carpenter",
+          "commentary": {
+            "lead": "A long-running chart favorite.",
+            "sources": ["https://example.com/source-c"],
+            "generatedAt": "2026-04-25T03:00:00Z"
+          }
         },
         {
           "rank": 2,

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -32,6 +32,62 @@ test("ChartFileSchema accepts null previewUrl (placeholder for lookup-failed tra
   expect(() => ChartFileSchema.parse(withNullPreview)).not.toThrow();
 });
 
+test("ChartFileSchema accepts null commentary (track skipped or failed generation)", () => {
+  const withNullCommentary = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+            commentary: null,
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withNullCommentary)).not.toThrow();
+});
+
+test("ChartFileSchema rejects commentary missing the required lead", () => {
+  const withBadCommentary = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+            commentary: {
+              detail: "Has detail but no lead.",
+              sources: ["https://example.com/a"],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withBadCommentary)).toThrow();
+});
+
 test("ChartFileSchema rejects an empty countries record", () => {
   const empty = {
     lastUpdated: "2026-05-16T00:00:00.000Z",

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -88,6 +88,36 @@ test("ChartFileSchema rejects commentary missing the required lead", () => {
   expect(() => ChartFileSchema.parse(withBadCommentary)).toThrow();
 });
 
+test("ChartFileSchema rejects commentary with an empty sources array", () => {
+  const withEmptySources = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+            commentary: {
+              lead: "Has a lead but no sources.",
+              sources: [],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withEmptySources)).toThrow();
+});
+
 test("ChartFileSchema rejects an empty countries record", () => {
   const empty = {
     lastUpdated: "2026-05-16T00:00:00.000Z",

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+const CommentarySchema = z.object({
+  lead: z.string().min(1),
+  detail: z.string().min(1).optional(),
+  tag: z.string().min(1).optional(),
+  sources: z.array(z.url()).min(1),
+  generatedAt: z.iso.datetime(),
+});
+
 const TrackSchema = z.object({
   rank: z.number().int().min(1).max(25),
   name: z.string().min(1),
@@ -8,6 +16,7 @@ const TrackSchema = z.object({
   artworkUrl: z.url(),
   appleUrl: z.url(),
   spotifySearchUrl: z.url(),
+  commentary: CommentarySchema.nullable().optional(),
 });
 
 const CountrySchema = z.object({
@@ -25,6 +34,7 @@ export const ChartFileSchema = z.object({
     }),
 });
 
+export type Commentary = z.infer<typeof CommentarySchema>;
 export type Track = z.infer<typeof TrackSchema>;
 export type Country = z.infer<typeof CountrySchema>;
 export type ChartFile = z.infer<typeof ChartFileSchema>;


### PR DESCRIPTION
Adds an optional, nullable `commentary` object to `TrackSchema` (`{ lead, detail?, tag?, sources[], generatedAt } | null`) as the data contract for the song context card. No UI or generation yet.

**Why nullable + optional:** old cached data has no `commentary`, and skipped/failed tracks carry `null`; both must validate, mirroring the `previewUrl` carry-forward contract.

**Verification:** typecheck, lint, test (218 passing), build all green locally.

Closes #94. Part of #90.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track commentary metadata now supported, including lead information, details, tags, and sources.

* **Tests**
  * Added test coverage for commentary field validation and null handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->