### PR TITLE
feat(countries): expand chart coverage to 2026 World Cup nations

### DIFF
--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -87,8 +87,10 @@ try {
       // tightest slot gap so per-slot check-in windows stay disjoint.
       checkinMargin: 150,
       // Clocks from the in-progress check-in, not the slot, so dispatch
-      // delay never eats into it. Sized to the ~50min crawl runtime.
-      maxRuntime: 90,
+      // delay never eats into it. Sized to the throttled crawl runtime
+      // (~26 requests/country at the 3s gap, ~80min at current coverage),
+      // kept under the 300min tightest slot gap with checkinMargin.
+      maxRuntime: 120,
     },
   );
 } finally {

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -10,7 +10,7 @@ export interface CountryEntry {
 }
 
 export const COUNTRIES: readonly CountryEntry[] = [
-  // Americas (8)
+  // Americas (12)
   {
     code: "us",
     name: "United States",
@@ -75,8 +75,40 @@ export const COUNTRIES: readonly CountryEntry[] = [
     lon: -77.052,
     isoNum: 604,
   },
+  {
+    code: "pa",
+    name: "Panama",
+    region: "Americas",
+    lat: 8.9824,
+    lon: -79.5199,
+    isoNum: 591,
+  },
+  {
+    code: "ec",
+    name: "Ecuador",
+    region: "Americas",
+    lat: -0.1807,
+    lon: -78.4678,
+    isoNum: 218,
+  },
+  {
+    code: "py",
+    name: "Paraguay",
+    region: "Americas",
+    lat: -25.2637,
+    lon: -57.5759,
+    isoNum: 600,
+  },
+  {
+    code: "uy",
+    name: "Uruguay",
+    region: "Americas",
+    lat: -34.9011,
+    lon: -56.1645,
+    isoNum: 858,
+  },
 
-  // Europe (14)
+  // Europe (20)
   {
     code: "gb",
     name: "United Kingdom",
@@ -189,8 +221,56 @@ export const COUNTRIES: readonly CountryEntry[] = [
     lon: 32.8624,
     isoNum: 792,
   },
+  {
+    code: "at",
+    name: "Austria",
+    region: "Europe",
+    lat: 48.2082,
+    lon: 16.3738,
+    isoNum: 40,
+  },
+  {
+    code: "be",
+    name: "Belgium",
+    region: "Europe",
+    lat: 50.8503,
+    lon: 4.3517,
+    isoNum: 56,
+  },
+  {
+    code: "ba",
+    name: "Bosnia and Herzegovina",
+    region: "Europe",
+    lat: 43.8563,
+    lon: 18.4131,
+    isoNum: 70,
+  },
+  {
+    code: "hr",
+    name: "Croatia",
+    region: "Europe",
+    lat: 45.815,
+    lon: 15.9819,
+    isoNum: 191,
+  },
+  {
+    code: "cz",
+    name: "Czechia",
+    region: "Europe",
+    lat: 50.0755,
+    lon: 14.4378,
+    isoNum: 203,
+  },
+  {
+    code: "ch",
+    name: "Switzerland",
+    region: "Europe",
+    lat: 46.948,
+    lon: 7.4474,
+    isoNum: 756,
+  },
 
-  // Asia (14)
+  // Asia (18)
   {
     code: "jp",
     name: "Japan",
@@ -303,6 +383,38 @@ export const COUNTRIES: readonly CountryEntry[] = [
     lon: 34.7681,
     isoNum: 376,
   },
+  {
+    code: "iq",
+    name: "Iraq",
+    region: "Asia",
+    lat: 33.3152,
+    lon: 44.3661,
+    isoNum: 368,
+  },
+  {
+    code: "jo",
+    name: "Jordan",
+    region: "Asia",
+    lat: 31.9539,
+    lon: 35.9106,
+    isoNum: 400,
+  },
+  {
+    code: "qa",
+    name: "Qatar",
+    region: "Asia",
+    lat: 25.2854,
+    lon: 51.531,
+    isoNum: 634,
+  },
+  {
+    code: "uz",
+    name: "Uzbekistan",
+    region: "Asia",
+    lat: 41.2995,
+    lon: 69.2401,
+    isoNum: 860,
+  },
 
   // Oceania (2)
   {
@@ -322,7 +434,7 @@ export const COUNTRIES: readonly CountryEntry[] = [
     isoNum: 554,
   },
 
-  // Africa (2)
+  // Africa (11)
   {
     code: "za",
     name: "South Africa",
@@ -338,5 +450,77 @@ export const COUNTRIES: readonly CountryEntry[] = [
     lat: 9.0853,
     lon: 7.5314,
     isoNum: 566,
+  },
+  {
+    code: "dz",
+    name: "Algeria",
+    region: "Africa",
+    lat: 36.7538,
+    lon: 3.0588,
+    isoNum: 12,
+  },
+  {
+    code: "cv",
+    name: "Cabo Verde",
+    region: "Africa",
+    lat: 14.9315,
+    lon: -23.5125,
+    isoNum: 132,
+  },
+  {
+    code: "cd",
+    name: "DR Congo",
+    region: "Africa",
+    lat: -4.4419,
+    lon: 15.2663,
+    isoNum: 180,
+  },
+  {
+    code: "ci",
+    name: "Côte d'Ivoire",
+    region: "Africa",
+    lat: 6.8276,
+    lon: -5.2893,
+    isoNum: 384,
+  },
+  {
+    code: "eg",
+    name: "Egypt",
+    region: "Africa",
+    lat: 30.0444,
+    lon: 31.2357,
+    isoNum: 818,
+  },
+  {
+    code: "gh",
+    name: "Ghana",
+    region: "Africa",
+    lat: 5.6037,
+    lon: -0.187,
+    isoNum: 288,
+  },
+  {
+    code: "ma",
+    name: "Morocco",
+    region: "Africa",
+    lat: 34.0209,
+    lon: -6.8416,
+    isoNum: 504,
+  },
+  {
+    code: "sn",
+    name: "Senegal",
+    region: "Africa",
+    lat: 14.7167,
+    lon: -17.4677,
+    isoNum: 686,
+  },
+  {
+    code: "tn",
+    name: "Tunisia",
+    region: "Africa",
+    lat: 36.8065,
+    lon: 10.1815,
+    isoNum: 788,
   },
 ];

--- a/src/lib/country-outlines.test.ts
+++ b/src/lib/country-outlines.test.ts
@@ -10,7 +10,7 @@ const realTopology = JSON.parse(
   readFileSync(join(process.cwd(), "public/data/countries-50m.json"), "utf-8"),
 );
 
-test("buildCountryOutlines splits 40-set countries from others by isoNum", () => {
+test("buildCountryOutlines splits chart-set countries from others by isoNum", () => {
   const outlines = buildCountryOutlines(realTopology);
 
   expect(outlines.byIso.has(410)).toBe(true);
@@ -30,7 +30,7 @@ test("buildCountryOutlines emits line-segment pairs (each segment = 6 floats)", 
   expect(outlines.tier2Positions.length % 6).toBe(0);
 });
 
-test("buildCountryOutlines includes a non-empty geometry for every 40-set country", () => {
+test("buildCountryOutlines includes a non-empty geometry for every chart-set country", () => {
   const outlines = buildCountryOutlines(realTopology);
 
   for (const country of COUNTRIES) {
@@ -46,7 +46,7 @@ test("buildCountryOutlines includes a non-empty geometry for every 40-set countr
   }
 });
 
-test("buildCountryOutlines exposes lat/lon rings for every 40-set country", () => {
+test("buildCountryOutlines exposes lat/lon rings for every chart-set country", () => {
   const outlines = buildCountryOutlines(realTopology);
 
   for (const country of COUNTRIES) {

--- a/src/lib/country-outlines.ts
+++ b/src/lib/country-outlines.ts
@@ -13,7 +13,7 @@ export interface CountryOutlines {
   byIsoRings: Map<number, CountryRings>;
 }
 
-const SET_40_ISO_NUMS = new Set(COUNTRIES.map((c) => c.isoNum));
+const CHART_COUNTRY_ISO_NUMS = new Set(COUNTRIES.map((c) => c.isoNum));
 
 export function buildCountryOutlines(
   topology: Topology<{ countries: GeometryCollection }>,
@@ -27,7 +27,7 @@ export function buildCountryOutlines(
 
   for (const f of collection.features) {
     const id = parseFeatureId(f.id);
-    const inSet = !Number.isNaN(id) && SET_40_ISO_NUMS.has(id);
+    const inSet = !Number.isNaN(id) && CHART_COUNTRY_ISO_NUMS.has(id);
     const rings = polygonToLatLonRings(f.geometry);
 
     const segmentTarget = inSet ? tier2Buffers : tier1Buffers;


### PR DESCRIPTION
## Why

The 2026 World Cup field is a natural coverage benchmark for a world-music discovery app, and 23 qualified nations were missing. This takes coverage from 40 to 63 countries and broadens regions that were thin — Africa goes from 2 to 11.

## What changed

- **`countries.ts`**: add 23 entries (`code`, `name`, `region`, capital `lat`/`lon`, `isoNum`) and update the per-region count comments.
  - AFC (4): Iraq, Jordan, Qatar, Uzbekistan
  - CAF (9): Algeria, Cabo Verde, DR Congo, Côte d'Ivoire, Egypt, Ghana, Morocco, Senegal, Tunisia
  - CONCACAF (1): Panama · CONMEBOL (3): Ecuador, Paraguay, Uruguay
  - UEFA (6): Austria, Belgium, Bosnia and Herzegovina, Croatia, Czechia, Switzerland
- **`country-outlines.ts`**: rename `SET_40_ISO_NUMS` → `CHART_COUNTRY_ISO_NUMS` (the name baked in the country count).
- **`country-outlines.test.ts`**: rename "40-set" test names to "chart-set".
- **`cron.ts`**: raise the crawl monitor `maxRuntime` 90 → 120 min. The crawl is a single 3s-gap throttle over 26 requests/country, so 63 countries run ~82 min vs ~52 for 40; 120 restores the prior buffer and keeps `checkinMargin + maxRuntime` (270) under the 300-min tightest slot gap.

### Excluded

Iran, Curaçao, and Haiti have no Apple Music storefront (RSS returns HTTP 500). Scotland is already covered by the single `gb` storefront.

## Test plan

- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓
- `pnpm test` — 259 passed; `country-outlines` asserts every chart-set country resolves a non-empty outline against `countries-50m.json`, so all 63 isoNums render (no topojson hand-supplementing).
- Pre-verified the data layer: all 23 storefronts return a 25-track feed; sampled small storefronts (Cabo Verde, DR Congo) show locally-relevant artists, full artwork, near-complete previews. Missing previews degrade gracefully (track kept with `previewUrl: null`, row disabled with a "No preview" label).
- Ran the dev globe: all new pins render, including the dense Africa cluster and the Cabo Verde island pin; country outlines draw; no runtime error from the data change.

## Notes

`package.json` is intentionally not bumped — the v1.3.0 version bump and tag are cut when the milestone ships (per #88). New countries ship without commentary, which is nullable per ADR-0007.

Closes #100