### PR TITLE
feat(commentary): require a claim risk tier on every blurb

### DIFF
--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -9,6 +9,7 @@ A short, grounded note about a charting track: what the song is about and why it
 - `lead` (required): a one-line conclusion, the first thing a reader sees.
 - `detail` (optional): a sentence or two of support, shown when the card expands.
 - `tag` (required): a short keyword; default to the worklist reason (new entry, rank jump, top debut), or a more specific one like "viral" when it fits.
+- `claim` (required): which kind of claim the blurb makes, `what-it-is` or `why-charting`. See "Classifying the claim" below.
 - `sources` (required): the URLs the claims rest on.
 - `generatedAt` (required): ISO timestamp of when the blurb was written.
 
@@ -22,6 +23,15 @@ It is never the song's lyrics. Commentary describes a song; it does not reproduc
 4. **Read every blurb** before publishing: no reproduced lyrics, claims match the sources, no overstatement. This read-through is the real guard; the lint is only a backstop.
 5. **Publish.** Run `pnpm commentary:publish <file>`. It hard-blocks on the schema and the no-lyric lint, backs up the live store, then uploads. A blocked publish uploads nothing.
 6. **Spot-check** the card on the site.
+
+## Classifying the claim
+
+Set `claim` to the blurb's risk tier, judged by its `lead`. The two tiers differ in how fast they go stale:
+
+- `what-it-is`: a stable note about the song itself. What it is about, its genre or mood, the artist, how it was made. These claims hold whether the track is at rank 1 or rank 50, so they age slowly. Example lead: "A long-running chart favorite."
+- `why-charting`: a time-sensitive note about the track's current chart movement. Why it entered, jumped, or went viral this week. These claims rest on a moment and go stale when the moment passes, so they carry higher risk. Example lead: "A new entry climbing fast this week."
+
+Classify by what the lead asserts, not by the worklist reason. If a blurb makes both kinds of claim, take the higher-risk tier: a lead that explains why a song is moving is `why-charting` even when it also says what the song is about. When the "why it is charting" claim does not clear the two-source bar, fall back to a `what-it-is` blurb rather than guessing.
 
 ## Source-authority policy
 

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -11,6 +11,7 @@ function validStore() {
     [commentaryKey("en", "Artist", "Song")]: {
       lead: "A blurb about the song.",
       tag: "new entry",
+      claim: "why-charting",
       sources: ["https://example.com/a"],
       generatedAt: "2026-05-16T00:00:00.000Z",
     },

--- a/scripts/commentary/prepublish.test.ts
+++ b/scripts/commentary/prepublish.test.ts
@@ -10,6 +10,7 @@ function validEntry() {
   return {
     lead: "A clean blurb about the song.",
     tag: "new entry",
+    claim: "why-charting",
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };

--- a/scripts/commentary/worklist.test.ts
+++ b/scripts/commentary/worklist.test.ts
@@ -34,6 +34,7 @@ function storeWith(...keys: string[]): CommentaryStore {
     store[key] = {
       lead: "Already written.",
       tag: "new entry",
+      claim: "why-charting",
       sources: ["https://example.com/a"],
       generatedAt: "2026-05-16T00:00:00.000Z",
     };

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -219,6 +219,7 @@ function commentaryEntry(lead: string) {
   return {
     lead,
     tag: "new entry",
+    claim: "why-charting" as const,
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-15T00:00:00.000Z",
   };

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -240,6 +240,7 @@ describe("TrackRow commentary card", () => {
     lead: "A new entry climbing fast this week.",
     detail: "Brief context on why the track is rising.",
     tag: "new entry",
+    claim: "why-charting",
     sources: [
       "https://www.billboard.com/charts",
       "https://pitchfork.com/reviews",
@@ -302,6 +303,7 @@ describe("TrackRow commentary card", () => {
       commentary: {
         lead: "A long-running chart favorite.",
         tag: "mainstay",
+        claim: "what-it-is",
         sources: ["https://npr.org/music"],
         generatedAt: "2026-04-25T03:00:00Z",
       },

--- a/src/lib/__fixtures__/charts.json
+++ b/src/lib/__fixtures__/charts.json
@@ -17,6 +17,7 @@
             "lead": "A new entry climbing fast this week.",
             "detail": "Short context about the track's rise.",
             "tag": "new entry",
+            "claim": "why-charting",
             "sources": [
               "https://example.com/source-a",
               "https://example.com/source-b"
@@ -59,6 +60,7 @@
           "commentary": {
             "lead": "A long-running chart favorite.",
             "tag": "mainstay",
+            "claim": "what-it-is",
             "sources": ["https://example.com/source-c"],
             "generatedAt": "2026-04-25T03:00:00Z"
           }

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -77,6 +77,7 @@ test("ChartFileSchema rejects commentary missing the required lead", () => {
             commentary: {
               detail: "Has detail but no lead.",
               tag: "new entry",
+              claim: "why-charting",
               sources: ["https://example.com/a"],
               generatedAt: "2026-05-16T00:00:00.000Z",
             },
@@ -108,6 +109,7 @@ test("ChartFileSchema rejects commentary with an empty sources array", () => {
             commentary: {
               lead: "Has a lead but no sources.",
               tag: "new entry",
+              claim: "why-charting",
               sources: [],
               generatedAt: "2026-05-16T00:00:00.000Z",
             },
@@ -138,6 +140,7 @@ test("ChartFileSchema rejects commentary missing the required tag", () => {
             spotifySearchUrl: "https://open.spotify.com/search/Test",
             commentary: {
               lead: "Has a lead but no tag.",
+              claim: "why-charting",
               sources: ["https://example.com/a"],
               generatedAt: "2026-05-16T00:00:00.000Z",
             },
@@ -148,6 +151,117 @@ test("ChartFileSchema rejects commentary missing the required tag", () => {
   };
 
   expect(() => ChartFileSchema.parse(withNoTag)).toThrow();
+});
+
+test("ChartFileSchema rejects commentary missing the required claim", () => {
+  const withNoClaim = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+            commentary: {
+              lead: "Has a lead but no claim.",
+              tag: "new entry",
+              sources: ["https://example.com/a"],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withNoClaim)).toThrow();
+});
+
+test("ChartFileSchema rejects a claim outside the allowed set", () => {
+  const withUnknownClaim = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/Test",
+            commentary: {
+              lead: "Has a lead and a bogus claim.",
+              tag: "new entry",
+              claim: "rank-jump",
+              sources: ["https://example.com/a"],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withUnknownClaim)).toThrow();
+});
+
+test("ChartFileSchema accepts both allowed claim values", () => {
+  const withBothClaims = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "What It Is",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifySearchUrl: "https://open.spotify.com/search/WhatItIs",
+            commentary: {
+              lead: "A stable note about the song itself.",
+              tag: "mainstay",
+              claim: "what-it-is",
+              sources: ["https://example.com/a"],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+          {
+            rank: 2,
+            name: "Why Charting",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/2",
+            spotifySearchUrl: "https://open.spotify.com/search/WhyCharting",
+            commentary: {
+              lead: "A time-sensitive note about the climb.",
+              tag: "new entry",
+              claim: "why-charting",
+              sources: ["https://example.com/b"],
+              generatedAt: "2026-05-16T00:00:00.000Z",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withBothClaims)).not.toThrow();
 });
 
 test("ChartFileSchema rejects an empty countries record", () => {

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -1,9 +1,17 @@
 import { z } from "zod";
 
+/**
+ * Which kind of claim a blurb makes, set at authoring time. `what-it-is` is a
+ * stable note about the song itself; `why-charting` is a time-sensitive note
+ * about its current chart movement, which carries a higher risk of going stale.
+ */
+export const ClaimSchema = z.enum(["what-it-is", "why-charting"]);
+
 export const CommentarySchema = z.object({
   lead: z.string().min(1),
   detail: z.string().min(1).optional(),
   tag: z.string().min(1),
+  claim: ClaimSchema,
   sources: z.array(z.url()).min(1),
   generatedAt: z.iso.datetime(),
 });
@@ -34,6 +42,7 @@ export const ChartFileSchema = z.object({
     }),
 });
 
+export type Claim = z.infer<typeof ClaimSchema>;
 export type Commentary = z.infer<typeof CommentarySchema>;
 export type Track = z.infer<typeof TrackSchema>;
 export type Country = z.infer<typeof CountrySchema>;

--- a/src/lib/commentary-store.test.ts
+++ b/src/lib/commentary-store.test.ts
@@ -42,6 +42,7 @@ test("commentaryForTrack returns the stored blurb on a key match", () => {
   const entry = {
     lead: "A blurb.",
     tag: "new entry",
+    claim: "why-charting" as const,
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };

--- a/src/lib/no-lyric-lint.test.ts
+++ b/src/lib/no-lyric-lint.test.ts
@@ -58,6 +58,7 @@ test("lintCommentary scans lead, detail, and tag", () => {
     lead: "A clean, lyric-free lead sentence.",
     detail: 'The hook repeats "na na na la la oh oh my my my" throughout.',
     tag: "na na na oh\nla la my my\noh oh na na",
+    claim: "what-it-is" as const,
     sources: ["https://example.com/a"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };
@@ -74,6 +75,7 @@ test("lintCommentary passes clean prose commentary", () => {
     detail:
       "The duo's first charting entry; momentum built over three weeks of streaming growth.",
     tag: "new entry",
+    claim: "why-charting" as const,
     sources: ["https://example.com/a", "https://example.com/b"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };


### PR DESCRIPTION
Adds a required `claim` risk tier (`what-it-is` | `why-charting`) to the commentary schema so later passes and the gate can route on it. First slice of the v1.4.0 risk-tiered commentary gate (PRD #105, ADR-0008).

The field lands on `CommentarySchema`; `CommentaryStoreSchema` reuses that schema, so the publish-candidate path enforces it too by construction. The playbook gains a "Classifying the claim" section. Adding a required field rippled `claim` into every existing commentary fixture/test.

## Acceptance criteria
- [x] Schema requires `claim` in {`what-it-is`, `why-charting`}; an entry missing it fails validation
- [x] The playbook documents how to classify a blurb
- [x] A candidate with `claim` round-trips publish → crawl → served chart unchanged
- [x] Schema validation is unit-tested (prior art: chart-schema tests)

## Test plan
- Local CI matrix green: typecheck / lint / `test:ci` (268 tests).

Closes #107
