### PR TITLE
fix(crawl): wire COMMENTARY_BLOB_URL into the cron crawl

### DIFF
--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -23,6 +23,7 @@ jobs:
       SITE_URL: https://sounds-abroad.vercel.app
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
       CHARTS_BLOB_URL: ${{ secrets.CHARTS_BLOB_URL }}
+      COMMENTARY_BLOB_URL: ${{ secrets.COMMENTARY_BLOB_URL }}
       REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
 

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -28,6 +28,13 @@ const previousUrl = process.env.CHARTS_BLOB_URL;
 // Session-owned commentary store, baked into the served charts when present.
 // The crawl only reads it (ADR-0007). Absent → no commentary this run.
 const commentaryUrl = process.env.COMMENTARY_BLOB_URL;
+if (!commentaryUrl) {
+  // Optional by design, so absence must not abort; warn so a missing wire
+  // surfaces in the run output instead of silently skipping all commentary.
+  console.warn(
+    "[crawl] COMMENTARY_BLOB_URL not set: commentary will not be baked this run.",
+  );
+}
 
 // Short-lived process: must flush before exit so the monitor check-in + the
 // charts:published message actually reach Sentry. withMonitor returning is not


### PR DESCRIPTION
The commentary store was published and the secret set, but the cron workflow never passed `COMMENTARY_BLOB_URL` to the crawl process, so the bake step silently skipped and the song context card never went live. This maps the secret into the workflow `env` and warns when the var is absent so a missing wire is visible in run output instead of failing silently.

## Test plan
- Local CI matrix green (typecheck / lint / prettier).
- After merge: dispatch a manual `cron-crawl` run, then confirm served charts carry the 22 commentaries and a card renders at soundsabroad.app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for optional feature support.
  * Enhanced error handling with informative warning messages when optional configuration is missing, preventing workflow failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->