### PR TITLE
feat(commentary): lint a blurb's self-classified claim tier

### DIFF
--- a/src/lib/tier-consistency-lint.test.ts
+++ b/src/lib/tier-consistency-lint.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "vitest";
+
+import { findTierSignals, lintTierConsistency } from "./tier-consistency-lint";
+
+test("findTierSignals flags causal language", () => {
+  const text = "It charted because of a sync placement.";
+
+  expect(findTierSignals(text).some((v) => v.rule === "causal-language")).toBe(
+    true,
+  );
+});
+
+test("findTierSignals flags a multi-word causal marker", () => {
+  const text = "Its rise came thanks to a late-night performance.";
+
+  expect(findTierSignals(text).some((v) => v.rule === "causal-language")).toBe(
+    true,
+  );
+});
+
+test("findTierSignals flags temporal/virality language", () => {
+  const text = "The track surged across short-form video this week.";
+
+  expect(
+    findTierSignals(text).some((v) => v.rule === "temporal-language"),
+  ).toBe(true);
+});
+
+test("findTierSignals does not match a marker inside another word", () => {
+  const text = "A reflective ballad written thereafter the tour.";
+
+  expect(findTierSignals(text)).toEqual([]);
+});
+
+test("findTierSignals leaves a stable descriptive note alone", () => {
+  const text = "A mid-tempo ballad about a long-distance friendship.";
+
+  expect(findTierSignals(text)).toEqual([]);
+});
+
+test("findTierSignals leaves a descriptive 'named after' alone", () => {
+  const text = "A ballad named after the singer's hometown.";
+
+  expect(findTierSignals(text)).toEqual([]);
+});
+
+test("findTierSignals flags a causal 'after'", () => {
+  const text = "It took off after the World Cup broadcast.";
+
+  expect(findTierSignals(text)).toContainEqual({
+    rule: "causal-language",
+    marker: "after",
+  });
+});
+
+test("findTierSignals leaves a descriptive 'debut album' alone", () => {
+  const text = "The lead track from their debut album.";
+
+  expect(findTierSignals(text)).toEqual([]);
+});
+
+test("findTierSignals flags a charting 'debuted at'", () => {
+  const text = "It debuted at number one on the singles chart.";
+
+  expect(
+    findTierSignals(text).some((v) => v.rule === "temporal-language"),
+  ).toBe(true);
+});
+
+test("lintTierConsistency flags a what-it-is entry carrying causal language", () => {
+  const entry = {
+    lead: "The duo's breakthrough single.",
+    detail: "It climbed because of a viral dance challenge.",
+    tag: "breakthrough",
+    claim: "what-it-is" as const,
+    sources: ["https://example.com/a", "https://example.com/b"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+
+  expect(
+    lintTierConsistency(entry).some((v) => v.rule === "causal-language"),
+  ).toBe(true);
+});
+
+test("lintTierConsistency flags a what-it-is entry carrying temporal language", () => {
+  const entry = {
+    lead: "A single from the quartet.",
+    detail: "It surged up the chart in its first days out.",
+    tag: "introduction",
+    claim: "what-it-is" as const,
+    sources: ["https://example.com/a", "https://example.com/b"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+
+  expect(
+    lintTierConsistency(entry).some((v) => v.rule === "temporal-language"),
+  ).toBe(true);
+});
+
+test("lintTierConsistency passes a clean what-it-is entry", () => {
+  const entry = {
+    lead: "A mid-tempo ballad about a long-distance friendship.",
+    detail: "The artist's third studio single, sung in two languages.",
+    tag: "ballad",
+    claim: "what-it-is" as const,
+    sources: ["https://example.com/a", "https://example.com/b"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+
+  expect(lintTierConsistency(entry)).toEqual([]);
+});
+
+test("lintTierConsistency never flags a why-charting entry carrying the same language", () => {
+  const entry = {
+    lead: "Surging this week after a viral clip.",
+    detail: "It exploded because of a dance challenge and jumped 40 spots.",
+    tag: "trending",
+    claim: "why-charting" as const,
+    sources: ["https://example.com/a", "https://example.com/b"],
+    generatedAt: "2026-05-16T00:00:00.000Z",
+  };
+
+  expect(lintTierConsistency(entry)).toEqual([]);
+});

--- a/src/lib/tier-consistency-lint.ts
+++ b/src/lib/tier-consistency-lint.ts
@@ -1,0 +1,142 @@
+import type { Commentary } from "./chart-schema";
+
+/**
+ * Deterministic backstop on a blurb's self-classified claim tier. A
+ * `what-it-is` blurb is meant to be a stable note about the song; a
+ * `why-charting` blurb is the time-sensitive one that explains current chart
+ * movement (ADR-0008). This lint flags a `what-it-is` entry whose text actually
+ * reads like a why-charting claim (causal or temporal/virality language), so it
+ * can be routed to human review rather than auto-published under the wrong tier.
+ *
+ * It only ever flags `what-it-is`; the same language is allowed (and expected)
+ * in `why-charting`. Like the no-lyric lint, the vocabulary is tuned to flag
+ * rather than miss: a false flag costs a reviewer a glance, a mislabelled blurb
+ * that slips through lets a risky time-sensitive claim auto-publish as if it
+ * were stable. This is a FLAG-FOR-REVIEW signal, not a publish-blocking gate;
+ * the routing that consumes it is the gate classifier, a later slice.
+ */
+
+export interface TierConsistencyViolation {
+  rule: "causal-language" | "temporal-language";
+  marker: string;
+}
+
+/**
+ * Markers that assert a CAUSE for charting ("it charted because/after X"). A
+ * what-it-is blurb describes the song; reaching for cause is a why-charting
+ * move. Multi-word markers ("due to", "thanks to") are matched as phrases.
+ */
+const CAUSAL_MARKERS = [
+  "because",
+  "due to",
+  "thanks to",
+  "following",
+  "sparked",
+  "drove",
+  "driven by",
+  "fueled",
+  "fuelled",
+  "propelled",
+  "boosted",
+  "powered by",
+];
+
+/**
+ * Markers of momentum or virality ("surging this week", "blew up"). These
+ * describe a song's current MOVEMENT, which is a why-charting concern; a stable
+ * what-it-is note has no reason to reach for them.
+ */
+const TEMPORAL_MARKERS = [
+  "surged",
+  "surging",
+  "spiked",
+  "soared",
+  "soaring",
+  "viral",
+  "trending",
+  "this week",
+  "exploded",
+  "blew up",
+  // Charting-context debut phrases only: a bare "debut" describes a release
+  // ("their debut album") and must not flag; "debuted at #2" is chart movement.
+  "debuted at",
+  "debuted on",
+  "chart debut",
+  "climbing",
+  "jumped",
+  "skyrocketed",
+  "breakout",
+];
+
+/**
+ * To extend either list: add a phrase a why-charting blurb would use and a
+ * stable what-it-is note would not. Prefer over-inclusion; a false flag is
+ * cheap, a missed mislabel is not. Keep entries lowercase; matching is
+ * case-insensitive and on word boundaries, so a marker never fires on a
+ * substring inside another word ("surge" will not match "resurgence"). A word
+ * that reads both ways (like "debut", stable in "debut album" but charting in
+ * "debuted at #2") belongs as a charting-context PHRASE, not a bare word, or as
+ * a context-sensitive check like `after` below.
+ */
+
+function escapeForRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** A whole-word, case-insensitive match for a (possibly multi-word) marker. */
+function containsMarker(text: string, marker: string): boolean {
+  const pattern = new RegExp(`\\b${escapeForRegExp(marker)}\\b`, "i");
+  return pattern.test(text);
+}
+
+function findMarkers(
+  text: string,
+  markers: string[],
+  rule: TierConsistencyViolation["rule"],
+): TierConsistencyViolation[] {
+  return markers
+    .filter((marker) => containsMarker(text, marker))
+    .map((marker) => ({ rule, marker }));
+}
+
+/**
+ * "after" asserts a cause in charting prose ("it surged after the final") but
+ * is just as often a plain descriptive idiom ("named after a city", "after
+ * all"). A bare-word match over-flags, so strip the known idioms first and only
+ * count an "after" that survives. This is the one context-sensitive marker: the
+ * surrounding words, not the word alone, decide whether it is a why-charting cue.
+ */
+const AFTER_IDIOMS =
+  /\b(?:named|modell?ed|patterned|fashioned|look(?:ing|ed)?|sought)\s+after\b|\bafter\s+(?:all|hours|school)\b|\bafter[-\s]?part(?:y|ies)\b/gi;
+
+function hasCausalAfter(text: string): boolean {
+  return /\bafter\b/i.test(text.replace(AFTER_IDIOMS, " "));
+}
+
+/** Every tier-consistency signal in a single block of text. */
+export function findTierSignals(text: string): TierConsistencyViolation[] {
+  const violations = [
+    ...findMarkers(text, CAUSAL_MARKERS, "causal-language"),
+    ...findMarkers(text, TEMPORAL_MARKERS, "temporal-language"),
+  ];
+  if (hasCausalAfter(text)) {
+    violations.push({ rule: "causal-language", marker: "after" });
+  }
+  return violations;
+}
+
+/**
+ * Tier-consistency violations across a commentary entry's human-authored
+ * fields. A `why-charting` entry is never flagged: that language belongs there,
+ * so the lint short-circuits to an empty result before scanning any text.
+ */
+export function lintTierConsistency(
+  entry: Commentary,
+): TierConsistencyViolation[] {
+  if (entry.claim !== "what-it-is") return [];
+
+  const fields = [entry.lead, entry.detail, entry.tag].filter(
+    (f): f is string => typeof f === "string",
+  );
+  return fields.flatMap(findTierSignals);
+}


### PR DESCRIPTION
Backstops the author's self-classification of a blurb's risk tier: a `what-it-is` entry whose text actually reads like a why-charting claim (causal or temporal/virality language) is flagged so it can be routed to human review. Part of the v1.4.0 risk-tiered commentary gate (PRD #105, ADR-0008).

This is a **flag-for-review** signal, not a publish-blocking gate (unlike the no-lyric and source-authority guards). The routing that consumes the flag is the gate classifier (#111), a later slice, so this PR is the pure module + tests only and is intentionally not wired into `prepublish.ts`.

## Acceptance criteria
- [x] A pure lint takes a commentary entry and returns tier-consistency violations (empty = consistent)
- [x] A `what-it-is` entry with causal/temporal language is flagged; a clean one passes
- [x] A `why-charting` entry is never flagged (it short-circuits before scanning)
- [x] Unit-tested across signal and no-signal cases (prior art: `no-lyric-lint.test.ts`)

## Signal vocabulary: context matching, not bare words
Most markers match as bare words (`because`, `surged`, `viral`, `sparked`, ...). Two were prone to false flags on stable descriptions, so they are matched by context instead:
- **`debut`** is a charting cue only with a chart-position word, so it is matched as a phrase (`debuted at`, `debuted on`, `chart debut`). "their debut album" no longer flags.
- **`after`** reads causal in charting prose ("surged after the final") but is also a plain idiom ("named after a city"). Known idioms are stripped first; only a surviving `after` flags.

Tuned to flag-don't-miss: a false flag costs a reviewer a glance, a missed mislabel lets a risky time-sensitive claim auto-publish as stable. The module comments document how to extend the lists.

## Test plan
- Local CI matrix green: typecheck / lint / `test:ci` (300 tests; 13 in this file, including the "debut album"/"named after" pass cases and the "debuted at #1"/"took off after" flag cases).

Closes #109
