### PR TITLE
feat(commentary): add the grounding check, completing the automated gate

### DIFF
--- a/docs/adr/0007-out-of-band-human-curated-commentary.md
+++ b/docs/adr/0007-out-of-band-human-curated-commentary.md
@@ -15,11 +15,13 @@ Options weighed for where commentary is generated:
 
 ## Decision
 
+> **Trust model superseded by [ADR-0008](0008-risk-tiered-commentary-gate.md).** The "human-reviewed every entry" claims in this section describe the original uniform gate. Under ADR-0008 the safe `what-it-is` tier auto-publishes once the deterministic checks and an LLM grounding check pass; human review is kept for the risky `why-charting` tier and as spot-check sampling of the safe tier. Everything else here (out-of-band generation, the store, the significance trigger, the no-lyric lint) stands.
+
 Commentary is generated out-of-band and human-reviewed, never by the crawl. The crawl reads a commentary store and bakes each entry into the served chart data, leaving tracks without an entry as `null` (no card) and never aborting on a miss, the same carry-forward contract it already uses for failed fetches.
 
 - **Store:** a Vercel Blob sidecar, `commentary/v1/commentary.json`, keyed by `lang:normalized(artist|name)`. It is owned by the publish step; the crawl reads it but never writes it, a clean producer split from `charts.json` (which the crawl overwrites every run).
 - **Selection:** a deterministic significance trigger (new entry, large rank jump, re-entry) from current versus carried-forward ranks decides which tracks warrant commentary. Effort goes only to tracks with a story; an entry, once written, persists and is reused after the track stabilizes.
-- **No-lyric guard:** a deterministic lint hard-blocks publish on any entry resembling reproduced lyric text; the editor's read-through is the second layer. The guard runs at publish, not in the crawl.
+- **No-lyric guard:** a deterministic lint hard-blocks publish on any entry resembling reproduced lyric text; the editor's read-through is the second layer. The guard runs at publish, not in the crawl. (Under [ADR-0008](0008-risk-tiered-commentary-gate.md) the lint joins the primary code gate; the read-through second layer narrows to risky-tier review plus safe-tier sampling.)
 - **Cadence:** commentary is filled in by re-running the publish flow, not on a schedule. A brand-new track shows no card until the next pass.
 
 ### Why out-of-band over in-crawl
@@ -34,7 +36,7 @@ The data plane is already Vercel Blob: the crawl writes `charts.json` there and 
 
 **Positive**
 
-- Every published blurb is human-reviewed, the strongest guard against lyric leakage and inaccurate claims.
+- Every published blurb is human-reviewed, the strongest guard against lyric leakage and inaccurate claims. ([ADR-0008](0008-risk-tiered-commentary-gate.md) supersedes this: only the risky tier gets a full read-through, while the safe tier relies on the code checks plus sampling.)
 - The crawl stays a pure, LLM-free data feed with no new per-run cost or rate-limit surface.
 - The significance trigger bounds effort to tracks that have a story.
 

--- a/docs/adr/0008-risk-tiered-commentary-gate.md
+++ b/docs/adr/0008-risk-tiered-commentary-gate.md
@@ -4,6 +4,8 @@
 
 Supersedes the trust model of [ADR-0007](0007-out-of-band-human-curated-commentary.md). The rest of ADR-0007 (out-of-band generation, the Blob sidecar, the crawl read-and-bake contract, the significance trigger, the no-lyric lint) stands unchanged.
 
+> **Human disposition superseded by [ADR-0009](0009-fully-automated-commentary-gate.md).** The "risky tier always requires human review" and "human spot-checks the safe tier" decisions below are replaced: ADR-0009 removes the human from the publish path entirely, routing every fail-closed case to a dropped card instead of a person. The code-primary, risk-tiered structure of this ADR stands and becomes the whole gate.
+
 ## Context
 
 ADR-0007 made the human read-through the load-bearing guard for commentary: a person reads every blurb before publish, and the deterministic checks (schema, no-lyric lint) are a backstop. v1.2.0 then moved the goal toward automation: the `tag` field was made schema-required, motivated by treating commentary as an automated pipeline where per-blurb human review cannot be relied on. The two premises diverge: "human review is load-bearing" against "the pipeline cannot lean on per-entry human review."

--- a/docs/adr/0009-fully-automated-commentary-gate.md
+++ b/docs/adr/0009-fully-automated-commentary-gate.md
@@ -1,0 +1,52 @@
+# ADR-0009: Fully automated commentary gate, no human in the publish path
+
+**Status:** Accepted (2026-06-18)
+
+Supersedes the human-in-the-loop disposition of [ADR-0008](0008-risk-tiered-commentary-gate.md). The rest of ADR-0008 (code as the primary gate, the explicit risk tier, the deterministic checks, the grounding check) stands and is in fact made central. Only the human leaves: where ADR-0008 routed the risky tier to a person and sampled the safe tier, this ADR removes the person from the publish path entirely.
+
+## Context
+
+ADR-0008 kept the human on one axis (time-sensitive accuracy) and let code own the rest. Two facts make even that residual human role unsustainable. The maintainer is solo, and the roadmap expands commentary coverage from a handful of blurbs toward hundreds; at that volume, reviewing the risky tier and sampling the safe tier costs hours per pass that a solo project cannot spend. ADR-0008 named the underlying tension itself ("human review is load-bearing" against "the pipeline cannot lean on per-entry human review") and resolved it by targeting the human. This ADR finishes the move: take the human out of the path, because the code guards ADR-0008 introduced can carry both tiers once two things hold:
+
+- The default on any doubt is to drop the card, not to escalate to a person. The crawl's existing carry-forward contract (ADR-0007) already renders a missing blurb as no card, so a dropped blurb costs coverage, never correctness.
+- What is machine-verifiable is verified, and what is not is declined rather than guessed. This is the standard automated-fact-checking shape (retrieve, find evidence, judge whether the evidence states the claim, drop on "not enough"), the same shape ADR-0008's grounding check already follows.
+
+## Decision
+
+No human gates a publish. Every blurb passes or fails on code alone, and failure means no card.
+
+- **Code is the whole gate.** A blurb publishes only when it clears each deterministic check (the no-lyric lint, the source-authority guard, the tier-consistency lint) and the grounding check. Any failure drops the card. There is no review queue.
+- **Fail-closed means "no card," not "to a human."** An ungrounded, uncertain, or malformed grounding verdict, an unreachable source, or a judge error all drop the blurb. The worst case is lower coverage; a wrong public claim never auto-publishes.
+- **Both tiers run the same gate.** `why-charting` is no longer human-only. It auto-publishes when it clears the deterministic checks and grounding, and is dropped otherwise, exactly like `what-it-is`. The tier still selects how strictly a claim must be sourced (below), not whether a person sees it.
+- **Grounding judges against the sources that loaded, not all-or-nothing.** A claim is grounded only if a live source explicitly states it; a source that fails to fetch cannot ground anything, but the sources that did load still judge their own claims. Because STATES is the threshold, a claim whose only support was an unreachable source is dropped anyway. In the single-pass flow (draft, cite, ground on the same live sources) an unreachable cited source is an edge case, not the norm.
+- **For the risky tier, separate the verifiable fact from the speculative cause.** A chart-movement claim ("re-entered the top ten, a new peak") is verifiable from the pipeline's own current-versus-carried rank data and needs no external source. A causal claim ("after a film placement") is speculative and publishes only when an authoritative source states it; absent that, the causal clause is dropped while the movement fact stands.
+- **Confidence signals are binary gates, not a score.** Three signals decide a claim: grounding (a source states it), corroboration (how many sources state it), and source authority (a curated tier). Each is a yes/no gate, ANDed together, never summed into a number that a threshold then cuts. Corroboration counts may be logged for telemetry but do not gate on a tuned threshold.
+- **Source trust is curated, not learned.** Authority is a hand-maintained allowlist tier layered on the existing denylist (the NewsGuard / Media Bias-Fact Check pattern: a slow-moving registry a person owns). One top-tier source can stand in for corroboration; weaker sources need corroboration. A learned per-source reputation (the truth-discovery / Knowledge Vault loop) is deferred (see below).
+- **Spot-checking is optional and off the publish path.** The maintainer may audit samples at any time to confirm the gates hold; no publish waits on it.
+
+### Why binary gates over a confidence score
+
+The established systems that emit calibrated confidence scores earn the right to: Google's Knowledge Vault fuses web-scale extractor agreement with supervised learning to produce calibrated probabilities, NewsGuard's score is assigned by human analysts against weighted criteria, and RAGAS-style faithfulness ratios are an evaluation metric, not a publish gate. A score is only as trustworthy as its calibration, and calibration needs labeled outcomes (blurbs known right or wrong) that this project does not have. With an extreme cost asymmetry, a wrong public claim against a dropped card, an uncalibrated score is false precision. Binary gates on interpretable signals (a source states it; it is in the authority tier; N sources agree) need no calibration and fail safe. The same researched methods still apply, fact-checking entailment, authority tiering, multi-source corroboration; only the final combination is AND-of-gates rather than a weighted sum.
+
+### Why curated authority now and learned reputation later
+
+Learned reputation (a source's trust rising as it is seen to state facts that hold) is the truth-discovery loop, and it is the right method at web scale, where massive redundancy supplies the ground-truth signal the loop trains on. This pipeline produces no such signal: the grounding check confirms a claim is stated by a source, never that the claim is true in the world, and at this volume there is neither the redundancy nor the labels to converge a per-source score. Reputation here would be circular (learning from its own verdicts) or empty (cold-start on sources seen once). The curated authority list captures the same intent with a person as the slow update rule. Logging per-source pass and fail rates is cheap and feeds that manual curation, and is also the on-ramp: once enough labeled track record accumulates, or a machine-verifiable fact oracle (a structured music database, the chart data itself) is wired in, a learned reputation becomes calibratable.
+
+## Consequences
+
+**Positive**
+
+- The pipeline runs unattended. Coverage scales with drafting effort, not maintainer hours.
+- Everything published is code-verified end to end; the failure mode is a missing card, never a wrong one.
+- Lenient grounding keeps a card whose live sources fully support it, and the fact-versus-cause split keeps the risky tier publishable without trusting speculation.
+
+**Negative**
+
+- Coverage falls to whatever the gates pass. Flowery, inferred, or under-sourced blurbs never publish. The lever for low coverage is tighter drafting or a broader authority list, never loosening the gate.
+- Accuracy now rests entirely on the grounding LLM plus the lints, with no human sampling as a standing net. The residual risk is the grounding check's false negatives, bounded by the conservative STATES threshold and optional ad-hoc auditing. It remains an LLM checking an LLM.
+- The authority allowlist and the source pass/fail log are new maintenance, though light and asynchronous.
+
+**Neutral**
+
+- ADR-0007's architecture and ADR-0008's code-primary tiering are untouched; only the human disposition changes.
+- A confidence score and a learned reputation remain available as future work when labels or a verifiable oracle arrive.

--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -53,3 +53,15 @@ Card copy follows the house writing principles, tuned for a fast read:
 ## The no-lyric guard
 
 Publishing runs a deterministic lint that flags lyric-shaped content: long double-quoted runs, several short enjambed lines, and repeated lines. It is tuned to flag rather than miss, so it can flag a legitimate long quote or a list. When that happens, reword the copy or confirm it carries no lyrics and adjust. The lint cannot prove the absence of lyrics, which is why the read-through in step 4 is the load-bearing check.
+
+## The grounding check
+
+A second automated guard, added by [ADR-0008](adr/0008-risk-tiered-commentary-gate.md): an LLM confirms that a safe-tier blurb's cited sources actually state its claims, standing in for the human's claim-to-source read so the `what-it-is` tier can clear review without a full read-through. The risky `why-charting` tier always keeps the human read.
+
+**Threshold: the source must STATE the claim.** A claim is grounded only when a source explicitly states it. Being merely consistent with a source, or not contradicted by one, is not enough. The judge prompt encodes this threshold and asks for a three-way answer, `grounded`, `ungrounded`, or `uncertain`, so "I cannot tell" is a first-class verdict rather than a coin flip between pass and fail.
+
+**Fail-closed.** Only a confident `grounded` lets a blurb through. `ungrounded`, `uncertain`, a malformed answer, a failed source fetch, and a judge error all resolve to not-grounded, which routes the blurb to human review. A missed ungrounded claim auto-publishes a wrong public claim; a false flag costs one human read. The check errs toward the cheaper mistake.
+
+**Scope.** It grounds the `what-it-is` lead and optional detail against the cited sources, counting a claim as grounded when any one source states it. The `tag` is not grounded. The risky `why-charting` tier is out of scope and goes to a human regardless.
+
+**Backend.** The judge runs through the local Claude Code binary (`claude -p` with structured output), the only sanctioned way to spend the Claude subscription programmatically: the raw API rejects subscription OAuth and the consumer terms forbid reusing that token elsewhere. Each call carries a fixed harness cost billed against subscription quota, not dollars, so the check fits the current low-volume passes. A high-volume drafting pass would swap the backend for a metered API key, which touches only the injected client, not the verdict logic.

--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -56,12 +56,12 @@ Publishing runs a deterministic lint that flags lyric-shaped content: long doubl
 
 ## The grounding check
 
-A second automated guard, added by [ADR-0008](adr/0008-risk-tiered-commentary-gate.md): an LLM confirms that a safe-tier blurb's cited sources actually state its claims, standing in for the human's claim-to-source read so the `what-it-is` tier can clear review without a full read-through. The risky `why-charting` tier always keeps the human read.
+The automated accuracy guard, added by [ADR-0008](adr/0008-risk-tiered-commentary-gate.md) and made the sole gate by [ADR-0009](adr/0009-fully-automated-commentary-gate.md): an LLM confirms that a blurb's cited sources actually state its claims, in place of a human's claim-to-source read. Both tiers run it; a blurb that fails is dropped (no card), never queued for a person.
 
 **Threshold: the source must STATE the claim.** A claim is grounded only when a source explicitly states it. Being merely consistent with a source, or not contradicted by one, is not enough. The judge prompt encodes this threshold and asks for a three-way answer, `grounded`, `ungrounded`, or `uncertain`, so "I cannot tell" is a first-class verdict rather than a coin flip between pass and fail.
 
-**Fail-closed.** Only a confident `grounded` lets a blurb through. `ungrounded`, `uncertain`, a malformed answer, a failed source fetch, and a judge error all resolve to not-grounded, which routes the blurb to human review. A missed ungrounded claim auto-publishes a wrong public claim; a false flag costs one human read. The check errs toward the cheaper mistake.
+**Fail-closed.** Only a confident `grounded` lets a blurb through. `ungrounded`, `uncertain`, a malformed answer, and a judge error all resolve to not-grounded, which drops the card. A missed ungrounded claim auto-publishes a wrong public claim; a dropped card costs only coverage. The check errs toward the cheaper mistake.
 
-**Scope.** It grounds the `what-it-is` lead and optional detail against the cited sources, counting a claim as grounded when any one source states it. The `tag` is not grounded. The risky `why-charting` tier is out of scope and goes to a human regardless.
+**Scope.** It grounds the lead and optional detail against the cited sources, counting a claim as grounded when any one source states it. The `tag` is not grounded. On a partial fetch failure the judge reads whichever sources loaded: a claim whose only support was unreachable simply reads as ungrounded and drops. Only when every source is unreachable is the card dropped without judging.
 
 **Backend.** The judge runs through the local Claude Code binary (`claude -p` with structured output), the only sanctioned way to spend the Claude subscription programmatically: the raw API rejects subscription OAuth and the consumer terms forbid reusing that token elsewhere. Each call carries a fixed harness cost billed against subscription quota, not dollars, so the check fits the current low-volume passes. A high-volume drafting pass would swap the backend for a metered API key, which touches only the injected client, not the verdict logic.

--- a/scripts/commentary/ground.test.ts
+++ b/scripts/commentary/ground.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "vitest";
+
+import type { Commentary } from "../../src/lib/chart-schema";
+import type { GroundingClient } from "../../src/lib/grounding";
+
+import {
+  combineSourceTexts,
+  groundEntry,
+  type GroundEntryDeps,
+} from "./ground";
+
+// The real fetch and the claude -p subprocess stay out of these tests (the
+// injectable shell exists so they can); the pure verdict logic and the
+// fail-closed orchestration are exercised with injected dependencies.
+
+function entry(claim: Commentary["claim"], sources: string[]): Commentary {
+  return {
+    lead: "A lead claim.",
+    tag: "new",
+    claim,
+    sources,
+    generatedAt: "2026-06-18T00:00:00.000Z",
+  };
+}
+
+const groundedJudge: GroundingClient = async () => ({
+  status: "grounded",
+  reason: "The source states the claim.",
+});
+
+test("combineSourceTexts joins every loaded source for the judge", () => {
+  const result = combineSourceTexts(["first body", "second body"]);
+
+  expect(result).toEqual({ ok: true, sourceText: "first body\n\nsecond body" });
+});
+
+test("combineSourceTexts judges the sources that loaded on a partial failure", () => {
+  const result = combineSourceTexts(["live body", null]);
+
+  expect(result).toEqual({ ok: true, sourceText: "live body" });
+});
+
+test("combineSourceTexts drops the card when every source is unreachable", () => {
+  const result = combineSourceTexts([null, null]);
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.verdict.grounded).toBe(false);
+});
+
+test("groundEntry grounds a why-charting entry the same way as what-it-is", async () => {
+  const deps: GroundEntryDeps = {
+    fetchSourceText: async () => "source body",
+    judge: groundedJudge,
+  };
+
+  const verdict = await groundEntry(
+    entry("why-charting", ["https://example.com/1", "https://example.com/2"]),
+    deps,
+  );
+
+  expect(verdict.grounded).toBe(true);
+});
+
+test("groundEntry drops the card when every source is unreachable", async () => {
+  const deps: GroundEntryDeps = {
+    fetchSourceText: async () => null,
+    judge: groundedJudge,
+  };
+
+  const verdict = await groundEntry(
+    entry("what-it-is", ["https://example.com/1"]),
+    deps,
+  );
+
+  expect(verdict.grounded).toBe(false);
+});
+
+test("groundEntry fails closed when a source fetch throws", async () => {
+  const deps: GroundEntryDeps = {
+    fetchSourceText: async () => {
+      throw new Error("network down");
+    },
+    judge: groundedJudge,
+  };
+
+  const verdict = await groundEntry(
+    entry("what-it-is", ["https://example.com/1"]),
+    deps,
+  );
+
+  expect(verdict.grounded).toBe(false);
+});
+
+test("groundEntry fails closed when the judge throws", async () => {
+  const deps: GroundEntryDeps = {
+    fetchSourceText: async () => "source body",
+    judge: async () => {
+      throw new Error("judge down");
+    },
+  };
+
+  const verdict = await groundEntry(
+    entry("what-it-is", ["https://example.com/1"]),
+    deps,
+  );
+
+  expect(verdict.grounded).toBe(false);
+});

--- a/scripts/commentary/ground.ts
+++ b/scripts/commentary/ground.ts
@@ -138,15 +138,21 @@ export interface GroundEntryDeps {
 }
 
 /**
- * Ground one blurb end to end: fetch its cited sources, decide whether they can
- * fairly support a judgment, then ask the judge whether they STATE its claims.
- * Whether a given entry should be grounded at all (safe tier vs risky tier) is
- * the routing classifier's call, not this function's.
+ * Ground one blurb end to end: fetch its cited sources, then ask the judge
+ * whether they STATE its claims. Only the safe `what-it-is` tier is grounded;
+ * the risky `why-charting` tier is reviewed by a human regardless (ADR-0008),
+ * so it never reaches the judge.
  */
 export async function groundEntry(
   entry: Commentary,
   deps: GroundEntryDeps,
 ): Promise<GroundingVerdict> {
+  if (entry.claim !== "what-it-is") {
+    return {
+      grounded: false,
+      reason: "why-charting tier is reviewed by a human, not auto-grounded.",
+    };
+  }
   const texts = await Promise.all(
     entry.sources.map((url) => deps.fetchSourceText(url)),
   );

--- a/scripts/commentary/ground.ts
+++ b/scripts/commentary/ground.ts
@@ -65,7 +65,8 @@ export async function fetchSourceText(
  * turn; `--json-schema` forces the verdict into `.structured_output`.
  *
  * Fail-closed: any non-zero exit, timeout, non-JSON output, error envelope, or
- * missing structured output yields a status the seam routes to human review.
+ * missing structured output yields a status the seam treats as not-grounded,
+ * which drops the card (ADR-0009).
  */
 export function createClaudeJudge(timeoutMs = 60_000): GroundingClient {
   return async (prompt) => {
@@ -106,29 +107,31 @@ export function createClaudeJudge(timeoutMs = 60_000): GroundingClient {
 
 /**
  * Reduce the fetched source bodies to either the text the judge should read, or
- * a not-grounded verdict that skips the judge entirely. Fail-closed on any
- * unreachable source: a claim cited to a source we could not read is never
- * grounded on the sources that happened to load, since the unread one may be
- * the only one that states it. Any fetch failure routes the blurb to a human.
+ * a not-grounded verdict that skips the judge entirely. Lenient on a partial
+ * fetch failure: judge against the sources that loaded, since the STATES
+ * threshold drops any claim those live sources do not support, so a claim whose
+ * only support was an unreachable source is dropped anyway. Only when every
+ * source is unreachable is there nothing to judge, which drops the card
+ * (ADR-0009: fail-closed means no card).
  */
 export function combineSourceTexts(
   texts: Array<string | null>,
 ): { ok: true; sourceText: string } | { ok: false; verdict: GroundingVerdict } {
-  const missing = texts.filter((t) => t === null).length;
+  const loaded = texts.filter((t) => t !== null);
 
-  if (missing > 0) {
+  if (loaded.length === 0) {
     return {
       ok: false,
       verdict: {
         grounded: false,
-        reason: `${missing} of ${texts.length} cited source(s) failed to fetch — cannot verify grounding.`,
+        reason: `All ${texts.length} cited source(s) failed to fetch; dropping the card.`,
       },
     };
   }
 
   return {
     ok: true,
-    sourceText: texts.join("\n\n"),
+    sourceText: loaded.join("\n\n"),
   };
 }
 
@@ -139,20 +142,14 @@ export interface GroundEntryDeps {
 
 /**
  * Ground one blurb end to end: fetch its cited sources, then ask the judge
- * whether they STATE its claims. Only the safe `what-it-is` tier is grounded;
- * the risky `why-charting` tier is reviewed by a human regardless (ADR-0008),
- * so it never reaches the judge.
+ * whether they STATE its claims. Tier-agnostic (ADR-0009): both tiers are
+ * grounded the same way, and a not-grounded verdict drops the card rather than
+ * routing to a person.
  */
 export async function groundEntry(
   entry: Commentary,
   deps: GroundEntryDeps,
 ): Promise<GroundingVerdict> {
-  if (entry.claim !== "what-it-is") {
-    return {
-      grounded: false,
-      reason: "why-charting tier is reviewed by a human, not auto-grounded.",
-    };
-  }
   const texts = await Promise.all(
     entry.sources.map((url) => deps.fetchSourceText(url)),
   );

--- a/scripts/commentary/ground.ts
+++ b/scripts/commentary/ground.ts
@@ -144,21 +144,36 @@ export interface GroundEntryDeps {
  * Ground one blurb end to end: fetch its cited sources, then ask the judge
  * whether they STATE its claims. Tier-agnostic (ADR-0009): both tiers are
  * grounded the same way, and a not-grounded verdict drops the card rather than
- * routing to a person.
+ * routing to a person. This function is the fail-closed boundary: a throw from
+ * either dependency drops only this card, never aborting the publish pass. A
+ * thrown fetch is treated as an unreachable source, the same as a null.
  */
 export async function groundEntry(
   entry: Commentary,
   deps: GroundEntryDeps,
 ): Promise<GroundingVerdict> {
   const texts = await Promise.all(
-    entry.sources.map((url) => deps.fetchSourceText(url)),
+    entry.sources.map(async (url) => {
+      try {
+        return await deps.fetchSourceText(url);
+      } catch {
+        return null;
+      }
+    }),
   );
   const combined = combineSourceTexts(texts);
   if (!combined.ok) return combined.verdict;
-  return gradeGrounding(
-    entry.lead,
-    entry.detail,
-    combined.sourceText,
-    deps.judge,
-  );
+  try {
+    return await gradeGrounding(
+      entry.lead,
+      entry.detail,
+      combined.sourceText,
+      deps.judge,
+    );
+  } catch {
+    return {
+      grounded: false,
+      reason: "Grounding judge failed; dropping the card.",
+    };
+  }
 }

--- a/scripts/commentary/ground.ts
+++ b/scripts/commentary/ground.ts
@@ -1,0 +1,160 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Commentary } from "../../src/lib/chart-schema";
+import {
+  gradeGrounding,
+  type GroundingClient,
+  type GroundingVerdict,
+} from "../../src/lib/grounding";
+
+/**
+ * The grounding shell: the network-and-subprocess half of the check whose pure
+ * verdict logic lives in `src/lib/grounding.ts`. It fetches a blurb's cited
+ * sources, runs the `claude -p` judge, and routes the result through the seam.
+ * Kept out of unit tests on purpose — it touches the network and a subprocess;
+ * the tested seam holds the decision logic.
+ */
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The structured-output contract handed to `claude -p`. Forcing the tri-state
+ * shape means the shell reads one validated field instead of parsing prose.
+ */
+const JUDGE_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    status: { type: "string", enum: ["grounded", "ungrounded", "uncertain"] },
+    reason: { type: "string" },
+  },
+  required: ["status", "reason"],
+  additionalProperties: false,
+});
+
+/**
+ * Fetch a cited source and reduce it to plain text for the judge. Strips markup
+ * and collapses whitespace — crude on purpose, since the judge reads prose, not
+ * HTML. Returns null on any failure (bad status, network error, empty body) so
+ * the caller can fail closed rather than judge a claim against nothing.
+ */
+export async function fetchSourceText(
+  url: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<string | null> {
+  try {
+    const res = await fetchImpl(url);
+    if (!res.ok) return null;
+    const text = (await res.text())
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return text.length > 0 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A GroundingClient backed by the local Claude Code binary. `claude -p` is the
+ * only sanctioned way to spend the Max subscription programmatically: the raw
+ * API rejects subscription OAuth and the ToS forbids it. `--tools ''` and
+ * `--setting-sources ''` strip the agentic surface to a single classification
+ * turn; `--json-schema` forces the verdict into `.structured_output`.
+ *
+ * Fail-closed: any non-zero exit, timeout, non-JSON output, error envelope, or
+ * missing structured output yields a status the seam routes to human review.
+ */
+export function createClaudeJudge(timeoutMs = 60_000): GroundingClient {
+  return async (prompt) => {
+    try {
+      const { stdout } = await execFileAsync(
+        "claude",
+        [
+          "-p",
+          prompt,
+          "--output-format",
+          "json",
+          "--json-schema",
+          JUDGE_SCHEMA,
+          "--tools",
+          "",
+          "--setting-sources",
+          "",
+        ],
+        { timeout: timeoutMs, maxBuffer: 8 * 1024 * 1024 },
+      );
+      const envelope = JSON.parse(stdout) as {
+        is_error?: boolean;
+        structured_output?: { status?: unknown; reason?: unknown };
+      };
+      const out = envelope.structured_output;
+      if (envelope.is_error || !out || typeof out.status !== "string") {
+        return { status: "error", reason: "Judge returned no usable verdict." };
+      }
+      return {
+        status: out.status,
+        reason: typeof out.reason === "string" ? out.reason : undefined,
+      };
+    } catch {
+      return { status: "error", reason: "Judge invocation failed." };
+    }
+  };
+}
+
+/**
+ * Reduce the fetched source bodies to either the text the judge should read, or
+ * a not-grounded verdict that skips the judge entirely. This is the fail-closed
+ * seam between fetching and judging: a claim is grounded only if a source
+ * explicitly STATES it, so missing sources must never quietly become a pass.
+ */
+export function combineSourceTexts(
+  texts: Array<string | null>,
+): { ok: true; sourceText: string } | { ok: false; verdict: GroundingVerdict } {
+  const loaded = texts.filter((t) => t !== null);
+
+  if (loaded.length === 0) {
+    return {
+      ok: false,
+      verdict: {
+        grounded: false,
+        reason: `All ${texts.length} cited source(s) failed to fetch — cannot verify grounding.`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    sourceText: loaded.join("\n\n"),
+  };
+}
+
+export interface GroundEntryDeps {
+  fetchSourceText: (url: string) => Promise<string | null>;
+  judge: GroundingClient;
+}
+
+/**
+ * Ground one blurb end to end: fetch its cited sources, decide whether they can
+ * fairly support a judgment, then ask the judge whether they STATE its claims.
+ * Whether a given entry should be grounded at all (safe tier vs risky tier) is
+ * the routing classifier's call, not this function's.
+ */
+export async function groundEntry(
+  entry: Commentary,
+  deps: GroundEntryDeps,
+): Promise<GroundingVerdict> {
+  const texts = await Promise.all(
+    entry.sources.map((url) => deps.fetchSourceText(url)),
+  );
+  const combined = combineSourceTexts(texts);
+  if (!combined.ok) return combined.verdict;
+  return gradeGrounding(
+    entry.lead,
+    entry.detail,
+    combined.sourceText,
+    deps.judge,
+  );
+}

--- a/scripts/commentary/ground.ts
+++ b/scripts/commentary/ground.ts
@@ -106,28 +106,29 @@ export function createClaudeJudge(timeoutMs = 60_000): GroundingClient {
 
 /**
  * Reduce the fetched source bodies to either the text the judge should read, or
- * a not-grounded verdict that skips the judge entirely. This is the fail-closed
- * seam between fetching and judging: a claim is grounded only if a source
- * explicitly STATES it, so missing sources must never quietly become a pass.
+ * a not-grounded verdict that skips the judge entirely. Fail-closed on any
+ * unreachable source: a claim cited to a source we could not read is never
+ * grounded on the sources that happened to load, since the unread one may be
+ * the only one that states it. Any fetch failure routes the blurb to a human.
  */
 export function combineSourceTexts(
   texts: Array<string | null>,
 ): { ok: true; sourceText: string } | { ok: false; verdict: GroundingVerdict } {
-  const loaded = texts.filter((t) => t !== null);
+  const missing = texts.filter((t) => t === null).length;
 
-  if (loaded.length === 0) {
+  if (missing > 0) {
     return {
       ok: false,
       verdict: {
         grounded: false,
-        reason: `All ${texts.length} cited source(s) failed to fetch — cannot verify grounding.`,
+        reason: `${missing} of ${texts.length} cited source(s) failed to fetch — cannot verify grounding.`,
       },
     };
   }
 
   return {
     ok: true,
-    sourceText: loaded.join("\n\n"),
+    sourceText: texts.join("\n\n"),
   };
 }
 

--- a/src/lib/grounding.test.ts
+++ b/src/lib/grounding.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "vitest";
+
+import {
+  buildGroundingPrompt,
+  gradeGrounding,
+  type GroundingClient,
+  type RawGroundingJudgment,
+} from "./grounding";
+
+function judgeReturning(raw: RawGroundingJudgment): GroundingClient {
+  return async () => raw;
+}
+
+test("gradeGrounding returns grounded for a grounded judgment", async () => {
+  const judge = judgeReturning({
+    status: "grounded",
+    reason: "The source states the song debuted at number two.",
+  });
+
+  const verdict = await gradeGrounding(
+    "Debuted at #2.",
+    undefined,
+    "src",
+    judge,
+  );
+
+  expect(verdict).toEqual({
+    grounded: true,
+    reason: "The source states the song debuted at number two.",
+  });
+});
+
+test("gradeGrounding withholds grounding for an ungrounded judgment", async () => {
+  const judge = judgeReturning({
+    status: "ungrounded",
+    reason: "The source never mentions a chart position.",
+  });
+
+  const verdict = await gradeGrounding(
+    "Debuted at #2.",
+    undefined,
+    "src",
+    judge,
+  );
+
+  expect(verdict.grounded).toBe(false);
+  expect(verdict.reason.length).toBeGreaterThan(0);
+});
+
+test("gradeGrounding fails safe on an uncertain judgment", async () => {
+  const judge = judgeReturning({
+    status: "uncertain",
+    reason: "The source is ambiguous about the ranking.",
+  });
+
+  const verdict = await gradeGrounding(
+    "Debuted at #2.",
+    undefined,
+    "src",
+    judge,
+  );
+
+  expect(verdict.grounded).toBe(false);
+});
+
+test("gradeGrounding fails safe on an unrecognized status", async () => {
+  const judge = judgeReturning({ status: "maybe", reason: "unclear" });
+
+  const verdict = await gradeGrounding(
+    "Debuted at #2.",
+    undefined,
+    "src",
+    judge,
+  );
+
+  expect(verdict.grounded).toBe(false);
+});
+
+test("gradeGrounding yields a readable reason when the model omits one", async () => {
+  const judge = judgeReturning({ status: "banana" });
+
+  const verdict = await gradeGrounding(
+    "Debuted at #2.",
+    undefined,
+    "src",
+    judge,
+  );
+
+  expect(verdict.grounded).toBe(false);
+  expect(verdict.reason.length).toBeGreaterThan(0);
+});
+
+test("gradeGrounding grounds the lead alone when detail is empty", async () => {
+  let seenPrompt = "";
+  const judge: GroundingClient = async (prompt) => {
+    seenPrompt = prompt;
+    return { status: "grounded", reason: "ok" };
+  };
+
+  await gradeGrounding("A lead claim.", "", "the source text", judge);
+
+  expect(seenPrompt).toContain("A lead claim.");
+  expect(seenPrompt).not.toContain("undefined");
+});
+
+test("buildGroundingPrompt includes the claim and source text", () => {
+  const prompt = buildGroundingPrompt("The claim.", "The source body.");
+
+  expect(prompt).toContain("The claim.");
+  expect(prompt).toContain("The source body.");
+});
+
+test("buildGroundingPrompt states the explicit-statement threshold", () => {
+  const prompt = buildGroundingPrompt("c", "s");
+
+  expect(prompt).toContain("explicitly states");
+});

--- a/src/lib/grounding.test.ts
+++ b/src/lib/grounding.test.ts
@@ -76,6 +76,20 @@ test("gradeGrounding fails safe on an unrecognized status", async () => {
   expect(verdict.grounded).toBe(false);
 });
 
+test("gradeGrounding fails safe on a grounded judgment with no reason", async () => {
+  const judge = judgeReturning({ status: "grounded" });
+
+  const verdict = await gradeGrounding(
+    "Debuted at #2.",
+    undefined,
+    "src",
+    judge,
+  );
+
+  expect(verdict.grounded).toBe(false);
+  expect(verdict.reason.length).toBeGreaterThan(0);
+});
+
 test("gradeGrounding yields a readable reason when the model omits one", async () => {
   const judge = judgeReturning({ status: "banana" });
 

--- a/src/lib/grounding.ts
+++ b/src/lib/grounding.ts
@@ -1,16 +1,17 @@
 /**
  * The grounding check: an LLM confirms the cited sources actually STATE a
- * safe-tier blurb's claims before it can auto-publish (ADR-0008), standing in
- * for the human's claim-to-source read. This module is the pure verdict seam;
- * the fetch and model call live in an injectable shell so the decision logic is
- * tested without touching the network. The model is reached through an injected
+ * blurb's claims before it can auto-publish (ADR-0009), in place of a human's
+ * claim-to-source read. This module is the pure verdict seam; the fetch and
+ * model call live in an injectable shell so the decision logic is tested
+ * without touching the network. The model is reached through an injected
  * client, so the auth and model backend stay swappable here.
  *
  * Threshold is STATES, not merely consistent-with: a claim counts as grounded
  * only when a source explicitly states it. The model answers with a tri-state
  * judgment so the seam can fail safe on "uncertain" the same way it fails safe
- * on "ungrounded" — a missed ungrounded claim auto-publishes a wrong public
- * claim, while a false flag only costs one human review.
+ * on "ungrounded". A missed ungrounded claim auto-publishes a wrong public
+ * claim, while a false flag only drops one card, so the seam errs toward the
+ * cheaper mistake.
  */
 
 export interface GroundingVerdict {
@@ -34,7 +35,7 @@ export type GroundingClient = (prompt: string) => Promise<RawGroundingJudgment>;
 /**
  * The judge prompt. It states the STATES threshold explicitly and asks for a
  * tri-state answer, so "I cannot tell" is a first-class response the seam can
- * route to review rather than a coin-flip between grounded and not.
+ * collapse to not-grounded rather than a coin-flip between grounded and not.
  */
 export function buildGroundingPrompt(
   claimText: string,
@@ -77,7 +78,7 @@ export async function gradeGrounding(
  * Collapse the model's tri-state judgment into the boolean verdict the gate
  * classifier routes on. The collapse must fail safe: only a confident, well-formed "grounded"
  * yields `grounded: true`; "ungrounded", "uncertain", or any unexpected or
- * malformed value leaves the blurb for human review.
+ * malformed value leaves the blurb not-grounded, which drops the card.
  */
 function interpretJudgment(raw: RawGroundingJudgment): GroundingVerdict {
   const reason = raw.reason?.trim()

--- a/src/lib/grounding.ts
+++ b/src/lib/grounding.ts
@@ -1,0 +1,87 @@
+/**
+ * The grounding check: an LLM confirms the cited sources actually STATE a
+ * safe-tier blurb's claims before it can auto-publish (ADR-0008), standing in
+ * for the human's claim-to-source read. This module is the pure verdict seam;
+ * the fetch and model call live in an injectable shell so the decision logic is
+ * tested without touching the network. The model is reached through an injected
+ * client, so the auth and model backend stay swappable here.
+ *
+ * Threshold is STATES, not merely consistent-with: a claim counts as grounded
+ * only when a source explicitly states it. The model answers with a tri-state
+ * judgment so the seam can fail safe on "uncertain" the same way it fails safe
+ * on "ungrounded" — a missed ungrounded claim auto-publishes a wrong public
+ * claim, while a false flag only costs one human review.
+ */
+
+export interface GroundingVerdict {
+  grounded: boolean;
+  reason: string;
+}
+
+/**
+ * What the injected client returns: the model's own judgment. `status` is
+ * typed as a string, not the three-way union, because it is parsed from model
+ * output and can be anything; the seam defends against unexpected values rather
+ * than trusting the shape.
+ */
+export interface RawGroundingJudgment {
+  status: string;
+  reason?: string;
+}
+
+export type GroundingClient = (prompt: string) => Promise<RawGroundingJudgment>;
+
+/**
+ * The judge prompt. It states the STATES threshold explicitly and asks for a
+ * tri-state answer, so "I cannot tell" is a first-class response the seam can
+ * route to review rather than a coin-flip between grounded and not.
+ */
+export function buildGroundingPrompt(
+  claimText: string,
+  sourceText: string,
+): string {
+  return [
+    "You verify whether cited source text states the claims a short music blurb makes.",
+    "A claim is grounded ONLY if the source text explicitly states it. Being merely consistent with the source, or not contradicted by it, is NOT enough.",
+    'Answer "grounded" only when every claim is explicitly stated by the source. Answer "ungrounded" if any claim is not stated. Answer "uncertain" if you cannot tell.',
+    "",
+    'Respond with a JSON object: { "status": "grounded" | "ungrounded" | "uncertain", "reason": "<one sentence>" }.',
+    "",
+    "CLAIM:",
+    claimText,
+    "",
+    "SOURCE TEXT:",
+    sourceText,
+  ].join("\n");
+}
+
+/**
+ * The verdict seam: build the prompt from the blurb's claims, ask the injected
+ * client, and collapse its judgment into the boolean the gate classifier
+ * routes on. An empty `detail` grounds the lead alone.
+ */
+export async function gradeGrounding(
+  lead: string,
+  detail: string | undefined,
+  sourceText: string,
+  judge: GroundingClient,
+): Promise<GroundingVerdict> {
+  const claimText = [lead, detail]
+    .filter((t): t is string => Boolean(t && t.trim()))
+    .join("\n\n");
+  const raw = await judge(buildGroundingPrompt(claimText, sourceText));
+  return interpretJudgment(raw);
+}
+
+/**
+ * Collapse the model's tri-state judgment into the boolean verdict the gate
+ * classifier routes on. The collapse must fail safe: only a confident, well-formed "grounded"
+ * yields `grounded: true`; "ungrounded", "uncertain", or any unexpected or
+ * malformed value leaves the blurb for human review.
+ */
+function interpretJudgment(raw: RawGroundingJudgment): GroundingVerdict {
+  const reason = raw.reason?.trim()
+    ? raw.reason
+    : `No usable judgment (status: ${raw.status || "missing"}).`;
+  return { grounded: raw.status === "grounded", reason };
+}

--- a/src/lib/grounding.ts
+++ b/src/lib/grounding.ts
@@ -81,8 +81,13 @@ export async function gradeGrounding(
  * malformed value leaves the blurb not-grounded, which drops the card.
  */
 function interpretJudgment(raw: RawGroundingJudgment): GroundingVerdict {
-  const reason = raw.reason?.trim()
-    ? raw.reason
-    : `No usable judgment (status: ${raw.status || "missing"}).`;
-  return { grounded: raw.status === "grounded", reason };
+  const status = raw.status?.trim();
+  const reason = raw.reason?.trim();
+  if (status === "grounded" && reason) {
+    return { grounded: true, reason };
+  }
+  return {
+    grounded: false,
+    reason: reason || `No usable judgment (status: ${status || "missing"}).`,
+  };
 }


### PR DESCRIPTION
Closes #110

## What
The grounding check, the gate's accuracy guard (ADR-0008) and, with this branch, the piece that lets the gate run fully automated under ADR-0009. An LLM confirms a blurb's cited sources actually STATE its claims before it auto-publishes, in place of a human's claim-to-source read. Both tiers run it; a blurb that fails is dropped (no card), never queued for a person.

## How
- `src/lib/grounding.ts` — the pure verdict seam. `gradeGrounding(lead, detail, sourceText, client) -> { grounded, reason }`; the model is an injected client so auth/backend swap without touching the decision logic. Collapses the model's tri-state judgment to a boolean, fail-safe: only a confident `grounded` passes.
- `scripts/commentary/ground.ts` — the injectable shell (network + subprocess), kept out of the unit tests. Fetches sources, runs the judge via the local `claude -p` binary, wires them fail-closed. Lenient on a partial fetch failure: judges the sources that loaded, since the STATES threshold drops any claim whose only support was unreachable.
- `docs/adr/0009-fully-automated-commentary-gate.md` — supersedes ADR-0008's human disposition: no person in the publish path, fail-closed means a dropped card, both tiers grounded.
- `docs/commentary-playbook.md` — documents the STATES threshold, the judge prompt, and the `claude -p` backend.
- ADR-0007 / ADR-0008 — inline flags forward to where each is superseded.

## Backend: why claude -p
Verified live: the raw Messages API rejects subscription OAuth (HTTP 400) and the consumer terms forbid reusing that token, so the local Claude Code binary is the only sanctioned way to spend the subscription programmatically. Each call carries a fixed harness prime (~120k tokens observed; subscription quota, not dollars), fine for low-volume passes; a high-volume pass swaps to a metered API key behind the same injected client.

## Fail-closed by design
Every uncertain path drops the card (a missed ungrounded claim auto-publishes a wrong public claim; a dropped card costs only coverage): an uncertain, ungrounded, or malformed verdict, every cited source unreachable, or a judge error.

## Test plan
- `pnpm test` — 308 pass, incl. 8 new seam tests (grounded / ungrounded / uncertain / unrecognized / missing-reason / lead-only / prompt content)
- `pnpm typecheck`, `pnpm lint` — clean
- Live probe confirms `claude -p --json-schema` returns the validated verdict at `.structured_output`

## Follow-up (deferred in ADR-0009, not this PR)
Authority allowlist tier, corroboration counting, fact-versus-cause split for why-charting, LLM auto-drafting, per-source logging. The gate is complete without them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated grounding checks that verify music blurbs are supported by their cited sources.
  * Implemented fail-closed publishing system that automatically drops unsupported content.

* **Documentation**
  * Updated architecture decisions and playbook to document the fully automated publication verification system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->