### PR TITLE
feat(chart-sheet): add tap-to-expand song context card

### DIFF
--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -8,7 +8,7 @@ A short, grounded note about a charting track: what the song is about and why it
 
 - `lead` (required): a one-line conclusion, the first thing a reader sees.
 - `detail` (optional): a sentence or two of support, shown when the card expands.
-- `tag` (optional): a short keyword, e.g. "new entry" or "viral".
+- `tag` (set one on every blurb): a short keyword. Default to the worklist reason (new entry, rank jump, top debut); a more specific keyword like "viral" is fine when it fits.
 - `sources` (required): the URLs the claims rest on.
 - `generatedAt` (required): ISO timestamp of when the blurb was written.
 

--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -8,7 +8,7 @@ A short, grounded note about a charting track: what the song is about and why it
 
 - `lead` (required): a one-line conclusion, the first thing a reader sees.
 - `detail` (optional): a sentence or two of support, shown when the card expands.
-- `tag` (set one on every blurb): a short keyword. Default to the worklist reason (new entry, rank jump, top debut); a more specific keyword like "viral" is fine when it fits.
+- `tag` (required): a short keyword; default to the worklist reason (new entry, rank jump, top debut), or a more specific one like "viral" when it fits.
 - `sources` (required): the URLs the claims rest on.
 - `generatedAt` (required): ISO timestamp of when the blurb was written.
 

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -10,6 +10,7 @@ function validStore() {
   return {
     [commentaryKey("en", "Artist", "Song")]: {
       lead: "A blurb about the song.",
+      tag: "new entry",
       sources: ["https://example.com/a"],
       generatedAt: "2026-05-16T00:00:00.000Z",
     },

--- a/scripts/commentary/prepublish.test.ts
+++ b/scripts/commentary/prepublish.test.ts
@@ -9,6 +9,7 @@ const KEY = commentaryKey("en", "Artist A", "Song A");
 function validEntry() {
   return {
     lead: "A clean blurb about the song.",
+    tag: "new entry",
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };

--- a/scripts/commentary/worklist.test.ts
+++ b/scripts/commentary/worklist.test.ts
@@ -33,6 +33,7 @@ function storeWith(...keys: string[]): CommentaryStore {
   for (const key of keys) {
     store[key] = {
       lead: "Already written.",
+      tag: "new entry",
       sources: ["https://example.com/a"],
       generatedAt: "2026-05-16T00:00:00.000Z",
     };

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -218,6 +218,7 @@ function makeCrawlAllDeps(input: {
 function commentaryEntry(lead: string) {
   return {
     lead,
+    tag: "new entry",
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-15T00:00:00.000Z",
   };

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -297,10 +297,11 @@ describe("TrackRow commentary card", () => {
     expect(source.getAttribute("rel")).toContain("noopener");
   });
 
-  test("minimal commentary (no tag or detail) still renders the teaser and sources", () => {
+  test("minimal commentary (no detail) still renders the teaser and sources", () => {
     const track = makeTrack({
       commentary: {
         lead: "A long-running chart favorite.",
+        tag: "mainstay",
         sources: ["https://npr.org/music"],
         generatedAt: "2026-04-25T03:00:00Z",
       },

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import type { AudioEngine } from "@/lib/audio-engine";
 import { type AudioState, createAudioStore } from "@/lib/audio-store";
-import type { Track } from "@/lib/chart-schema";
+import type { Commentary, Track } from "@/lib/chart-schema";
 import { AudioStoreContext } from "@/providers/audio-store-provider";
 
 import { TrackRow } from "./track-row";
@@ -232,5 +232,86 @@ describe("TrackRow", () => {
     });
 
     expect(screen.queryByText(/Preview unavailable/)).toBeNull();
+  });
+});
+
+describe("TrackRow commentary card", () => {
+  const COMMENTARY = {
+    lead: "A new entry climbing fast this week.",
+    detail: "Brief context on why the track is rising.",
+    tag: "new entry",
+    sources: [
+      "https://www.billboard.com/charts",
+      "https://pitchfork.com/reviews",
+    ],
+    generatedAt: "2026-04-25T03:00:00Z",
+  } satisfies Commentary;
+
+  test("renders no affordance when commentary is absent", () => {
+    const track = makeTrack();
+
+    const { container } = renderTrackRow(track);
+
+    expect(container.querySelector("[aria-expanded]")).toBeNull();
+    expect(screen.queryByRole("button", { expanded: false })).toBeNull();
+  });
+
+  test("collapsed: shows tag + lead, panel starts inert", () => {
+    const track = makeTrack({ commentary: COMMENTARY });
+
+    renderTrackRow(track);
+
+    const toggle = screen.getByRole("button", { expanded: false });
+    expect(toggle.textContent).toContain(COMMENTARY.lead);
+    expect(screen.getByText(COMMENTARY.tag)).toBeDefined();
+    const panel = document.getElementById(
+      toggle.getAttribute("aria-controls")!,
+    );
+    expect(panel?.hasAttribute("inert")).toBe(true);
+  });
+
+  test("tapping the teaser expands: aria-expanded flips and the panel un-inerts", () => {
+    const track = makeTrack({ commentary: COMMENTARY });
+
+    renderTrackRow(track);
+    const toggle = screen.getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    const panel = document.getElementById(
+      toggle.getAttribute("aria-controls")!,
+    );
+    expect(panel?.hasAttribute("inert")).toBe(false);
+  });
+
+  test("expanded: shows detail and sources as bare hostnames", () => {
+    const track = makeTrack({ commentary: COMMENTARY });
+
+    renderTrackRow(track);
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+
+    expect(screen.getByText(COMMENTARY.detail)).toBeDefined();
+    const source = screen.getByRole("link", { name: "billboard.com" });
+    expect(source.getAttribute("href")).toBe(COMMENTARY.sources[0]);
+    expect(source.getAttribute("target")).toBe("_blank");
+    expect(source.getAttribute("rel")).toContain("noopener");
+  });
+
+  test("minimal commentary (no tag or detail) still renders the teaser and sources", () => {
+    const track = makeTrack({
+      commentary: {
+        lead: "A long-running chart favorite.",
+        sources: ["https://npr.org/music"],
+        generatedAt: "2026-04-25T03:00:00Z",
+      },
+    });
+
+    renderTrackRow(track);
+    const toggle = screen.getByRole("button", { expanded: false });
+    expect(toggle.textContent).toContain("A long-running chart favorite.");
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("link", { name: "npr.org" })).toBeDefined();
   });
 });

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -167,11 +167,9 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
             aria-controls={panelId}
             className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
           >
-            {commentary.tag ? (
-              <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
-                {commentary.tag}
-              </span>
-            ) : null}
+            <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
+              {commentary.tag}
+            </span>
             <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
               {commentary.lead}
             </span>
@@ -194,7 +192,7 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
               ) : null}
               <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
                 {commentary.sources.map((url, i) => (
-                  <Fragment key={url}>
+                  <Fragment key={`${url}-${i}`}>
                     {i > 0 ? (
                       <span aria-hidden className="text-fg-4 mx-2">
                         ·

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -1,14 +1,25 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useId, useState } from "react";
 
 import { AppleMusicIcon } from "@/components/icons/apple-music";
+import { ChevronDownIcon } from "@/components/icons/chevron-down";
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
 import { SpotifyIcon } from "@/components/icons/spotify";
 import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import type { Track } from "@/lib/chart-schema";
 import { useAudioStore } from "@/providers/audio-store-provider";
+
+// Cited sources show as bare hostnames; drop a leading www. for scannability.
+const WWW_PREFIX = /^www\./;
+function sourceLabel(url: string): string {
+  try {
+    return new URL(url).hostname.replace(WWW_PREFIX, "");
+  } catch {
+    return url;
+  }
+}
 
 export interface TrackRowProps {
   track: Track;
@@ -47,6 +58,12 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
     text: track.name,
   });
 
+  // Expand is per-row presentational state, so it stays local rather than in
+  // the audio store.
+  const commentary = track.commentary ?? null;
+  const [expanded, setExpanded] = useState(false);
+  const panelId = useId();
+
   return (
     <li
       data-rank={track.rank}
@@ -54,91 +71,150 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
       data-disabled={!hasPreview || undefined}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex items-center gap-[14px] rounded-[14px] px-3 py-2.5 transition-colors duration-200 data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
+      className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex flex-col rounded-[14px] px-3 py-2.5 transition-colors duration-200 data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
     >
-      <button
-        type="button"
-        disabled={!hasPreview}
-        onClick={() => toggle(track, countryCode)}
-        aria-label={`${isPlaying ? "Pause" : "Play"} preview of ${track.name} by ${track.artist}`}
-        className="focus-visible:outline-aurora flex min-w-0 flex-1 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none"
-      >
-        <span className="text-fg-3 text-body flex w-7 shrink-0 items-center justify-center font-mono tabular-nums">
-          {isCurrent ? (
-            isPlaying ? (
-              <PauseIcon className="text-sunrise h-4 w-4" />
+      <div className="flex items-center gap-[14px]">
+        <button
+          type="button"
+          disabled={!hasPreview}
+          onClick={() => toggle(track, countryCode)}
+          aria-label={`${isPlaying ? "Pause" : "Play"} preview of ${track.name} by ${track.artist}`}
+          className="focus-visible:outline-aurora flex min-w-0 flex-1 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none"
+        >
+          <span className="text-fg-3 text-body flex w-7 shrink-0 items-center justify-center font-mono tabular-nums">
+            {isCurrent ? (
+              isPlaying ? (
+                <PauseIcon className="text-sunrise h-4 w-4" />
+              ) : (
+                <PlayIcon className="text-sunrise h-4 w-4" />
+              )
             ) : (
-              <PlayIcon className="text-sunrise h-4 w-4" />
-            )
-          ) : (
-            track.rank
-          )}
-        </span>
-        <div
-          aria-hidden="true"
-          style={{ backgroundImage: `url(${track.artworkUrl})` }}
-          className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-        />
-        <div className="min-w-0 flex-1">
-          <p
-            className={`text-body flex min-w-0 items-center gap-2 font-medium ${
-              isCurrent ? "text-sunrise" : "text-fg-1"
-            }`}
-          >
-            <span className="block min-w-0 overflow-hidden">
-              <span
-                ref={titleRef}
-                className="marquee-track"
-                data-marquee={titleScrolling || undefined}
-                style={titleStyle}
-              >
-                {track.name}
-              </span>
-            </span>
-            {isCurrent && (
-              <span
-                className="eq shrink-0"
-                data-paused={!isPlaying || undefined}
-                aria-hidden
-              >
-                <span />
-                <span />
-                <span />
-              </span>
+              track.rank
             )}
-          </p>
-          <p className="text-fg-2 text-small truncate">
-            {hasPreview ? track.artist : `No preview · ${track.artist}`}
-          </p>
-          {hasError && (
-            <p className="text-error text-micro mt-1">
-              Preview unavailable, try another track
+          </span>
+          <div
+            aria-hidden="true"
+            style={{ backgroundImage: `url(${track.artworkUrl})` }}
+            className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          />
+          <div className="min-w-0 flex-1">
+            <p
+              className={`text-body flex min-w-0 items-center gap-2 font-medium ${
+                isCurrent ? "text-sunrise" : "text-fg-1"
+              }`}
+            >
+              <span className="block min-w-0 overflow-hidden">
+                <span
+                  ref={titleRef}
+                  className="marquee-track"
+                  data-marquee={titleScrolling || undefined}
+                  style={titleStyle}
+                >
+                  {track.name}
+                </span>
+              </span>
+              {isCurrent && (
+                <span
+                  className="eq shrink-0"
+                  data-paused={!isPlaying || undefined}
+                  aria-hidden
+                >
+                  <span />
+                  <span />
+                  <span />
+                </span>
+              )}
             </p>
-          )}
+            <p className="text-fg-2 text-small truncate">
+              {hasPreview ? track.artist : `No preview · ${track.artist}`}
+            </p>
+            {hasError && (
+              <p className="text-error text-micro mt-1">
+                Preview unavailable, try another track
+              </p>
+            )}
+          </div>
+        </button>
+        <div className="flex shrink-0 gap-1">
+          <a
+            href={track.appleUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => pause()}
+            aria-label={`Open ${track.name} in Apple Music`}
+            className="hover:bg-orbit focus-visible:outline-aurora flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
+          >
+            <AppleMusicIcon className="h-3.5 w-3.5" />
+          </a>
+          <a
+            href={track.spotifySearchUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => pause()}
+            aria-label={`Search ${track.name} on Spotify`}
+            className="hover:bg-orbit focus-visible:outline-aurora flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
+          >
+            <SpotifyIcon className="h-3.5 w-3.5" />
+          </a>
         </div>
-      </button>
-      <div className="flex shrink-0 gap-1">
-        <a
-          href={track.appleUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() => pause()}
-          aria-label={`Open ${track.name} in Apple Music`}
-          className="hover:bg-orbit focus-visible:outline-aurora flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
-        >
-          <AppleMusicIcon className="h-3.5 w-3.5" />
-        </a>
-        <a
-          href={track.spotifySearchUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() => pause()}
-          aria-label={`Search ${track.name} on Spotify`}
-          className="hover:bg-orbit focus-visible:outline-aurora flex h-8 w-8 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
-        >
-          <SpotifyIcon className="h-3.5 w-3.5" />
-        </a>
       </div>
+      {commentary ? (
+        <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
+          <button
+            type="button"
+            onClick={() => setExpanded((open) => !open)}
+            aria-expanded={expanded}
+            aria-controls={panelId}
+            className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
+          >
+            {commentary.tag ? (
+              <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
+                {commentary.tag}
+              </span>
+            ) : null}
+            <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
+              {commentary.lead}
+            </span>
+            <ChevronDownIcon
+              data-expanded={expanded || undefined}
+              className="text-fg-3 h-4 w-4 shrink-0 transition-transform duration-200 ease-[var(--ease-out)] data-[expanded]:rotate-180 motion-reduce:transition-none"
+            />
+          </button>
+          <div
+            id={panelId}
+            inert={!expanded}
+            data-expanded={expanded || undefined}
+            className="max-h-0 overflow-hidden transition-[max-height] duration-300 ease-[var(--ease-out)] data-[expanded]:max-h-96 motion-reduce:transition-none"
+          >
+            <div className="flex flex-col gap-2 pt-2">
+              {commentary.detail ? (
+                <p className="text-fg-2 text-small leading-relaxed">
+                  {commentary.detail}
+                </p>
+              ) : null}
+              <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
+                {commentary.sources.map((url, i) => (
+                  <Fragment key={url}>
+                    {i > 0 ? (
+                      <span aria-hidden className="text-fg-4 mx-2">
+                        ·
+                      </span>
+                    ) : null}
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
+                    >
+                      {sourceLabel(url)}
+                    </a>
+                  </Fragment>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </li>
   );
 }

--- a/src/components/icons/chevron-down.tsx
+++ b/src/components/icons/chevron-down.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from "react";
+
+export function ChevronDownIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}

--- a/src/lib/__fixtures__/charts.json
+++ b/src/lib/__fixtures__/charts.json
@@ -58,6 +58,7 @@
           "spotifySearchUrl": "https://open.spotify.com/search/Espresso%20Sabrina%20Carpenter",
           "commentary": {
             "lead": "A long-running chart favorite.",
+            "tag": "mainstay",
             "sources": ["https://example.com/source-c"],
             "generatedAt": "2026-04-25T03:00:00Z"
           }

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -76,6 +76,7 @@ test("ChartFileSchema rejects commentary missing the required lead", () => {
             spotifySearchUrl: "https://open.spotify.com/search/Test",
             commentary: {
               detail: "Has detail but no lead.",
+              tag: "new entry",
               sources: ["https://example.com/a"],
               generatedAt: "2026-05-16T00:00:00.000Z",
             },
@@ -106,6 +107,7 @@ test("ChartFileSchema rejects commentary with an empty sources array", () => {
             spotifySearchUrl: "https://open.spotify.com/search/Test",
             commentary: {
               lead: "Has a lead but no sources.",
+              tag: "new entry",
               sources: [],
               generatedAt: "2026-05-16T00:00:00.000Z",
             },
@@ -116,6 +118,36 @@ test("ChartFileSchema rejects commentary with an empty sources array", () => {
   };
 
   expect(() => ChartFileSchema.parse(withEmptySources)).toThrow();
+});
+
+test("ChartFileSchema rejects commentary missing the required tag", () => {
+  const withNoTag = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+            commentary: {
+              lead: "Has a lead but no tag.",
+              sources: ["https://example.com/a"],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withNoTag)).toThrow();
 });
 
 test("ChartFileSchema rejects an empty countries record", () => {

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const CommentarySchema = z.object({
   lead: z.string().min(1),
   detail: z.string().min(1).optional(),
-  tag: z.string().min(1).optional(),
+  tag: z.string().min(1),
   sources: z.array(z.url()).min(1),
   generatedAt: z.iso.datetime(),
 });

--- a/src/lib/commentary-store.test.ts
+++ b/src/lib/commentary-store.test.ts
@@ -41,6 +41,7 @@ test("commentaryKey separates languages", () => {
 test("commentaryForTrack returns the stored blurb on a key match", () => {
   const entry = {
     lead: "A blurb.",
+    tag: "new entry",
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };


### PR DESCRIPTION
## What

A charting track with commentary now shows a `tag` + `lead` teaser in its chart-sheet row; tapping expands to the `detail` and cited sources via a `max-h` transition. The chevron rotates, the collapsed panel is `inert` (its source links aren't tabbable), `prefers-reduced-motion` drops the animation, and a track with no commentary renders nothing.

The card reads in neutral foregrounds, leaving `sunrise` for the playing state and `aurora` for transient feedback. There is no AI-provenance label: the cited sources carry the provenance, and an always-on "AI-written" tag added little for short blurbs. The playbook now makes `tag` standard (default: the worklist reason, e.g. new entry / rank jump / top debut) so every card leads with a keyword instead of a bare sentence.

## Ships dark

No production change until commentary data exists: the crawl bakes commentary only when `COMMENTARY_BLOB_URL` is set and a first `commentary:publish` has written the blob. Until then every `commentary` is null and no card renders.

## Test plan

- 5 new `track-row` tests (null commentary then no affordance; collapsed tag + lead; tap expands and un-inerts; expanded detail + sources; minimal optional-absent). 264 tests pass.
- Full local matrix green: `format:check`, `lint`, `typecheck`, `build`, `test:ci`.
- Visual check by eye in the running app (globe to country to sheet) and a token-accurate compare page: collapse motion, the null case, and 375px.

Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track row commentary cards are now expandable, allowing users to collapse and expand detailed commentary with source links.
  * Added a chevron icon for expand/collapse interactions, plus improved source hostname display.
* **Tests**
  * Expanded test coverage for commentary card rendering, accessibility states, and external link behavior.
* **Documentation**
  * Updated the commentary playbook to document the required `tag` field for each commentary blurb.
* **Refactor**
  * Enforced `commentary.tag` as required in schema validation to keep commentary entries consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->