### PR TITLE
feat(commentary): guard source authority at publish

### DIFF
--- a/scripts/commentary/prepublish.test.ts
+++ b/scripts/commentary/prepublish.test.ts
@@ -10,7 +10,7 @@ function validEntry() {
   return {
     lead: "A clean blurb about the song.",
     tag: "new entry",
-    sources: ["https://example.com/a"],
+    sources: ["https://www.billboard.com/a", "https://pitchfork.com/b"],
     generatedAt: "2026-05-16T00:00:00.000Z",
   };
 }
@@ -48,5 +48,38 @@ test("blocks an entry that trips the no-lyric lint", () => {
   expect(result.ok).toBe(false);
   if (!result.ok) {
     expect(result.errors.some((e) => e.startsWith("no-lyric"))).toBe(true);
+  }
+});
+
+test("blocks an entry sourced from a denylisted domain", () => {
+  const store = {
+    [KEY]: {
+      ...validEntry(),
+      sources: ["https://www.billboard.com/a", "https://www.azlyrics.com/b"],
+    },
+  };
+
+  const result = prepublishCheck(store);
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.errors.some((e) => e.startsWith("source-authority"))).toBe(
+      true,
+    );
+  }
+});
+
+test("blocks an entry with too few sources", () => {
+  const store = {
+    [KEY]: { ...validEntry(), sources: ["https://www.billboard.com/a"] },
+  };
+
+  const result = prepublishCheck(store);
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.errors.some((e) => e.startsWith("source-authority"))).toBe(
+      true,
+    );
   }
 });

--- a/scripts/commentary/prepublish.ts
+++ b/scripts/commentary/prepublish.ts
@@ -3,11 +3,14 @@ import {
   type CommentaryStore,
 } from "../../src/lib/commentary-store";
 import { lintCommentary } from "../../src/lib/no-lyric-lint";
+import { findSourceViolations } from "../../src/lib/source-authority";
 
 /**
- * The publish gate: a candidate store must parse to the schema AND clear the
- * no-lyric lint before it can go live. Either failure hard-blocks the upload
- * (ADR-0007). Pure, so the gate is tested without touching the blob store.
+ * The publish gate: a candidate store must parse to the schema, clear the
+ * no-lyric lint, AND clear the source-authority guard before it can go live.
+ * Any failure hard-blocks the upload (ADR-0007; the source-authority guard is
+ * an ADR-0008 addition that makes code the primary gate). Pure, so the gate is
+ * tested without touching the blob store.
  */
 export type PrepublishResult =
   | { ok: true; store: CommentaryStore }
@@ -29,6 +32,11 @@ export function prepublishCheck(raw: unknown): PrepublishResult {
   for (const [key, entry] of Object.entries(parsed.data)) {
     for (const risk of lintCommentary(entry)) {
       errors.push(`no-lyric (${risk.rule}) in "${key}": ${risk.excerpt}`);
+    }
+    for (const violation of findSourceViolations(entry)) {
+      errors.push(
+        `source-authority (${violation.rule}) in "${key}": ${violation.source}`,
+      );
     }
   }
   if (errors.length > 0) return { ok: false, errors };

--- a/src/lib/source-authority.test.ts
+++ b/src/lib/source-authority.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "vitest";
+
+import { findSourceViolations } from "./source-authority";
+
+function entry(sources: string[]) {
+  return {
+    lead: "A grounded note about the song.",
+    tag: "new entry",
+    sources,
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+}
+
+test("findSourceViolations passes two reputable sources", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://pitchfork.com/reviews/b",
+  ];
+
+  expect(findSourceViolations(entry(sources))).toEqual([]);
+});
+
+test("findSourceViolations flags a denylisted lyrics domain", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://www.azlyrics.com/lyrics/b",
+  ];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "denied-source")).toBe(true);
+});
+
+test("findSourceViolations names the offending denylisted source", () => {
+  const denied = "https://www.azlyrics.com/lyrics/b";
+  const sources = ["https://www.billboard.com/music/a", denied];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations).toContainEqual({ rule: "denied-source", source: denied });
+});
+
+test("findSourceViolations flags a fan-wiki subdomain on the registrable domain", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://some-artist.fandom.com/wiki/Song",
+  ];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "denied-source")).toBe(true);
+});
+
+test("findSourceViolations allows Genius alongside the lyrics-site denials", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://genius.com/some-song",
+  ];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "denied-source")).toBe(false);
+});
+
+test("findSourceViolations flags a single source as too few", () => {
+  const sources = ["https://www.billboard.com/music/a"];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "too-few-sources")).toBe(true);
+});
+
+test("findSourceViolations ignores www and casing when matching a denied domain", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://WWW.AZLyrics.com/lyrics/b",
+  ];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "denied-source")).toBe(true);
+});
+
+test("findSourceViolations reports both a denied source and too few sources", () => {
+  const sources = ["https://www.azlyrics.com/lyrics/b"];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "denied-source")).toBe(true);
+  expect(violations.some((v) => v.rule === "too-few-sources")).toBe(true);
+});

--- a/src/lib/source-authority.ts
+++ b/src/lib/source-authority.ts
@@ -1,0 +1,84 @@
+import type { Commentary } from "./chart-schema";
+
+/**
+ * Deterministic guard that every claim rests on authoritative sources, part of
+ * the code-primary publish gate (ADR-0008). It is tier-independent: it judges
+ * where a blurb's sources come from and how many there are, never what the
+ * blurb claims. The playbook's source-authority policy is codified here so a
+ * denylisted source or a thin source set hard-blocks publish in code, not by a
+ * reviewer remembering the policy.
+ */
+
+export interface SourceViolation {
+  rule: "denied-source" | "too-few-sources";
+  source: string;
+}
+
+// Two credible sources is the floor for a grounded blurb (playbook source
+// policy); below it, stay conservative or write nothing.
+const MIN_SOURCES = 2;
+
+// Registrable domains we never source a claim from. Lyrics sites reproduce the
+// words we license around; fan wikis and gossip/SEO farms are unreliable. The
+// match is on registrable domain, so any subdomain (lyrics.example) is covered.
+const DENIED_DOMAINS = new Set([
+  // Lyrics sites: pure lyrics, no editorial context to ground a claim on.
+  // (Genius is deliberately absent: its credits and annotations can ground a
+  // claim, and its lyric-reproduction risk is caught by the no-lyric lint.)
+  "azlyrics.com",
+  "metrolyrics.com",
+  "lyrics.com",
+  "musixmatch.com",
+  // Fan wikis: community-edited, not authoritative.
+  "fandom.com",
+  "wikia.com",
+  // Gossip / SEO content farms.
+  "tmz.com",
+  "popsugar.com",
+]);
+
+/**
+ * The registrable domain of a URL: host minus any leading "www." and lowered.
+ * A bare two-label domain ("example.com") is returned as-is; this is a
+ * pragmatic match, not a full public-suffix resolution.
+ */
+function registrableDomain(url: string): string | null {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  return host.replace(/^www\./, "");
+}
+
+function isDenied(domain: string): boolean {
+  if (DENIED_DOMAINS.has(domain)) return true;
+  // A subdomain of a denied domain is denied too (lyrics.example.com under
+  // example.com), matched on the registrable-domain suffix.
+  for (const denied of DENIED_DOMAINS) {
+    if (domain.endsWith(`.${denied}`)) return true;
+  }
+  return false;
+}
+
+/** Every source-authority violation across a commentary entry's sources. */
+export function findSourceViolations(entry: Commentary): SourceViolation[] {
+  const violations: SourceViolation[] = [];
+
+  for (const source of entry.sources) {
+    const domain = registrableDomain(source);
+    if (domain !== null && isDenied(domain)) {
+      violations.push({ rule: "denied-source", source });
+    }
+  }
+
+  if (entry.sources.length < MIN_SOURCES) {
+    violations.push({
+      rule: "too-few-sources",
+      source: `${entry.sources.length} of ${MIN_SOURCES} required`,
+    });
+  }
+
+  return violations;
+}


### PR DESCRIPTION
Codifies the playbook's source policy as a pure, tier-independent guard wired into the publish gate: a denylisted source or too few sources hard-blocks publish, naming the offending source and rule. Part of the v1.4.0 risk-tiered commentary gate (PRD #105, ADR-0008).

## Acceptance criteria
- [x] A pure guard takes a commentary entry and returns the source-authority violations (empty = pass)
- [x] Publish hard-blocks on a denylisted domain or too few sources, naming the source and rule
- [x] Allow/deny lists and the minimum count are unit-tested (prior art: `no-lyric-lint.test.ts`, `prepublish.test.ts`)

## Policy decisions (intentional, flagged for review)
- **Denylist + min-count, not a strict allowlist.** The playbook's allow set is open-ended ("established music press ... and equivalents", reputable market-specific sources), so a strict allowlist would false-block legitimate local sources in thin markets. The allowlist stays advisory in the playbook; code enforces the denylist + minimum count.
- **Genius is allowed.** Its credits and annotations can ground a claim, and its lyric-reproduction risk is already caught by the no-lyric lint (which scans the blurb text, not the source domain). Pure lyrics sites (azlyrics, metrolyrics, lyrics.com, musixmatch), fan wikis (fandom, wikia), and gossip/SEO farms (tmz, popsugar) stay denied.
- **`MIN_SOURCES = 2` applies to every entry.** The playbook mandates two sources for why-charting claims; this guard can't be tier-aware yet because it branches from `main` before #107's `claim` field exists. Uniform-2 is a conservative stopgap; a follow-up can make the count tier-aware once #107 and #108 are both on `main`.

## Test plan
- Local CI matrix green: typecheck / lint / `test:ci` (275 tests).

Closes #108
