### PR TITLE
feat(commentary): add refinement workflow and crawl merge

### DIFF
--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -1,0 +1,45 @@
+# Commentary refinement playbook
+
+How to write and publish the per-track context blurbs ("commentary") shown on the chart card. Commentary is curated out of band in human-reviewed passes, never by the crawl (see [ADR-0007](adr/0007-out-of-band-human-curated-commentary.md)). This is the runbook a pass follows.
+
+## What commentary is
+
+A short, grounded note about a charting track: what the song is about and why it is charting in that market. Structured, not a paragraph:
+
+- `lead` (required): a one-line conclusion, the first thing a reader sees.
+- `detail` (optional): a sentence or two of support, shown when the card expands.
+- `tag` (optional): a short keyword, e.g. "new entry" or "viral".
+- `sources` (required): the URLs the claims rest on.
+- `generatedAt` (required): ISO timestamp of when the blurb was written.
+
+It is never the song's lyrics. Commentary describes a song; it does not reproduce its words. Full-lyric display needs a publisher license we do not hold.
+
+## Per-pass steps
+
+1. **Get the worklist.** Run `pnpm commentary:todo`. It lists significant movers that have no blurb yet, deduped across countries, so a track is written once and reused everywhere it charts. The list is pre-filtered; work straight down it.
+2. **Research each track** under the source policy below. Establish what the song is and why it is moving. If two credible sources do not support a "why it is charting" claim, keep the blurb to what the song is, or skip the track.
+3. **Write the entry** in the style below, into a candidate file keyed by the worklist key (`pnpm commentary:todo --json` emits the keys).
+4. **Read every blurb** before publishing: no reproduced lyrics, claims match the sources, no overstatement. This read-through is the real guard; the lint is only a backstop.
+5. **Publish.** Run `pnpm commentary:publish <file>`. It hard-blocks on the schema and the no-lyric lint, backs up the live store, then uploads. A blocked publish uploads nothing.
+6. **Spot-check** the card on the site.
+
+## Source-authority policy
+
+Ground every claim. A "why it is charting" claim needs at least two credible sources; below that, stay conservative or write nothing.
+
+**Use:** official artist and label channels; established music press (Billboard, Pitchfork, Rolling Stone, NPR, The Guardian, and equivalents); Wikipedia where it cites primary sources; Genius for credits only. For a non-English track, prefer reputable sources from the track's own market.
+
+**Avoid:** gossip aggregators, fan wikis, and lyric or SEO content farms. Never source a claim from a lyrics site.
+
+## Writing style
+
+Card copy follows the house writing principles, tuned for a fast read:
+
+- **Lead with the point.** The `lead` states the conclusion, not a wind-up.
+- **Plain and concise.** One lead sentence plus brief support; cut filler and hedges.
+- **No em-dashes.** Use a colon, a semicolon, or a period.
+- **No reproduced lyrics.** Do not wrap a long phrase or a lyric-like line in double quotes: the lint treats a long double-quoted run as a lyric signal and will block it. Refer to a title bare.
+
+## The no-lyric guard
+
+Publishing runs a deterministic lint that flags lyric-shaped content: long double-quoted runs, several short enjambed lines, and repeated lines. It is tuned to flag rather than miss, so it can flag a legitimate long quote or a list. When that happens, reword the copy or confirm it carries no lyrics and adjust. The lint cannot prove the absence of lyrics, which is why the read-through in step 4 is the load-bearing check.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:ci": "vitest --watch=false --reporter=default --reporter=github-actions",
     "crawl": "tsx --env-file=.env.local scripts/crawl/main.ts",
     "crawl:cron": "tsx scripts/crawl/cron.ts",
+    "commentary:todo": "tsx --env-file=.env.local scripts/commentary/todo.ts",
+    "commentary:publish": "tsx --env-file=.env.local scripts/commentary/publish.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "vitest";
+
+import { commentaryKey } from "../../src/lib/commentary-store";
+
+import { fetchCommentaryStore } from "./fetch-commentary";
+
+const URL = "https://blob/commentary/v1/commentary.json";
+
+function validStore() {
+  return {
+    [commentaryKey("en", "Artist", "Song")]: {
+      lead: "A blurb about the song.",
+      sources: ["https://example.com/a"],
+      generatedAt: "2026-05-16T00:00:00.000Z",
+    },
+  };
+}
+
+function fakeFetch(response: {
+  ok?: boolean;
+  status?: number;
+  body: string;
+}): typeof fetch {
+  return (async () =>
+    new Response(response.body, {
+      status: response.status ?? (response.ok === false ? 500 : 200),
+    })) as typeof fetch;
+}
+
+test("returns the parsed store on a valid response", async () => {
+  const store = validStore();
+
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ body: JSON.stringify(store) }),
+  );
+
+  expect(result).toEqual(store);
+});
+
+test("returns null on a non-OK response", async () => {
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ ok: false, status: 404, body: "Not Found" }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns null on invalid JSON", async () => {
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ body: "<html>nope</html>" }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns null on schema mismatch", async () => {
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ body: JSON.stringify({ "en:a|b": { lead: "" } }) }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns null when fetch rejects", async () => {
+  const failingFetch: typeof fetch = (async () => {
+    throw new TypeError("network down");
+  }) as typeof fetch;
+
+  const result = await fetchCommentaryStore(URL, failingFetch);
+
+  expect(result).toBeNull();
+});

--- a/scripts/commentary/fetch-commentary.ts
+++ b/scripts/commentary/fetch-commentary.ts
@@ -1,0 +1,24 @@
+import {
+  CommentaryStoreSchema,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
+
+/**
+ * Reads the published commentary store for the crawl to bake in and for the
+ * worklist to diff against. Degrades to null on any failure — commentary is
+ * additive and must never abort the crawl (mirrors the carry-forward read).
+ */
+export async function fetchCommentaryStore(
+  url: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<CommentaryStore | null> {
+  try {
+    const res = await fetchImpl(url);
+    if (!res.ok) return null;
+    const json: unknown = await res.json();
+    const parsed = CommentaryStoreSchema.safeParse(json);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/commentary/prepublish.test.ts
+++ b/scripts/commentary/prepublish.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "vitest";
+
+import { commentaryKey } from "../../src/lib/commentary-store";
+
+import { prepublishCheck } from "./prepublish";
+
+const KEY = commentaryKey("en", "Artist A", "Song A");
+
+function validEntry() {
+  return {
+    lead: "A clean blurb about the song.",
+    sources: ["https://example.com/a"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+}
+
+test("accepts a valid, lyric-free store", () => {
+  const store = { [KEY]: validEntry() };
+
+  const result = prepublishCheck(store);
+
+  expect(result.ok).toBe(true);
+  if (result.ok) expect(result.store).toEqual(store);
+});
+
+test("blocks a schema-invalid entry", () => {
+  const store = { [KEY]: { ...validEntry(), sources: [] } };
+
+  const result = prepublishCheck(store);
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.errors.some((e) => e.startsWith("schema"))).toBe(true);
+  }
+});
+
+test("blocks an entry that trips the no-lyric lint", () => {
+  const store = {
+    [KEY]: {
+      ...validEntry(),
+      detail: 'It repeats "na na na la la oh oh my my my" in the hook.',
+    },
+  };
+
+  const result = prepublishCheck(store);
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.errors.some((e) => e.startsWith("no-lyric"))).toBe(true);
+  }
+});

--- a/scripts/commentary/prepublish.ts
+++ b/scripts/commentary/prepublish.ts
@@ -1,0 +1,37 @@
+import {
+  CommentaryStoreSchema,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
+import { lintCommentary } from "../../src/lib/no-lyric-lint";
+
+/**
+ * The publish gate: a candidate store must parse to the schema AND clear the
+ * no-lyric lint before it can go live. Either failure hard-blocks the upload
+ * (ADR-0007). Pure, so the gate is tested without touching the blob store.
+ */
+export type PrepublishResult =
+  | { ok: true; store: CommentaryStore }
+  | { ok: false; errors: string[] };
+
+export function prepublishCheck(raw: unknown): PrepublishResult {
+  const parsed = CommentaryStoreSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map(
+        (issue) =>
+          `schema: ${issue.path.join(".") || "(root)"} — ${issue.message}`,
+      ),
+    };
+  }
+
+  const errors: string[] = [];
+  for (const [key, entry] of Object.entries(parsed.data)) {
+    for (const risk of lintCommentary(entry)) {
+      errors.push(`no-lyric (${risk.rule}) in "${key}": ${risk.excerpt}`);
+    }
+  }
+  if (errors.length > 0) return { ok: false, errors };
+
+  return { ok: true, store: parsed.data };
+}

--- a/scripts/commentary/publish.ts
+++ b/scripts/commentary/publish.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+
+import { prepublishCheck } from "./prepublish";
+import { backupCommentary, uploadCommentary } from "./upload-commentary";
+
+// Validates a candidate commentary file, hard-blocks on the schema or the
+// no-lyric lint, then publishes it. See docs/commentary-playbook.md.
+
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  throw new Error(
+    "BLOB_READ_WRITE_TOKEN missing. Run via: pnpm commentary:publish <file>.",
+  );
+}
+
+const file = process.argv[2];
+if (!file) {
+  throw new Error("Usage: pnpm commentary:publish <candidate.json>");
+}
+
+const raw: unknown = JSON.parse(await readFile(file, "utf8"));
+const checked = prepublishCheck(raw);
+if (!checked.ok) {
+  console.error(`Publish blocked (${checked.errors.length} issue(s)):`);
+  for (const error of checked.errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+// Snapshot the live store before overwriting, so a bad publish can be undone.
+// Absent on the first publish (nothing to back up yet).
+const previousUrl = process.env.COMMENTARY_BLOB_URL;
+if (previousUrl) {
+  const backupUrl = await backupCommentary(
+    previousUrl,
+    new Date().toISOString(),
+  );
+  console.log(`Backed up current store -> ${backupUrl}`);
+}
+
+const url = await uploadCommentary(checked.store);
+console.log(
+  `Published ${Object.keys(checked.store).length} entr(ies) -> ${url}`,
+);

--- a/scripts/commentary/todo.ts
+++ b/scripts/commentary/todo.ts
@@ -1,0 +1,43 @@
+import { fetchPublishedCharts } from "../crawl/published-charts";
+
+import { fetchCommentaryStore } from "./fetch-commentary";
+import { computeWorklist } from "./worklist";
+
+// Prints the tracks a refinement pass still needs to write: significant movers
+// without a blurb yet, deduped across countries. See docs/commentary-playbook.md.
+
+const chartsUrl = process.env.CHARTS_BLOB_URL;
+if (!chartsUrl) {
+  throw new Error(
+    "CHARTS_BLOB_URL missing. Set it to the published charts.json URL.",
+  );
+}
+
+const current = await fetchPublishedCharts(chartsUrl);
+if (!current) {
+  throw new Error(`Could not read published charts from ${chartsUrl}.`);
+}
+
+// Optional prior snapshot. Without it, the worklist falls back to absolute
+// prominence (top-ranked tracks) instead of rank movement.
+const prevUrl = process.env.CHARTS_PREV_BLOB_URL;
+const previous = prevUrl ? await fetchPublishedCharts(prevUrl) : null;
+
+const commentaryUrl = process.env.COMMENTARY_BLOB_URL;
+const commentary = commentaryUrl
+  ? ((await fetchCommentaryStore(commentaryUrl)) ?? {})
+  : {};
+
+const worklist = computeWorklist({ current, previous, commentary });
+
+if (process.argv.includes("--json")) {
+  console.log(JSON.stringify(worklist, null, 2));
+} else {
+  console.log(`${worklist.length} track(s) to write:\n`);
+  for (const item of worklist) {
+    const where = item.countries.map((c) => `${c.cc}#${c.rank}`).join(", ");
+    console.log(`  [${item.reason}] ${item.name} by ${item.artist}`);
+    console.log(`      key: ${item.key}`);
+    console.log(`      best rank ${item.bestRank} · ${where}\n`);
+  }
+}

--- a/scripts/commentary/upload-commentary.ts
+++ b/scripts/commentary/upload-commentary.ts
@@ -1,0 +1,40 @@
+import { copy, put } from "@vercel/blob";
+
+import type { CommentaryStore } from "../../src/lib/commentary-store";
+
+export const COMMENTARY_PATHNAME = "commentary/v1/commentary.json";
+
+export async function uploadCommentary(
+  store: CommentaryStore,
+): Promise<string> {
+  const body = JSON.stringify(store, null, 2);
+  const result = await put(COMMENTARY_PATHNAME, body, {
+    access: "public",
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    contentType: "application/json",
+    cacheControlMaxAge: 60,
+  });
+  return result.url;
+}
+
+/**
+ * Snapshots the live store to a timestamped path before an overwrite, so a bad
+ * publish can be rolled back by reading the backup.
+ */
+export async function backupCommentary(
+  fromUrl: string,
+  timestamp: string,
+): Promise<string> {
+  const safe = timestamp.replace(/[:.]/g, "-");
+  const result = await copy(
+    fromUrl,
+    `commentary/v1/backups/commentary-${safe}.json`,
+    {
+      access: "public",
+      addRandomSuffix: false,
+      contentType: "application/json",
+    },
+  );
+  return result.url;
+}

--- a/scripts/commentary/worklist.test.ts
+++ b/scripts/commentary/worklist.test.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "vitest";
+
+import type { ChartFile, Country, Track } from "../../src/lib/chart-schema";
+import {
+  commentaryKey,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
+
+import { computeWorklist } from "./worklist";
+
+function track(rank: number, artist: string, name: string): Track {
+  return {
+    rank,
+    name,
+    artist,
+    previewUrl: null,
+    artworkUrl: "https://art/x/600x600bb.jpg",
+    appleUrl: "https://music.apple.com/x/1",
+    spotifySearchUrl: "https://open.spotify.com/search/x",
+  };
+}
+
+function country(name: string, tracks: Track[]): Country {
+  return { name, valid: true, tracks };
+}
+
+function chart(countries: ChartFile["countries"]): ChartFile {
+  return { lastUpdated: "2026-05-16T00:00:00.000Z", countries };
+}
+
+function storeWith(...keys: string[]): CommentaryStore {
+  const store: CommentaryStore = {};
+  for (const key of keys) {
+    store[key] = {
+      lead: "Already written.",
+      sources: ["https://example.com/a"],
+      generatedAt: "2026-05-16T00:00:00.000Z",
+    };
+  }
+  return store;
+}
+
+test("dedups a track that charts in several countries into one item", () => {
+  const current = chart({
+    kr: country("South Korea", [track(5, "Artist A", "Song A")]),
+    us: country("United States", [track(3, "Artist A", "Song A")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items).toHaveLength(1);
+  expect(items[0].bestRank).toBe(3);
+  expect(items[0].countries).toEqual([
+    { cc: "us", rank: 3 },
+    { cc: "kr", rank: 5 },
+  ]);
+});
+
+test("excludes a track that already has commentary (cache hit)", () => {
+  const current = chart({
+    us: country("United States", [track(1, "Artist A", "Song A")]),
+  });
+  const commentary = storeWith(commentaryKey("en", "Artist A", "Song A"));
+
+  const items = computeWorklist({ current, previous: null, commentary });
+
+  expect(items).toEqual([]);
+});
+
+test("includes a significant track with no commentary yet (cache miss)", () => {
+  const current = chart({
+    us: country("United States", [track(1, "Artist A", "Song A")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Song A"]);
+});
+
+test("without history, keeps only prominently-ranked tracks", () => {
+  const current = chart({
+    us: country("United States", [
+      track(2, "Artist A", "Top Song"),
+      track(18, "Artist B", "Deep Cut"),
+    ]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Top Song"]);
+  expect(items[0].reason).toBe("top-debut");
+});
+
+test("flags a track absent from the previous snapshot as a new entry", () => {
+  const previous = chart({
+    us: country("United States", [track(1, "Artist A", "Song A")]),
+  });
+  const current = chart({
+    us: country("United States", [
+      track(1, "Artist A", "Song A"),
+      track(2, "Artist B", "Song B"),
+    ]),
+  });
+  const commentary = storeWith(commentaryKey("en", "Artist A", "Song A"));
+
+  const items = computeWorklist({ current, previous, commentary });
+
+  expect(items.map((i) => i.name)).toEqual(["Song B"]);
+  expect(items[0].reason).toBe("new-entry");
+});
+
+test("flags a large climb as a rank jump", () => {
+  const previous = chart({
+    us: country("United States", [track(20, "Artist A", "Climber")]),
+  });
+  const current = chart({
+    us: country("United States", [track(5, "Artist A", "Climber")]),
+  });
+
+  const items = computeWorklist({ current, previous, commentary: {} });
+
+  expect(items).toHaveLength(1);
+  expect(items[0].reason).toBe("rank-jump");
+});
+
+test("flags entering the top band from outside it as a top debut", () => {
+  const previous = chart({
+    us: country("United States", [track(14, "Artist A", "Riser")]),
+  });
+  const current = chart({
+    us: country("United States", [track(8, "Artist A", "Riser")]),
+  });
+
+  const items = computeWorklist({ current, previous, commentary: {} });
+
+  expect(items).toHaveLength(1);
+  expect(items[0].reason).toBe("top-debut");
+});
+
+test("skips a track that holds a stable rank", () => {
+  const previous = chart({
+    us: country("United States", [track(5, "Artist A", "Steady")]),
+  });
+  const current = chart({
+    us: country("United States", [track(6, "Artist A", "Steady")]),
+  });
+
+  const items = computeWorklist({ current, previous, commentary: {} });
+
+  expect(items).toEqual([]);
+});
+
+test("ignores tracks from invalid (failed) countries", () => {
+  const current = chart({
+    us: {
+      name: "United States",
+      valid: false,
+      tracks: [track(1, "Artist A", "Song A")],
+    },
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items).toEqual([]);
+});
+
+test("sorts the worklist by best rank ascending", () => {
+  const current = chart({
+    us: country("United States", [
+      track(9, "Artist A", "Third"),
+      track(1, "Artist B", "First"),
+      track(4, "Artist C", "Second"),
+    ]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["First", "Second", "Third"]);
+});

--- a/scripts/commentary/worklist.ts
+++ b/scripts/commentary/worklist.ts
@@ -1,0 +1,144 @@
+import type { ChartFile } from "../../src/lib/chart-schema";
+import {
+  DEFAULT_LANG,
+  commentaryKey,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
+
+/**
+ * The worklist for a refinement pass: which charting tracks still need a blurb.
+ * A track qualifies only if its movement is significant AND no blurb exists yet,
+ * so a pass surfaces a tractable, deduped list instead of every charting track
+ * (ADR-0007's quantitative gate, an analog to a significance trigger).
+ */
+
+export type WorklistReason = "new-entry" | "rank-jump" | "top-debut";
+
+export interface WorklistItem {
+  key: string;
+  artist: string;
+  name: string;
+  bestRank: number;
+  reason: WorklistReason;
+  countries: { cc: string; rank: number }[];
+}
+
+export interface WorklistOptions {
+  lang?: string;
+  /** A climb of at least this many ranks counts as significant. */
+  jumpBy?: number;
+  /** Entering this rank or better counts as significant. */
+  topDebutMax?: number;
+}
+
+const DEFAULT_JUMP_BY = 10;
+const DEFAULT_TOP_DEBUT_MAX = 10;
+
+interface Aggregate {
+  artist: string;
+  name: string;
+  bestRank: number;
+  countries: { cc: string; rank: number }[];
+}
+
+function aggregateByKey(
+  chart: ChartFile,
+  lang: string,
+): Map<string, Aggregate> {
+  const byKey = new Map<string, Aggregate>();
+  for (const [cc, country] of Object.entries(chart.countries)) {
+    if (!country.valid) continue;
+    for (const track of country.tracks) {
+      const key = commentaryKey(lang, track.artist, track.name);
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.countries.push({ cc, rank: track.rank });
+        existing.bestRank = Math.min(existing.bestRank, track.rank);
+      } else {
+        byKey.set(key, {
+          artist: track.artist,
+          name: track.name,
+          bestRank: track.rank,
+          countries: [{ cc, rank: track.rank }],
+        });
+      }
+    }
+  }
+  return byKey;
+}
+
+function bestRankByKey(
+  chart: ChartFile | null,
+  lang: string,
+): Map<string, number> {
+  const best = new Map<string, number>();
+  if (!chart) return best;
+  for (const country of Object.values(chart.countries)) {
+    if (!country.valid) continue;
+    for (const track of country.tracks) {
+      const key = commentaryKey(lang, track.artist, track.name);
+      const prev = best.get(key);
+      if (prev === undefined || track.rank < prev) best.set(key, track.rank);
+    }
+  }
+  return best;
+}
+
+function classify(
+  cur: number,
+  prev: number | undefined,
+  hasHistory: boolean,
+  jumpBy: number,
+  topDebutMax: number,
+): WorklistReason | null {
+  if (!hasHistory) {
+    // No prior snapshot to diff against (e.g. a first pass): fall back to
+    // absolute prominence so the list stays tractable instead of surfacing the
+    // whole long tail.
+    return cur <= topDebutMax ? "top-debut" : null;
+  }
+  if (prev === undefined) return "new-entry";
+  if (prev - cur >= jumpBy) return "rank-jump";
+  if (cur <= topDebutMax && prev > topDebutMax) return "top-debut";
+  return null;
+}
+
+export function computeWorklist(input: {
+  current: ChartFile;
+  previous: ChartFile | null;
+  commentary: CommentaryStore;
+  options?: WorklistOptions;
+}): WorklistItem[] {
+  const lang = input.options?.lang ?? DEFAULT_LANG;
+  const jumpBy = input.options?.jumpBy ?? DEFAULT_JUMP_BY;
+  const topDebutMax = input.options?.topDebutMax ?? DEFAULT_TOP_DEBUT_MAX;
+
+  const current = aggregateByKey(input.current, lang);
+  const previousBest = bestRankByKey(input.previous, lang);
+  const hasHistory = input.previous !== null;
+
+  const items: WorklistItem[] = [];
+  for (const [key, agg] of current) {
+    if (key in input.commentary) continue; // cache hit: never regenerate
+    const reason = classify(
+      agg.bestRank,
+      previousBest.get(key),
+      hasHistory,
+      jumpBy,
+      topDebutMax,
+    );
+    if (!reason) continue;
+    items.push({
+      key,
+      artist: agg.artist,
+      name: agg.name,
+      bestRank: agg.bestRank,
+      reason,
+      countries: [...agg.countries].sort((a, b) => a.rank - b.rank),
+    });
+  }
+
+  return items.sort(
+    (a, b) => a.bestRank - b.bestRank || a.key.localeCompare(b.key),
+  );
+}

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -2,6 +2,7 @@ import "./sentry-init";
 import * as Sentry from "@sentry/node";
 
 import { COUNTRIES } from "../../src/lib/countries";
+import { fetchCommentaryStore } from "../commentary/fetch-commentary";
 
 import { AppleRssError, fetchAppleRss } from "./apple-rss";
 import { lookupTrack } from "./itunes-lookup";
@@ -23,6 +24,10 @@ const sleep = (ms: number): Promise<void> =>
 // Public URL of the last published payload, read back for carry-forward.
 // Absent locally → carry-forward skipped.
 const previousUrl = process.env.CHARTS_BLOB_URL;
+
+// Session-owned commentary store, baked into the served charts when present.
+// The crawl only reads it (ADR-0007). Absent → no commentary this run.
+const commentaryUrl = process.env.COMMENTARY_BLOB_URL;
 
 // Short-lived process: must flush before exit so the monitor check-in + the
 // charts:published message actually reach Sentry. withMonitor returning is not
@@ -46,6 +51,9 @@ try {
         triggerRevalidate,
         fetchPrevious: previousUrl
           ? () => fetchPublishedCharts(previousUrl)
+          : undefined,
+        fetchCommentary: commentaryUrl
+          ? () => fetchCommentaryStore(commentaryUrl)
           : undefined,
       });
 

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -5,6 +5,10 @@ import {
   type ChartFile,
   type Country,
 } from "../../src/lib/chart-schema";
+import {
+  commentaryKey,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
 import type { CountryEntry } from "../../src/lib/countries";
 
 import { AppleRssError, type AppleRssTrack } from "./apple-rss";
@@ -194,6 +198,7 @@ function makeCrawlAllDeps(input: {
   countries: readonly CountryEntry[];
   fetchRss?: (cc: string) => Promise<AppleRssTrack[]>;
   fetchPrevious?: () => Promise<ChartFile | null>;
+  fetchCommentary?: () => Promise<CommentaryStore | null>;
 }): CrawlAllDeps {
   return {
     countries: input.countries,
@@ -205,7 +210,16 @@ function makeCrawlAllDeps(input: {
     uploadCharts: vi.fn(async () => BLOB_URL),
     triggerRevalidate: vi.fn(async () => {}),
     fetchPrevious: input.fetchPrevious,
+    fetchCommentary: input.fetchCommentary,
     now: () => FROZEN_NOW,
+  };
+}
+
+function commentaryEntry(lead: string) {
+  return {
+    lead,
+    sources: ["https://example.com/a"],
+    generatedAt: "2026-05-15T00:00:00.000Z",
   };
 }
 
@@ -404,4 +418,69 @@ test("summarizeValidity reports total, valid count, and the invalid codes", asyn
   const summary = summarizeValidity(chartFile);
 
   expect(summary).toEqual({ total: 3, validCount: 2, invalidCodes: ["ng"] });
+});
+
+test("crawlAll bakes a matching blurb and sets null on tracks without one", async () => {
+  const krEntry = commentaryEntry("KR blurb.");
+  const store: CommentaryStore = {
+    [commentaryKey("en", "kr artist", "kr song")]: krEntry,
+  };
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    fetchCommentary: vi.fn(async () => store),
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.kr.tracks[0].commentary).toEqual(krEntry);
+  expect(result.chartFile.countries.ng.tracks[0].commentary).toBeNull();
+});
+
+test("crawlAll leaves commentary unset when no commentary source is wired", async () => {
+  const deps = makeCrawlAllDeps({ countries: [KR] });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.kr.tracks[0].commentary).toBeUndefined();
+});
+
+test("crawlAll skips the bake and still publishes when commentary yields null", async () => {
+  const deps = makeCrawlAllDeps({
+    countries: [KR],
+    fetchCommentary: vi.fn(async () => null),
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.kr.tracks[0].commentary).toBeUndefined();
+  expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
+});
+
+test("crawlAll clears a stale blurb carried forward from a failed country", async () => {
+  const stalePriorNg: Country = {
+    name: NG.name,
+    valid: true,
+    tracks: [
+      {
+        rank: 1,
+        name: "ng song",
+        artist: "ng artist",
+        previewUrl: null,
+        artworkUrl: "https://prior/art/1/600x600bb.jpg",
+        appleUrl: "https://music.apple.com/prior/1",
+        spotifySearchUrl: "https://open.spotify.com/search/prior1",
+        commentary: commentaryEntry("stale blurb."),
+      },
+    ],
+  };
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    fetchRss: failRssFor(NG.code),
+    fetchPrevious: vi.fn(async () => previousChartFile({ ng: stalePriorNg })),
+    fetchCommentary: vi.fn(async () => ({})),
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng.tracks[0].commentary).toBeNull();
 });

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -1,4 +1,9 @@
 import type { ChartFile, Country, Track } from "../../src/lib/chart-schema";
+import {
+  DEFAULT_LANG,
+  commentaryForTrack,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
 import type { CountryEntry } from "../../src/lib/countries";
 
 import { AppleRssError, type AppleRssTrack } from "./apple-rss";
@@ -28,6 +33,13 @@ export interface CrawlAllDeps {
   // Source for carrying forward a country that fails this run. Must resolve
   // null (never reject) when unavailable, which skips carry-forward.
   fetchPrevious?: () => Promise<ChartFile | null>;
+  // Out-of-band commentary baked into the served charts. Like fetchPrevious,
+  // must resolve null (never reject) when unavailable, which skips the bake and
+  // leaves charts untouched. The crawl only ever reads this store (ADR-0007).
+  fetchCommentary?: () => Promise<CommentaryStore | null>;
+  // Language whose commentary is baked in (English-first; the store key carries
+  // the language so others slot in later).
+  lang?: string;
   now?: () => Date;
 }
 
@@ -97,6 +109,28 @@ export async function crawlCountry(
   return { cc, country: { name, valid: true, tracks } };
 }
 
+/**
+ * Back-fills each track's commentary from the session-owned store. The store is
+ * authoritative: a track with no entry is set to null, clearing any stale blurb
+ * a carried-forward country brought with it. Never writes the store; pure data.
+ */
+export function bakeCommentary(
+  countries: ChartFile["countries"],
+  store: CommentaryStore,
+  lang: string,
+): void {
+  for (const country of Object.values(countries)) {
+    for (const track of country.tracks) {
+      track.commentary = commentaryForTrack(
+        store,
+        lang,
+        track.artist,
+        track.name,
+      );
+    }
+  }
+}
+
 export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
   const {
     countries,
@@ -138,6 +172,11 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
     console.log(
       `[crawl ${cc}] ${country.tracks.length} tracks (valid=${country.valid})`,
     );
+  }
+
+  const commentary = deps.fetchCommentary ? await deps.fetchCommentary() : null;
+  if (commentary) {
+    bakeCommentary(countriesMap, commentary, deps.lang ?? DEFAULT_LANG);
   }
 
   const chartFile: ChartFile = {

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const CommentarySchema = z.object({
+export const CommentarySchema = z.object({
   lead: z.string().min(1),
   detail: z.string().min(1).optional(),
   tag: z.string().min(1).optional(),

--- a/src/lib/commentary-store.test.ts
+++ b/src/lib/commentary-store.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "vitest";
+
+import {
+  CommentaryStoreSchema,
+  commentaryForTrack,
+  commentaryKey,
+  normalizeForKey,
+} from "./commentary-store";
+
+test("normalizeForKey folds case, surrounding and repeated whitespace", () => {
+  expect(normalizeForKey("  The   BAND  ")).toBe("the band");
+});
+
+test("normalizeForKey folds Unicode composition so accents key the same", () => {
+  const name = "Beyonc" + String.fromCharCode(0xe9); // ...e-acute
+  const composed = name.normalize("NFC");
+  const decomposed = name.normalize("NFD");
+
+  expect(composed).not.toBe(decomposed);
+  expect(normalizeForKey(composed)).toBe(normalizeForKey(decomposed));
+});
+
+test("commentaryKey joins language, artist, and title", () => {
+  expect(commentaryKey("en", "The Band", "Hit Song")).toBe(
+    "en:the band|hit song",
+  );
+});
+
+test("commentaryKey is stable across cosmetic differences in artist and title", () => {
+  expect(commentaryKey("en", "  the band ", "HIT  song")).toBe(
+    commentaryKey("en", "The Band", "Hit Song"),
+  );
+});
+
+test("commentaryKey separates languages", () => {
+  expect(commentaryKey("en", "Artist", "Song")).not.toBe(
+    commentaryKey("es", "Artist", "Song"),
+  );
+});
+
+test("commentaryForTrack returns the stored blurb on a key match", () => {
+  const entry = {
+    lead: "A blurb.",
+    sources: ["https://example.com/a"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+  const store = { [commentaryKey("en", "Artist", "Song")]: entry };
+
+  expect(commentaryForTrack(store, "en", "Artist", "Song")).toEqual(entry);
+});
+
+test("commentaryForTrack returns null when no blurb is on file", () => {
+  expect(commentaryForTrack({}, "en", "Artist", "Song")).toBeNull();
+});
+
+test("CommentaryStoreSchema accepts an empty store", () => {
+  expect(CommentaryStoreSchema.parse({})).toEqual({});
+});
+
+test("CommentaryStoreSchema rejects an entry that is not valid commentary", () => {
+  const bad = { "en:artist|song": { lead: "No sources or timestamp." } };
+
+  expect(() => CommentaryStoreSchema.parse(bad)).toThrow();
+});

--- a/src/lib/commentary-store.ts
+++ b/src/lib/commentary-store.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import { CommentarySchema, type Commentary } from "./chart-schema";
+
+/**
+ * The out-of-band commentary store: a flat map from track key to one
+ * human-curated blurb. Session-owned — the crawl reads it to bake into the
+ * served charts but never writes it (ADR-0007).
+ */
+export const CommentaryStoreSchema = z.record(z.string(), CommentarySchema);
+
+export type CommentaryStore = z.infer<typeof CommentaryStoreSchema>;
+
+/** Commentary is English-only for now; the key carries the language so other
+ * languages slot in later without re-keying the store. */
+export const DEFAULT_LANG = "en";
+
+/**
+ * Folds away differences that don't change which track this is: surrounding and
+ * repeated whitespace, case, and Unicode composition (so a title keys the same
+ * whether its accents arrive composed or decomposed).
+ */
+export function normalizeForKey(value: string): string {
+  return value.normalize("NFC").trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/**
+ * Identity of a charting track across countries: same artist + title yields the
+ * same key, so a blurb is written once and reused everywhere the track charts.
+ */
+export function commentaryKey(
+  lang: string,
+  artist: string,
+  name: string,
+): string {
+  return `${lang}:${normalizeForKey(artist)}|${normalizeForKey(name)}`;
+}
+
+/** The stored blurb for a track, or null when none is on file. */
+export function commentaryForTrack(
+  store: CommentaryStore,
+  lang: string,
+  artist: string,
+  name: string,
+): Commentary | null {
+  return store[commentaryKey(lang, artist, name)] ?? null;
+}

--- a/src/lib/no-lyric-lint.test.ts
+++ b/src/lib/no-lyric-lint.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "vitest";
+
+import { findLyricRisks, lintCommentary } from "./no-lyric-lint";
+
+// Test strings are deliberately nonsense in a lyric SHAPE (quoted runs, short
+// enjambed lines, repeats); they reproduce no real song.
+
+test("findLyricRisks flags a quoted run longer than a short phrase", () => {
+  const text =
+    'The hook leans on "na na na la la oh oh my my my" all the way through.';
+
+  expect(findLyricRisks(text).some((r) => r.rule === "quoted-span")).toBe(true);
+});
+
+test("findLyricRisks flags a quoted run inside typographic quotes", () => {
+  const open = "“";
+  const close = "”";
+  const text = `It returns to ${open}na na na la la oh oh my my my${close} each chorus.`;
+
+  expect(findLyricRisks(text).some((r) => r.rule === "quoted-span")).toBe(true);
+});
+
+test("findLyricRisks leaves a short quoted title alone", () => {
+  const text = 'The single is called "Midnight Drive" on the record.';
+
+  expect(findLyricRisks(text)).toEqual([]);
+});
+
+test("findLyricRisks does not pair apostrophes into a quoted span", () => {
+  const text = "The duo's debut, the artist's biggest week, can't-miss energy.";
+
+  expect(findLyricRisks(text)).toEqual([]);
+});
+
+test("findLyricRisks flags several short unpunctuated lines as verse", () => {
+  const text = "na na na oh\nla la my my\noh oh na na\nla la my my";
+
+  expect(findLyricRisks(text).some((r) => r.rule === "verse-lines")).toBe(true);
+});
+
+test("findLyricRisks leaves terse punctuated prose lines alone", () => {
+  const text = "A new entry.\nClimbing on strong streaming.\nFirst week out.";
+
+  expect(findLyricRisks(text)).toEqual([]);
+});
+
+test("findLyricRisks flags a repeated line", () => {
+  const text =
+    "This is the summer breakout here.\nIt owns radio play.\nThis is the summer breakout here.";
+
+  expect(findLyricRisks(text).some((r) => r.rule === "repeated-line")).toBe(
+    true,
+  );
+});
+
+test("lintCommentary scans lead, detail, and tag", () => {
+  const entry = {
+    lead: 'It opens on "na na na la la oh oh my my my" before the verse.',
+    sources: ["https://example.com/a"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+
+  expect(lintCommentary(entry).length).toBeGreaterThan(0);
+});
+
+test("lintCommentary passes clean prose commentary", () => {
+  const entry = {
+    lead: "A summer single riding a viral dance clip to the top.",
+    detail:
+      "The duo's first charting entry; momentum built over three weeks of streaming growth.",
+    tag: "new entry",
+    sources: ["https://example.com/a", "https://example.com/b"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+
+  expect(lintCommentary(entry)).toEqual([]);
+});

--- a/src/lib/no-lyric-lint.test.ts
+++ b/src/lib/no-lyric-lint.test.ts
@@ -55,12 +55,17 @@ test("findLyricRisks flags a repeated line", () => {
 
 test("lintCommentary scans lead, detail, and tag", () => {
   const entry = {
-    lead: 'It opens on "na na na la la oh oh my my my" before the verse.',
+    lead: "A clean, lyric-free lead sentence.",
+    detail: 'The hook repeats "na na na la la oh oh my my my" throughout.',
+    tag: "na na na oh\nla la my my\noh oh na na",
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };
 
-  expect(lintCommentary(entry).length).toBeGreaterThan(0);
+  const risks = lintCommentary(entry);
+
+  expect(risks.some((r) => r.rule === "quoted-span")).toBe(true);
+  expect(risks.some((r) => r.rule === "verse-lines")).toBe(true);
 });
 
 test("lintCommentary passes clean prose commentary", () => {

--- a/src/lib/no-lyric-lint.ts
+++ b/src/lib/no-lyric-lint.ts
@@ -1,0 +1,100 @@
+import type { Commentary } from "./chart-schema";
+
+/**
+ * Deterministic guard against reproducing song lyrics in commentary, the
+ * programmatic backstop behind the human read-through (ADR-0007). Commentary is
+ * prose ABOUT a song, never its words. The heuristics are tuned to flag rather
+ * than miss: a cleared false positive costs a reviewer a glance, a reproduced
+ * line that slips through is a licensing problem.
+ */
+
+export interface LyricRisk {
+  rule: "quoted-span" | "verse-lines" | "repeated-line";
+  excerpt: string;
+}
+
+// A quoted run this long reads as a reproduced line; titles and short phrases
+// sit comfortably under it. Only straight/typographic DOUBLE quotes count —
+// apostrophes ("don't", "the artist's") would otherwise pair up across prose.
+const MAX_QUOTED_WORDS = 6;
+
+// Several short lines in a row that never resolve into a sentence are
+// verse-shaped; prose commentary runs in sentences that close with punctuation.
+const MIN_VERSE_LINES = 3;
+const VERSE_LINE_MAX_WORDS = 9;
+
+// A whole line repeated is a chorus hallmark (and never how prose reads). Short
+// enough to skip section labels, long enough to catch a hook.
+const MIN_REPEATED_LINE_WORDS = 2;
+
+function wordCount(text: string): number {
+  const trimmed = text.trim();
+  return trimmed === "" ? 0 : trimmed.split(/\s+/).length;
+}
+
+function endsASentence(line: string): boolean {
+  return /[.!?]["”]?$/.test(line.trim());
+}
+
+function findQuotedSpans(text: string): LyricRisk[] {
+  const risks: LyricRisk[] = [];
+  const pattern = /["“]([^"“”\n]+)["”]/g;
+  for (const match of text.matchAll(pattern)) {
+    if (wordCount(match[1]) > MAX_QUOTED_WORDS) {
+      risks.push({ rule: "quoted-span", excerpt: match[0] });
+    }
+  }
+  return risks;
+}
+
+function findVerseRuns(lines: string[]): LyricRisk[] {
+  let run: string[] = [];
+  for (const line of lines) {
+    const isVerse =
+      line.trim() !== "" &&
+      wordCount(line) <= VERSE_LINE_MAX_WORDS &&
+      !endsASentence(line);
+    if (isVerse) {
+      run.push(line.trim());
+    } else {
+      if (run.length >= MIN_VERSE_LINES) {
+        return [{ rule: "verse-lines", excerpt: run.join(" / ") }];
+      }
+      run = [];
+    }
+  }
+  return run.length >= MIN_VERSE_LINES
+    ? [{ rule: "verse-lines", excerpt: run.join(" / ") }]
+    : [];
+}
+
+function findRepeatedLines(lines: string[]): LyricRisk[] {
+  const seen = new Set<string>();
+  for (const raw of lines) {
+    const line = raw.trim().toLowerCase().replace(/\s+/g, " ");
+    if (wordCount(line) < MIN_REPEATED_LINE_WORDS) continue;
+    if (seen.has(line)) {
+      return [{ rule: "repeated-line", excerpt: raw.trim() }];
+    }
+    seen.add(line);
+  }
+  return [];
+}
+
+/** Every lyric risk in a single block of text. */
+export function findLyricRisks(text: string): LyricRisk[] {
+  const lines = text.split("\n");
+  return [
+    ...findQuotedSpans(text),
+    ...findVerseRuns(lines),
+    ...findRepeatedLines(lines),
+  ];
+}
+
+/** Every lyric risk across a commentary entry's human-authored fields. */
+export function lintCommentary(entry: Commentary): LyricRisk[] {
+  const fields = [entry.lead, entry.detail, entry.tag].filter(
+    (f): f is string => typeof f === "string",
+  );
+  return fields.flatMap(findLyricRisks);
+}


### PR DESCRIPTION
Slice B of v1.2.0 (the song context card). Closes #95.

Commentary is curated out of band in human-reviewed passes and baked into
the served charts by the crawl, which only ever reads the store (ADR-0007).
This slice adds the workflow and the merge; no card UI yet (Slice C, #96),
and the crawl bakes nothing until COMMENTARY_BLOB_URL is set, so it ships
as a no-op.

## What's here
- Worklist (`pnpm commentary:todo`): significant movers without a blurb yet,
  deduped across countries.
- Publish (`pnpm commentary:publish <file>`): hard-blocks on the schema and a
  deterministic no-lyric lint, backs up the live store, then uploads. A
  blocked publish uploads nothing.
- Crawl merge (run.ts): bakes the store into the served charts; a missing
  entry serves null, a read failure never aborts, the crawl never writes it.
- Playbook (docs/commentary-playbook.md): source policy, writing style,
  no-lyric rule, per-pass steps.

## Design notes
- Significance needs a prior snapshot, not persisted today. Only one
  charts.json exists at a time, so movement-vs-previous reads an optional
  CHARTS_PREV_BLOB_URL; without it the worklist falls back to absolute
  prominence (top-ranked). Rank-jump / re-entry logic is built and tested but
  only fires once a prior snapshot is supplied. A persisted prior-snapshot
  store is a candidate v1.2.x follow-up.
- Store-authoritative bake: a transient read failure (null) leaves existing
  commentary alone; an authoritatively-empty store ({}) clears stale blurbs.
- The playbook is tool-agnostic, consistent with ADR-0007.

## Test plan
Local CI matrix, all green: build · format:check · lint · typecheck ·
test:ci (259 passed, +34 this slice). New tests cover dedup, cache
hit/miss, the no-lyric lint, the publish gate, and the crawl merge
(match / null-on-miss / skip-on-null / stale-clearing).

## Follow-up (external, not in this PR)
Setting COMMENTARY_BLOB_URL (Vercel env + GH secret) and running the first
commentary:publish to create the blob. Until then the feature is a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a commentary system for enriching chart cards with curated editorial blurbs
  * New CLI commands for generating commentary worklists based on chart activity and publishing updates
  * Automated safeguards to detect and prevent reproduced song lyrics in commentary

* **Documentation**
  * Added comprehensive playbook guide for the commentary refinement and publishing workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->