### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` to `1.2.0` to cut the **song context card** release. The annotated tag and GitHub Release follow this merge per the ADR-0005 checklist (#88).

## What ships in v1.2.0

First AI-content feature, additive: a short grounded per-track commentary (what a song is about + why it's charting there), shown as a tap-to-expand card and served static (per-request cost zero). Generated by human-in-the-loop refinement, not an automated API call (ADR-0007); no lyric reproduction or translation, hard-blocked by a no-lyric lint.

Slices, already merged to `main`:
- #97 — nullable `commentary` field on the chart schema (Slice A)
- #98 — ADR-0007: out-of-band human-curated commentary
- #99 — refinement workflow + crawl merge (Slice B)
- #101 — tap-to-expand card UI (Slice C)

## Note on the tag tree

`main` already stacks v1.3.0 (#102) on top, so this release commit's tree includes that World Cup data. The tag marks where v1.2.0 was cut, not a content-isolated snapshot; the v1.2.0 code boundary is the feature commits above, ending `9353fbc`. v1.3.0 is cut next, on top of this commit.

## Test plan

Bump-only change; no code paths touched. Pre-commit ran prettier + typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->