### PR TITLE
feat(commentary): skip thin-market chart noise in the worklist

### DIFF
--- a/scripts/commentary/todo.ts
+++ b/scripts/commentary/todo.ts
@@ -28,7 +28,18 @@ const commentary = commentaryUrl
   ? ((await fetchCommentaryStore(commentaryUrl)) ?? {})
   : {};
 
-const worklist = computeWorklist({ current, previous, commentary });
+// Drop thin-market low-confidence positions instead of just down-ranking them,
+// so a focused pass writes only solid stories. See --json for the full list.
+const suppressLowConfidence = process.argv.includes(
+  "--suppress-low-confidence",
+);
+
+const worklist = computeWorklist({
+  current,
+  previous,
+  commentary,
+  options: { suppressLowConfidence },
+});
 
 if (process.argv.includes("--json")) {
   console.log(JSON.stringify(worklist, null, 2));
@@ -36,7 +47,8 @@ if (process.argv.includes("--json")) {
   console.log(`${worklist.length} track(s) to write:\n`);
   for (const item of worklist) {
     const where = item.countries.map((c) => `${c.cc}#${c.rank}`).join(", ");
-    console.log(`  [${item.reason}] ${item.name} by ${item.artist}`);
+    const flag = item.confidence === "low" ? " [low-confidence]" : "";
+    console.log(`  [${item.reason}]${flag} ${item.name} by ${item.artist}`);
     console.log(`      key: ${item.key}`);
     console.log(`      best rank ${item.bestRank} · ${where}\n`);
   }

--- a/scripts/commentary/worklist.test.ts
+++ b/scripts/commentary/worklist.test.ts
@@ -6,7 +6,7 @@ import {
   type CommentaryStore,
 } from "../../src/lib/commentary-store";
 
-import { computeWorklist } from "./worklist";
+import { chartConfidence, computeWorklist } from "./worklist";
 
 function track(rank: number, artist: string, name: string): Track {
   return {
@@ -177,4 +177,94 @@ test("sorts the worklist by best rank ascending", () => {
   const items = computeWorklist({ current, previous: null, commentary: {} });
 
   expect(items.map((i) => i.name)).toEqual(["First", "Second", "Third"]);
+});
+
+test("chartConfidence flags a lone-storefront placement as low", () => {
+  const level = chartConfidence([{ cc: "jp" }]);
+
+  expect(level).toBe("low");
+});
+
+test("chartConfidence still flags a same-region pair as low (adjacency alone is thin)", () => {
+  const level = chartConfidence([{ cc: "jp" }, { cc: "kr" }]);
+
+  expect(level).toBe("low");
+});
+
+test("chartConfidence trusts a placement reaching across two regions", () => {
+  const level = chartConfidence([{ cc: "jp" }, { cc: "us" }]);
+
+  expect(level).toBe("ok");
+});
+
+test("chartConfidence trusts a broad same-region footprint of three countries", () => {
+  const level = chartConfidence([{ cc: "jp" }, { cc: "kr" }, { cc: "tw" }]);
+
+  expect(level).toBe("ok");
+});
+
+test("flags a thin-market top placement with no breadth as low confidence", () => {
+  const current = chart({
+    jp: country("Japan", [track(1, "Artist A", "Deep Cut")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Deep Cut"]);
+  expect(items[0].confidence).toBe("low");
+});
+
+test("flags a placement in two same-region storefronts as low confidence", () => {
+  const current = chart({
+    jp: country("Japan", [track(1, "Artist A", "Regional Quirk")]),
+    kr: country("South Korea", [track(2, "Artist A", "Regional Quirk")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Regional Quirk"]);
+  expect(items[0].confidence).toBe("low");
+});
+
+test("trusts a genuine broad mover charting across countries", () => {
+  const current = chart({
+    us: country("United States", [track(3, "Artist A", "Hit")]),
+    de: country("Germany", [track(5, "Artist A", "Hit")]),
+    kr: country("South Korea", [track(7, "Artist A", "Hit")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Hit"]);
+  expect(items[0].confidence).toBe("ok");
+});
+
+test("down-ranks low-confidence items below confident ones by default", () => {
+  const current = chart({
+    jp: country("Japan", [track(1, "Artist A", "Thin #1")]),
+    us: country("United States", [track(8, "Artist B", "Broad Mover")]),
+    kr: country("South Korea", [track(9, "Artist B", "Broad Mover")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Broad Mover", "Thin #1"]);
+  expect(items.map((i) => i.confidence)).toEqual(["ok", "low"]);
+});
+
+test("suppresses low-confidence items entirely when asked", () => {
+  const current = chart({
+    jp: country("Japan", [track(1, "Artist A", "Thin #1")]),
+    us: country("United States", [track(8, "Artist B", "Broad Mover")]),
+    kr: country("South Korea", [track(9, "Artist B", "Broad Mover")]),
+  });
+
+  const items = computeWorklist({
+    current,
+    previous: null,
+    commentary: {},
+    options: { suppressLowConfidence: true },
+  });
+
+  expect(items.map((i) => i.name)).toEqual(["Broad Mover"]);
 });

--- a/scripts/commentary/worklist.ts
+++ b/scripts/commentary/worklist.ts
@@ -4,6 +4,7 @@ import {
   commentaryKey,
   type CommentaryStore,
 } from "../../src/lib/commentary-store";
+import { COUNTRIES, type Region } from "../../src/lib/countries";
 
 /**
  * The worklist for a refinement pass: which charting tracks still need a blurb.
@@ -20,6 +21,7 @@ export interface WorklistItem {
   name: string;
   bestRank: number;
   reason: WorklistReason;
+  confidence: ConfidenceLevel;
   countries: { cc: string; rank: number }[];
 }
 
@@ -29,6 +31,12 @@ export interface WorklistOptions {
   jumpBy?: number;
   /** Entering this rank or better counts as significant. */
   topDebutMax?: number;
+  /**
+   * Drop low-confidence positions entirely instead of down-ranking them. Default
+   * false: they stay on the list but sort after every confident item, so a pass
+   * spends effort on solid stories first and reaches thin-market noise last.
+   */
+  suppressLowConfidence?: boolean;
 }
 
 const DEFAULT_JUMP_BY = 10;
@@ -65,6 +73,51 @@ function aggregateByKey(
     }
   }
   return byKey;
+}
+
+/**
+ * Whether a track's chart footprint is solid enough to be worth writing about,
+ * orthogonal to how far it moved. The artifact this guards against: an album
+ * deep cut sitting near the top of one or two small storefronts and nowhere
+ * else, with no broad reach. Such a position is most likely a thin-market quirk,
+ * not a real story.
+ *
+ * Confidence is "ok" only on genuine breadth, since we hold no artist-home-market
+ * data and, by default, no day-over-day volatility. Two signals stand in for it:
+ *   1. cross-region reach: charting in 2+ distinct regions (a hit spilling past
+ *      its home region), or
+ *   2. a broad same-region footprint: 3+ distinct countries even within one
+ *      region (sustained regional reach, not a one-off storefront).
+ * Anything thinner is "low": a lone storefront, or two storefronts that share a
+ * region (adjacent markets alone don't separate a real regional hit from a
+ * thin-market quirk). Adjacency is necessary but not sufficient; breadth is.
+ */
+export type ConfidenceLevel = "low" | "ok";
+
+const BROAD_FOOTPRINT_MIN = 3;
+
+const REGION_BY_CC = new Map<string, Region>(
+  COUNTRIES.map((c) => [c.code, c.region]),
+);
+
+export function chartConfidence(
+  countries: readonly { cc: string }[],
+): ConfidenceLevel {
+  const distinctCountries = new Set(countries.map((c) => c.cc));
+  const distinctRegions = new Set<Region>();
+  for (const cc of distinctCountries) {
+    const region = REGION_BY_CC.get(cc);
+    if (region) distinctRegions.add(region);
+  }
+
+  // Spilled past one region: a hit, not a single-market quirk.
+  if (distinctRegions.size > 1) return "ok";
+
+  // Broad reach within a single region still reads as a real story.
+  if (distinctCountries.size >= BROAD_FOOTPRINT_MIN) return "ok";
+
+  // A lone storefront, or a same-region pair: too thin to trust.
+  return "low";
 }
 
 function bestRankByKey(
@@ -112,6 +165,7 @@ export function computeWorklist(input: {
   const lang = input.options?.lang ?? DEFAULT_LANG;
   const jumpBy = input.options?.jumpBy ?? DEFAULT_JUMP_BY;
   const topDebutMax = input.options?.topDebutMax ?? DEFAULT_TOP_DEBUT_MAX;
+  const suppressLowConfidence = input.options?.suppressLowConfidence ?? false;
 
   const current = aggregateByKey(input.current, lang);
   const previousBest = bestRankByKey(input.previous, lang);
@@ -128,17 +182,26 @@ export function computeWorklist(input: {
       topDebutMax,
     );
     if (!reason) continue;
+    const confidence = chartConfidence(agg.countries);
+    if (confidence === "low" && suppressLowConfidence) continue;
     items.push({
       key,
       artist: agg.artist,
       name: agg.name,
       bestRank: agg.bestRank,
       reason,
+      confidence,
       countries: [...agg.countries].sort((a, b) => a.rank - b.rank),
     });
   }
 
+  // Confident items first so a pass spends effort on them before any retained
+  // low-confidence ones; within a tier, by best rank then key for stability.
+  const confidenceWeight = (c: ConfidenceLevel) => (c === "low" ? 1 : 0);
   return items.sort(
-    (a, b) => a.bestRank - b.bestRank || a.key.localeCompare(b.key),
+    (a, b) =>
+      confidenceWeight(a.confidence) - confidenceWeight(b.confidence) ||
+      a.bestRank - b.bestRank ||
+      a.key.localeCompare(b.key),
   );
 }


### PR DESCRIPTION
Adds a chart-confidence signal so the commentary worklist suppresses or down-ranks thin-market noise before any effort is spent writing. Sibling of the v1.4.0 gate (upstream worklist/significance concern, PRD #105; touches ADR-0007's significance trigger).

The signal is region-aware: a placement clears the bar by reaching across two regions, or by a broad same-region footprint of 3+ countries. A lone storefront, or two that share a region, reads low-confidence. With no artist-home-market or day-over-day data on hand, breadth is the proxy.

## Acceptance criteria
- [x] A chart-confidence signal flags low-volume / high-volatility storefront positions _(no volatility data on hand by default; degrades to the cross-region/breadth proxy per the slice's graceful-degradation note)_
- [x] A single-country top placement absent from the artist's home and adjacent markets is flagged as low-confidence
- [x] The worklist suppresses (`--suppress-low-confidence`) or down-ranks low-confidence positions so effort skips them
- [x] The signal is unit-tested against thin-market and genuine-broad-movement fixtures

## Test plan
- Local CI matrix green: typecheck / lint / `test:ci` (274 tests).

Closes #112
