### PR TITLE
chore: release v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` to `1.3.0` to cut the **World Cup 2026 coverage** release. The annotated tag and GitHub Release follow this merge per the ADR-0005 checklist (#88).

## What ships in v1.3.0

Additive data expansion: charts grow from 40 to 63 countries by adding the 23 World Cup nations that have an Apple Music storefront. No committed UI feature; broadens thin regions (Africa 2 → 11). Iran, Curaçao, and Haiti are excluded (no storefront); Scotland is already covered by the `gb` storefront.

- #102 — expand chart coverage to 2026 World Cup nations (40 → 63), closes #100

## AC 3 verified live

The post-merge crawl (`lastUpdated 2026-06-16T00:19:33Z`) populated all 63 countries, and all 23 new countries carry a full 25-track feed — none missing, none empty. #100's AC 3 is ticked.

## Test plan

Bump-only change; no code paths touched. Pre-commit ran prettier + typecheck clean.