### PR TITLE
feat(commentary): auto-draft worklist blurbs through the publish gate (#121)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "crawl": "tsx --env-file=.env.local scripts/crawl/main.ts",
     "crawl:cron": "tsx scripts/crawl/cron.ts",
     "commentary:todo": "tsx --env-file=.env.local scripts/commentary/todo.ts",
+    "commentary:draft": "tsx --env-file=.env.local scripts/commentary/draft-batch.ts",
     "commentary:publish": "tsx --env-file=.env.local scripts/commentary/publish.ts",
     "prepare": "husky"
   },

--- a/scripts/commentary/draft-batch.ts
+++ b/scripts/commentary/draft-batch.ts
@@ -1,0 +1,141 @@
+import type { Commentary } from "../../src/lib/chart-schema";
+import type { CommentaryStore } from "../../src/lib/commentary-store";
+import { fetchPublishedCharts } from "../crawl/published-charts";
+
+import { createClaudeDrafter, draftEntry } from "./draft";
+import { fetchCommentaryStore } from "./fetch-commentary";
+import { createClaudeJudge, fetchSourceText, groundEntry } from "./ground";
+import { routeStore } from "./route";
+import { backupCommentary, uploadCommentary } from "./upload-commentary";
+import { computeWorklist, type WorklistItem } from "./worklist";
+
+// Auto-drafts blurbs for the worklist, then routes each through the publish gate
+// and merges the survivors into the live store (#121). The drafter and the gate
+// both spend the subscription, so the batch is bounded by --limit and runs on
+// the laptop. See docs/commentary-playbook.md.
+
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  throw new Error(
+    "BLOB_READ_WRITE_TOKEN missing. Run via: pnpm commentary:draft.",
+  );
+}
+
+const chartsUrl = process.env.CHARTS_BLOB_URL;
+if (!chartsUrl) {
+  throw new Error("CHARTS_BLOB_URL missing. Set it to the charts.json URL.");
+}
+
+function flagValue(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+// Bound the batch: each item costs a drafter call and, if it drafts, a grounding
+// call. Default small so a run is observable and cheap; raise it deliberately.
+const limit = Number(flagValue("--limit") ?? 5);
+if (!Number.isInteger(limit) || limit < 1) {
+  throw new Error(`--limit must be a positive integer, got ${limit}.`);
+}
+// Optional case-insensitive filter on artist/title/key, to target specific
+// tracks (e.g. a well-documented song for a first live run).
+const grep = flagValue("--grep")?.toLowerCase();
+
+const current = await fetchPublishedCharts(chartsUrl);
+if (!current) {
+  throw new Error(`Could not read published charts from ${chartsUrl}.`);
+}
+
+const prevUrl = process.env.CHARTS_PREV_BLOB_URL;
+const previous = prevUrl ? await fetchPublishedCharts(prevUrl) : null;
+
+const commentaryUrl = process.env.COMMENTARY_BLOB_URL;
+const existing: CommentaryStore = commentaryUrl
+  ? ((await fetchCommentaryStore(commentaryUrl)) ?? {})
+  : {};
+
+// Suppress thin-market low-confidence positions: don't spend a drafter call on
+// noise the worklist would rank last anyway (#117).
+const worklist = computeWorklist({
+  current,
+  previous,
+  commentary: existing,
+  options: { suppressLowConfidence: true },
+});
+
+const matches = (item: WorklistItem): boolean =>
+  !grep ||
+  item.artist.toLowerCase().includes(grep) ||
+  item.name.toLowerCase().includes(grep) ||
+  item.key.toLowerCase().includes(grep);
+
+const selected = worklist.filter(matches).slice(0, limit);
+
+if (selected.length === 0) {
+  console.log("Nothing to draft (worklist empty or no --grep match).");
+  process.exit(0);
+}
+
+console.log(
+  `Drafting ${selected.length} of ${worklist.length} worklist item(s):`,
+);
+
+// One timestamp for the batch; every blurb is generated in this pass.
+const generatedAt = new Date().toISOString();
+const drafter = createClaudeDrafter();
+
+const candidates: CommentaryStore = {};
+for (const item of selected) {
+  console.log(`  drafting "${item.name}" by ${item.artist}...`);
+  const draft = await draftEntry(item, generatedAt, drafter);
+  if (!draft) {
+    console.warn(
+      `    could not draft (malformed or research failed); skipping.`,
+    );
+    continue;
+  }
+  candidates[item.key] = draft;
+}
+
+const draftedCount = Object.keys(candidates).length;
+if (draftedCount === 0) {
+  console.error(
+    "No blurbs drafted. Nothing to route; the live store is unchanged.",
+  );
+  process.exit(1);
+}
+
+// Route only the new drafts through the gate. The existing store already passed
+// when it was published, so re-routing it would re-spend grounding calls and
+// could drop a card whose source has since gone stale.
+const judge = createClaudeJudge();
+const ground = (entry: Commentary) =>
+  groundEntry(entry, { fetchSourceText, judge });
+
+const { published, dropped } = await routeStore(candidates, { ground });
+for (const { key, reasons } of dropped) {
+  console.warn(`Dropped "${key}": ${reasons.join("; ")}`);
+}
+
+const survivors = Object.keys(published).length;
+if (survivors === 0) {
+  console.log(
+    `No drafts cleared the gate (${dropped.length} dropped). The live store is unchanged.`,
+  );
+  process.exit(0);
+}
+
+// The worklist excludes keys that already have a blurb, so the merge is purely
+// additive: new survivors join the live store, the existing cards are untouched.
+const merged: CommentaryStore = { ...existing, ...published };
+
+// Snapshot the live store before overwriting, so a bad batch can be undone.
+// Absent only if commentary has never been published.
+if (commentaryUrl) {
+  const backupUrl = await backupCommentary(commentaryUrl, generatedAt);
+  console.log(`Backed up current store -> ${backupUrl}`);
+}
+
+const url = await uploadCommentary(merged);
+console.log(
+  `Published ${survivors} new blurb(s), dropped ${dropped.length}; store now ${Object.keys(merged).length} -> ${url}`,
+);

--- a/scripts/commentary/draft-batch.ts
+++ b/scripts/commentary/draft-batch.ts
@@ -3,7 +3,7 @@ import type { CommentaryStore } from "../../src/lib/commentary-store";
 import { fetchPublishedCharts } from "../crawl/published-charts";
 
 import { createClaudeDrafter, draftEntry } from "./draft";
-import { fetchCommentaryStore } from "./fetch-commentary";
+import { fetchCommentaryStoreRaw } from "./fetch-commentary";
 import { createClaudeJudge, fetchSourceText, groundEntry } from "./ground";
 import { routeStore } from "./route";
 import { backupCommentary, uploadCommentary } from "./upload-commentary";
@@ -48,9 +48,13 @@ if (!current) {
 const prevUrl = process.env.CHARTS_PREV_BLOB_URL;
 const previous = prevUrl ? await fetchPublishedCharts(prevUrl) : null;
 
+// Read the live store raw, never schema-validated: one entry that fails the
+// since-tightened schema must not void the whole store, and a failed read must
+// abort (fetchCommentaryStoreRaw throws) rather than leave an empty base that
+// the additive merge would overwrite the live cards with.
 const commentaryUrl = process.env.COMMENTARY_BLOB_URL;
 const existing: CommentaryStore = commentaryUrl
-  ? ((await fetchCommentaryStore(commentaryUrl)) ?? {})
+  ? await fetchCommentaryStoreRaw(commentaryUrl)
   : {};
 
 // Suppress thin-market low-confidence positions: don't spend a drafter call on
@@ -94,6 +98,13 @@ for (const item of selected) {
     continue;
   }
   candidates[item.key] = draft;
+  // Echo the full blurb the drafter produced so a run shows every field a drop
+  // is judged against (tag and detail trip lints too) and the sources the
+  // allowlist grows from.
+  console.log(`    [${draft.claim}] tag: ${draft.tag}`);
+  console.log(`    lead: ${draft.lead}`);
+  if (draft.detail) console.log(`    detail: ${draft.detail}`);
+  console.log(`    sources: ${draft.sources.join(", ")}`);
 }
 
 const draftedCount = Object.keys(candidates).length;
@@ -127,6 +138,15 @@ if (survivors === 0) {
 // The worklist excludes keys that already have a blurb, so the merge is purely
 // additive: new survivors join the live store, the existing cards are untouched.
 const merged: CommentaryStore = { ...existing, ...published };
+
+// Defense in depth before a destructive overwrite: an additive merge can only
+// grow the store, so a smaller result means the existing read was wrong. Abort
+// rather than publish a store that drops live cards.
+if (Object.keys(merged).length < Object.keys(existing).length) {
+  throw new Error(
+    "Merge would shrink the store; aborting before overwrite to protect the live cards.",
+  );
+}
 
 // Snapshot the live store before overwriting, so a bad batch can be undone.
 // Absent only if commentary has never been published.

--- a/scripts/commentary/draft.test.ts
+++ b/scripts/commentary/draft.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "vitest";
+
+import type { DraftClient, RawDraft } from "../../src/lib/drafting";
+
+import { draftEntry, toDraftInput } from "./draft";
+import type { WorklistItem } from "./worklist";
+
+// The claude -p subprocess stays out of these tests (the injectable drafter
+// exists so it can); the pure mapping and the fail-closed orchestration are
+// exercised with an injected client.
+
+function item(overrides: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    key: "en:artist|song",
+    artist: "Artist",
+    name: "Song",
+    bestRank: 3,
+    reason: "new-entry",
+    confidence: "ok",
+    countries: [
+      { cc: "us", rank: 3 },
+      { cc: "ca", rank: 5 },
+    ],
+    ...overrides,
+  };
+}
+
+const TS = "2026-06-19T00:00:00.000Z";
+
+const validDrafter: DraftClient = async () => ({
+  lead: "A clean blurb about the song.",
+  tag: "new entry",
+  claim: "why-charting",
+  sources: ["https://www.billboard.com/a", "https://pitchfork.com/b"],
+});
+
+test("toDraftInput maps chart positions to cc#rank tokens", () => {
+  expect(toDraftInput(item()).chartedIn).toEqual(["us#3", "ca#5"]);
+});
+
+test("toDraftInput passes the artist and title through unchanged", () => {
+  const input = toDraftInput(item({ artist: "aespa", name: "LEMONADE" }));
+
+  expect(input.artist).toBe("aespa");
+  expect(input.name).toBe("LEMONADE");
+});
+
+test("draftEntry stamps the supplied timestamp on a valid draft", async () => {
+  const entry = await draftEntry(item(), TS, validDrafter);
+
+  expect(entry?.generatedAt).toBe(TS);
+});
+
+test("draftEntry returns null when the drafter throws", async () => {
+  const drafter: DraftClient = async () => {
+    throw new Error("subprocess down");
+  };
+
+  expect(await draftEntry(item(), TS, drafter)).toBeNull();
+});
+
+test("draftEntry returns null when the draft fails the schema", async () => {
+  const badDrafter: DraftClient = async () =>
+    ({ lead: "", tag: "x", claim: "why-charting", sources: [] }) as RawDraft;
+
+  expect(await draftEntry(item(), TS, badDrafter)).toBeNull();
+});

--- a/scripts/commentary/draft.ts
+++ b/scripts/commentary/draft.ts
@@ -44,12 +44,16 @@ const RAW_DRAFT_SCHEMA = JSON.stringify({
 
 /**
  * A DraftClient backed by the local Claude Code binary. Unlike the grounding
- * judge, the drafter KEEPS web search and fetch on (`--tools WebSearch,WebFetch`)
- * — it must research the track before writing — while `--setting-sources ""`
- * still strips project settings to a clean turn. `--json-schema` forces the
- * draft into `.structured_output`. `claude -p` is the only sanctioned way to
- * spend the Max subscription programmatically (the raw API rejects subscription
- * OAuth), behind this seam so an SDK key can replace it in one place later.
+ * judge, the drafter must research before writing, so it keeps the web tools:
+ * `--tools` makes only WebSearch and WebFetch available, and `--allowedTools`
+ * permits them — both are needed, since in non-interactive mode an available
+ * but un-permitted tool is auto-denied and the model drafts blind. The narrow
+ * surface (no Bash/Edit) keeps it scoped rather than `--dangerously-skip-
+ * permissions`. `--setting-sources ""` still strips project settings to a clean
+ * turn; `--json-schema` forces the draft into `.structured_output`. `claude -p`
+ * is the only sanctioned way to spend the Max subscription programmatically (the
+ * raw API rejects subscription OAuth), behind this seam so an SDK key can
+ * replace it in one place later.
  *
  * Throws on any non-zero exit, timeout, non-JSON output, or error envelope, so
  * the caller fails closed to no card rather than drafting against nothing.
@@ -66,6 +70,8 @@ export function createClaudeDrafter(timeoutMs = 180_000): DraftClient {
         "--json-schema",
         RAW_DRAFT_SCHEMA,
         "--tools",
+        "WebSearch,WebFetch",
+        "--allowedTools",
         "WebSearch,WebFetch",
         "--setting-sources",
         "",

--- a/scripts/commentary/draft.ts
+++ b/scripts/commentary/draft.ts
@@ -128,7 +128,11 @@ export async function draftEntry(
 ): Promise<Commentary | null> {
   try {
     return await draftBlurb(toDraftInput(item), generatedAt, drafter);
-  } catch {
+  } catch (error) {
+    // Fail closed to null, but name why: a thrown draft is a drafter failure
+    // (subprocess down, timeout) the batch log should surface, not silently drop.
+    const reason = error instanceof Error ? error.message : String(error);
+    console.warn(`drafting "${item.name}" by ${item.artist} failed: ${reason}`);
     return null;
   }
 }

--- a/scripts/commentary/draft.ts
+++ b/scripts/commentary/draft.ts
@@ -1,0 +1,128 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Commentary } from "../../src/lib/chart-schema";
+import {
+  draftBlurb,
+  type DraftClient,
+  type DraftInput,
+  type RawDraft,
+} from "../../src/lib/drafting";
+
+import type { WorklistItem, WorklistReason } from "./worklist";
+
+/**
+ * The drafting shell: the subprocess half of auto-drafting, whose pure prompt
+ * and validation logic live in `src/lib/drafting.ts`. It maps a worklist item to
+ * the prompt facts, runs `claude -p` with web search to research and draft, and
+ * routes the result through the seam. Kept out of unit tests on purpose — it
+ * spends the subscription and reaches the network; the tested seam and the
+ * `toDraftInput` mapping below hold the decision logic.
+ */
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The structured-output contract handed to `claude -p`. Forcing the draft shape
+ * means the shell reads validated fields instead of parsing prose; the claim
+ * enum keeps the model on a known tier. `sources` is floored at two here, the
+ * gate's corroboration minimum, so the model aims above the bar rather than at
+ * the schema's one-source floor.
+ */
+const RAW_DRAFT_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    lead: { type: "string" },
+    detail: { type: "string" },
+    tag: { type: "string" },
+    claim: { type: "string", enum: ["what-it-is", "why-charting"] },
+    sources: { type: "array", items: { type: "string" }, minItems: 2 },
+  },
+  required: ["lead", "tag", "claim", "sources"],
+  additionalProperties: false,
+});
+
+/**
+ * A DraftClient backed by the local Claude Code binary. Unlike the grounding
+ * judge, the drafter KEEPS web search and fetch on (`--tools WebSearch,WebFetch`)
+ * — it must research the track before writing — while `--setting-sources ""`
+ * still strips project settings to a clean turn. `--json-schema` forces the
+ * draft into `.structured_output`. `claude -p` is the only sanctioned way to
+ * spend the Max subscription programmatically (the raw API rejects subscription
+ * OAuth), behind this seam so an SDK key can replace it in one place later.
+ *
+ * Throws on any non-zero exit, timeout, non-JSON output, or error envelope, so
+ * the caller fails closed to no card rather than drafting against nothing.
+ */
+export function createClaudeDrafter(timeoutMs = 180_000): DraftClient {
+  return async (prompt) => {
+    const { stdout } = await execFileAsync(
+      "claude",
+      [
+        "-p",
+        prompt,
+        "--output-format",
+        "json",
+        "--json-schema",
+        RAW_DRAFT_SCHEMA,
+        "--tools",
+        "WebSearch,WebFetch",
+        "--setting-sources",
+        "",
+      ],
+      { timeout: timeoutMs, maxBuffer: 8 * 1024 * 1024 },
+    );
+    const envelope = JSON.parse(stdout) as {
+      is_error?: boolean;
+      structured_output?: unknown;
+    };
+    if (envelope.is_error || !envelope.structured_output) {
+      throw new Error("Drafter returned no structured output.");
+    }
+    return envelope.structured_output as RawDraft;
+  };
+}
+
+/**
+ * Plain-words context for each worklist reason, steering what the model
+ * researches. The phrasing is the only signal the drafter gets for WHY a track
+ * is worth a blurb, so it should read as a human would describe the chart move,
+ * not echo the enum.
+ */
+const SIGNIFICANCE: Record<WorklistReason, (bestRank: number) => string> = {
+  "new-entry": (r) => `a new chart entry, peaking at #${r}`,
+  "rank-jump": (r) => `a sharp climb up the chart, now peaking at #${r}`,
+  "top-debut": (r) => `a strong move into the upper chart, peaking at #${r}`,
+};
+
+/**
+ * Map a worklist item to the facts the draft prompt is built from: the chart
+ * positions as `cc#rank` tokens and the significance as plain words. Pure, so
+ * the mapping is tested without the subprocess.
+ */
+export function toDraftInput(item: WorklistItem): DraftInput {
+  return {
+    artist: item.artist,
+    name: item.name,
+    significance: SIGNIFICANCE[item.reason](item.bestRank),
+    chartedIn: item.countries.map((c) => `${c.cc}#${c.rank}`),
+  };
+}
+
+/**
+ * Draft one blurb for a worklist item end to end. The fail-closed boundary: a
+ * throw from the drafter (subprocess down, timeout, bad output) drops only this
+ * card as null, never aborting the batch. The draft is still only a candidate;
+ * the publish gate decides what ships.
+ */
+export async function draftEntry(
+  item: WorklistItem,
+  generatedAt: string,
+  drafter: DraftClient,
+): Promise<Commentary | null> {
+  try {
+    return await draftBlurb(toDraftInput(item), generatedAt, drafter);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -98,3 +98,9 @@ test("fetchCommentaryStoreRaw throws on a failed read rather than returning empt
     ),
   ).rejects.toThrow();
 });
+
+test("fetchCommentaryStoreRaw throws on a non-object payload rather than merging it", async () => {
+  await expect(
+    fetchCommentaryStoreRaw(URL, fakeFetch({ body: JSON.stringify([]) })),
+  ).rejects.toThrow();
+});

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from "vitest";
 
 import { commentaryKey } from "../../src/lib/commentary-store";
 
-import { fetchCommentaryStore } from "./fetch-commentary";
+import {
+  fetchCommentaryStore,
+  fetchCommentaryStoreRaw,
+} from "./fetch-commentary";
 
 const URL = "https://blob/commentary/v1/commentary.json";
 
@@ -75,4 +78,23 @@ test("returns null when fetch rejects", async () => {
   const result = await fetchCommentaryStore(URL, failingFetch);
 
   expect(result).toBeNull();
+});
+
+test("fetchCommentaryStoreRaw keeps an entry the strict schema would reject", async () => {
+  // The strict read returns null for this same body (see "schema mismatch");
+  // the raw read preserves it so one stale entry cannot void the whole store.
+  const body = JSON.stringify({ "en:a|b": { lead: "" } });
+
+  const store = await fetchCommentaryStoreRaw(URL, fakeFetch({ body }));
+
+  expect(Object.keys(store)).toEqual(["en:a|b"]);
+});
+
+test("fetchCommentaryStoreRaw throws on a failed read rather than returning empty", async () => {
+  await expect(
+    fetchCommentaryStoreRaw(
+      URL,
+      fakeFetch({ ok: false, status: 500, body: "" }),
+    ),
+  ).rejects.toThrow();
 });

--- a/scripts/commentary/fetch-commentary.ts
+++ b/scripts/commentary/fetch-commentary.ts
@@ -29,9 +29,10 @@ export async function fetchCommentaryStore(
  * safe to overwrite from: it does NOT validate, so one entry that fails the
  * since-tightened schema cannot void the whole store; and it THROWS on a failed
  * read instead of degrading to null, so a merge-then-overwrite aborts rather
- * than wiping the live cards when a read transiently fails. The cast is the
- * boundary lie this accepts: a merge only spreads and re-keys, so an unvalidated
- * value passes through untouched.
+ * than wiping the live cards when a read transiently fails. Per-entry VALUES go
+ * unvalidated (a merge only spreads and re-keys them), but the top-level shape
+ * is checked: a non-object payload (null, an array) would otherwise spread into
+ * an empty or malformed merge and persist a broken store.
  */
 export async function fetchCommentaryStoreRaw(
   url: string,
@@ -41,5 +42,9 @@ export async function fetchCommentaryStoreRaw(
   if (!res.ok) {
     throw new Error(`Commentary store read failed (${res.status}) at ${url}.`);
   }
-  return (await res.json()) as CommentaryStore;
+  const json: unknown = await res.json();
+  if (json === null || typeof json !== "object" || Array.isArray(json)) {
+    throw new Error(`Commentary store is not a JSON object at ${url}.`);
+  }
+  return json as CommentaryStore;
 }

--- a/scripts/commentary/fetch-commentary.ts
+++ b/scripts/commentary/fetch-commentary.ts
@@ -22,3 +22,24 @@ export async function fetchCommentaryStore(
     return null;
   }
 }
+
+/**
+ * Read the store as raw JSON for a writer that merges new entries in, preserving
+ * every existing entry verbatim. Two differences from the strict read make it
+ * safe to overwrite from: it does NOT validate, so one entry that fails the
+ * since-tightened schema cannot void the whole store; and it THROWS on a failed
+ * read instead of degrading to null, so a merge-then-overwrite aborts rather
+ * than wiping the live cards when a read transiently fails. The cast is the
+ * boundary lie this accepts: a merge only spreads and re-keys, so an unvalidated
+ * value passes through untouched.
+ */
+export async function fetchCommentaryStoreRaw(
+  url: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<CommentaryStore> {
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`Commentary store read failed (${res.status}) at ${url}.`);
+  }
+  return (await res.json()) as CommentaryStore;
+}

--- a/src/lib/drafting.test.ts
+++ b/src/lib/drafting.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+
+import { interpretDraft, type RawDraft } from "./drafting";
+
+const TS = "2026-06-18T00:00:00.000Z";
+
+function rawDraft(overrides: Partial<RawDraft> = {}): RawDraft {
+  return {
+    lead: "A clean blurb about the song.",
+    tag: "new entry",
+    claim: "why-charting",
+    sources: ["https://www.billboard.com/a", "https://pitchfork.com/b"],
+    ...overrides,
+  };
+}
+
+test("interpretDraft stamps generatedAt and returns a schema-valid entry", () => {
+  const entry = interpretDraft(rawDraft({ detail: "More context." }), TS);
+
+  expect(entry).toEqual({
+    lead: "A clean blurb about the song.",
+    detail: "More context.",
+    tag: "new entry",
+    claim: "why-charting",
+    sources: ["https://www.billboard.com/a", "https://pitchfork.com/b"],
+    generatedAt: TS,
+  });
+});
+
+test("interpretDraft rejects an unknown claim tier", () => {
+  expect(interpretDraft(rawDraft({ claim: "speculation" }), TS)).toBeNull();
+});
+
+test("interpretDraft rejects a non-URL source", () => {
+  expect(interpretDraft(rawDraft({ sources: ["not a url"] }), TS)).toBeNull();
+});
+
+test("interpretDraft rejects an empty lead", () => {
+  expect(interpretDraft(rawDraft({ lead: "" }), TS)).toBeNull();
+});

--- a/src/lib/drafting.test.ts
+++ b/src/lib/drafting.test.ts
@@ -1,8 +1,23 @@
 import { expect, test } from "vitest";
 
-import { interpretDraft, type RawDraft } from "./drafting";
+import { buildDraftPrompt, interpretDraft, type RawDraft } from "./drafting";
 
 const TS = "2026-06-18T00:00:00.000Z";
+
+test("buildDraftPrompt carries the track facts and frames chart data as context", () => {
+  const prompt = buildDraftPrompt({
+    artist: "aespa",
+    name: "LEMONADE",
+    significance: "a new chart entry, peaking at #1",
+    chartedIn: ["tw#1", "kr#2"],
+  });
+
+  expect(prompt).toContain('"LEMONADE" by aespa');
+  expect(prompt).toContain("tw#1, kr#2");
+  // The positions are our own data; the prompt must mark them as context, not a
+  // claim, or the model restates them and grounding drops the card.
+  expect(prompt).toContain("context only");
+});
 
 function rawDraft(overrides: Partial<RawDraft> = {}): RawDraft {
   return {

--- a/src/lib/drafting.ts
+++ b/src/lib/drafting.ts
@@ -37,29 +37,38 @@ export interface DraftInput {
 }
 
 /**
- * The drafting instructions. It states the claim-tier choice, the source policy
- * the gate will enforce (authoritative outlets, two or more, that explicitly
- * STATE the claims so grounding passes), and the no-lyric rule, so the model
- * drafts toward what the gate accepts rather than against it.
+ * The drafting instructions, shaped by the gate the draft must pass. Its core
+ * rule separates signal from claim: the chart positions we feed in are why we
+ * PICKED the track, not something to assert, since they are our own ranking data
+ * and no outlet reports them, so grounding can never verify them. The lead and
+ * detail must instead claim a stable, press-backed fact about the song; the
+ * timely hook lives in the tag, which grounding does not check. The model is
+ * pointed at specific articles it has read, the authority allowlist, and the
+ * no-lyric rule, so it drafts toward what the gate accepts rather than against it.
  */
 export function buildDraftPrompt(input: DraftInput): string {
   return [
-    "You write a short, factual blurb about why a song is on a music chart, for a discovery app.",
-    "Research the track with web search before writing. Never cite lyrics sites, fan wikis, or gossip/SEO farms.",
-    `At least one source MUST come from this trusted-outlet list: ${[...AUTHORITY_ALLOWLIST].join(", ")}. Use a Wikipedia article only to find the primary sources it cites, never as a cited source itself.`,
+    "You write a short, factual blurb about a song for a music-discovery app, then cite where each fact is stated.",
+    "Research the track with web search and open the pages before writing.",
+    "",
+    "What to claim:",
+    "- Default to a stable, well-documented fact about the SONG ITSELF: its release, album, collaborators, genre, or a milestone a major outlet reported (e.g. a first #1 on a named chart).",
+    "- Give a time-sensitive reason it is rising only when a source explicitly states that cause; otherwise stay with the stable fact.",
+    "- The chart positions below are OUR OWN ranking data and only tell you why we picked the track. No outlet publishes them, so never assert them as fact in the lead or detail; they cannot be verified. Treat them as context only.",
     "",
     "Write:",
-    "- lead: one sentence, the single most interesting true thing about the song or its chart run.",
-    "- detail: an optional second sentence with context. Omit it rather than pad.",
-    '- tag: a 2-4 word hook naming why it matters now (e.g. "new top-5 debut").',
-    '- claim: "what-it-is" for a stable fact about the song, or "why-charting" for a time-sensitive reason it is moving. Only choose why-charting when a source states the cause.',
-    "- sources: two or more URLs to authoritative pages that EXPLICITLY STATE every claim you make. A claim a source only implies does not count; a later check drops any claim its sources do not state.",
+    "- lead: one sentence, the single most interesting verifiable fact about the song.",
+    "- detail: an optional second sentence of context. Omit it rather than pad.",
+    '- tag: a 2-4 word hook for why it matters now (e.g. "new top-5 debut"). This is a hook, not a verified claim, and may reflect the chart movement.',
+    '- claim: "what-it-is" for a stable fact about the song, or "why-charting" for a stated, time-sensitive reason it is moving.',
+    "- sources: two or more URLs to specific articles or reviews you opened that EXPLICITLY STATE every claim in your lead and detail. Never cite an artist hub, a tag or category page, a search page, or a homepage; they state nothing. A claim a source only implies does not count; a later check drops any claim its sources do not state.",
+    "",
+    `At least one source must be from this trusted-outlet list: ${[...AUTHORITY_ALLOWLIST].join(", ")}. Use Wikipedia only to find the primary sources it cites, never as a cited source. Never cite lyrics sites, fan wikis, or gossip/SEO farms.`,
     "",
     "Never reproduce song lyrics. Describe the song; do not quote its words.",
     "",
     `TRACK: "${input.name}" by ${input.artist}`,
-    `SIGNIFICANCE: ${input.significance}`,
-    `CHARTING: ${input.chartedIn.join(", ")}`,
+    `WHY WE PICKED IT (our data, context only): ${input.significance}, charting at ${input.chartedIn.join(", ")}`,
   ].join("\n");
 }
 

--- a/src/lib/drafting.ts
+++ b/src/lib/drafting.ts
@@ -1,0 +1,93 @@
+import { CommentarySchema, type Commentary } from "./chart-schema";
+import { AUTHORITY_ALLOWLIST } from "./source-authority";
+
+/**
+ * The drafting seam: an LLM researches a charting track and writes a candidate
+ * blurb, in place of a human authoring it (#121). This module is the pure half
+ * of the auto-drafting step, mirroring `grounding.ts`: it builds the prompt and
+ * validates the model's output, while the network-and-subprocess research call
+ * lives in an injectable shell. The model is reached through an injected client,
+ * so the auth and model backend (claude -p now, an SDK key later) stay swappable.
+ *
+ * A draft is only a CANDIDATE: it still runs the publish gate (`routeStore`),
+ * which grounds the claims against the cited sources and drops anything that
+ * fails. So this seam fails safe to null on a malformed draft rather than
+ * trusting the model's shape, and the gate, not this step, is the trust arbiter.
+ */
+
+/** The structured fields the drafting model returns, before validation. */
+export interface RawDraft {
+  lead: string;
+  detail?: string;
+  tag: string;
+  claim: string;
+  sources: string[];
+}
+
+export type DraftClient = (prompt: string) => Promise<RawDraft>;
+
+/** The track facts the prompt is built from, mapped from a worklist item. */
+export interface DraftInput {
+  artist: string;
+  name: string;
+  /** Why the track is on the worklist, in plain words (e.g. "a top-5 debut"). */
+  significance: string;
+  /** Where it charts, as `cc#rank` tokens (e.g. ["us#1", "ca#2"]). */
+  chartedIn: string[];
+}
+
+/**
+ * The drafting instructions. It states the claim-tier choice, the source policy
+ * the gate will enforce (authoritative outlets, two or more, that explicitly
+ * STATE the claims so grounding passes), and the no-lyric rule, so the model
+ * drafts toward what the gate accepts rather than against it.
+ */
+export function buildDraftPrompt(input: DraftInput): string {
+  return [
+    "You write a short, factual blurb about why a song is on a music chart, for a discovery app.",
+    "Research the track with web search before writing. Never cite lyrics sites, fan wikis, or gossip/SEO farms.",
+    `At least one source MUST come from this trusted-outlet list: ${[...AUTHORITY_ALLOWLIST].join(", ")}. Use a Wikipedia article only to find the primary sources it cites, never as a cited source itself.`,
+    "",
+    "Write:",
+    "- lead: one sentence, the single most interesting true thing about the song or its chart run.",
+    "- detail: an optional second sentence with context. Omit it rather than pad.",
+    '- tag: a 2-4 word hook naming why it matters now (e.g. "new top-5 debut").',
+    '- claim: "what-it-is" for a stable fact about the song, or "why-charting" for a time-sensitive reason it is moving. Only choose why-charting when a source states the cause.',
+    "- sources: two or more URLs to authoritative pages that EXPLICITLY STATE every claim you make. A claim a source only implies does not count; a later check drops any claim its sources do not state.",
+    "",
+    "Never reproduce song lyrics. Describe the song; do not quote its words.",
+    "",
+    `TRACK: "${input.name}" by ${input.artist}`,
+    `SIGNIFICANCE: ${input.significance}`,
+    `CHARTING: ${input.chartedIn.join(", ")}`,
+  ].join("\n");
+}
+
+/**
+ * Validate the model's draft into a schema-valid commentary entry, stamping the
+ * supplied timestamp. Returns null on any schema failure (bad claim tier,
+ * non-URL or missing sources, empty lead), so a malformed draft is dropped
+ * rather than published. The timestamp is injected, not read here, to keep the
+ * seam pure and testable.
+ */
+export function interpretDraft(
+  raw: RawDraft,
+  generatedAt: string,
+): Commentary | null {
+  const parsed = CommentarySchema.safeParse({ ...raw, generatedAt });
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Draft one blurb end to end: build the prompt, ask the injected client, and
+ * validate the result. The orchestrator stays pure given its client, so the
+ * decision logic is tested without the research call.
+ */
+export async function draftBlurb(
+  input: DraftInput,
+  generatedAt: string,
+  client: DraftClient,
+): Promise<Commentary | null> {
+  const raw = await client(buildDraftPrompt(input));
+  return interpretDraft(raw, generatedAt);
+}

--- a/src/lib/source-authority.test.ts
+++ b/src/lib/source-authority.test.ts
@@ -63,6 +63,41 @@ test("findSourceViolations allows Genius alongside the lyrics-site denials", () 
   expect(violations.some((v) => v.rule === "denied-source")).toBe(false);
 });
 
+test("findSourceViolations flags an entry with no allowlisted source", () => {
+  const sources = [
+    "https://some-music-blog.example/post",
+    "https://another-site.example/story",
+  ];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(violations.some((v) => v.rule === "no-authoritative-source")).toBe(
+    true,
+  );
+});
+
+test("findSourceViolations accepts a non-allowlisted source alongside one allowlisted", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://some-music-blog.example/post",
+  ];
+
+  expect(findSourceViolations(entry(sources))).toEqual([]);
+});
+
+test("findSourceViolations counts an allowlisted subdomain as authoritative", () => {
+  const sources = [
+    "https://music.theguardian.com/article",
+    "https://some-music-blog.example/post",
+  ];
+
+  expect(
+    findSourceViolations(entry(sources)).some(
+      (v) => v.rule === "no-authoritative-source",
+    ),
+  ).toBe(false);
+});
+
 test("findSourceViolations flags a single source as too few", () => {
   const sources = ["https://www.billboard.com/music/a"];
 

--- a/src/lib/source-authority.ts
+++ b/src/lib/source-authority.ts
@@ -4,13 +4,18 @@ import type { Commentary } from "./chart-schema";
  * Deterministic guard that every claim rests on authoritative sources, part of
  * the code-primary publish gate (ADR-0008). It is tier-independent: it judges
  * where a blurb's sources come from and how many there are, never what the
- * blurb claims. The playbook's source-authority policy is codified here so a
- * denylisted source or a thin source set hard-blocks publish in code, not by a
- * reviewer remembering the policy.
+ * blurb claims. The playbook's source-authority policy is codified here so an
+ * under-sourced blurb hard-blocks publish in code, not by a reviewer
+ * remembering the policy. Three rules apply: a denylist of known-bad domains,
+ * a minimum source count, and (model b, ADR-0008/0009) a requirement that at
+ * least one source sits on a curated authority allowlist. A denylist alone
+ * cannot vouch for credibility, only block known offenders; the allowlist is
+ * what an automated drafting pass needs, since a model picking sources has none
+ * of a human author's judgment about which outlets are trustworthy.
  */
 
 export interface SourceViolation {
-  rule: "denied-source" | "too-few-sources";
+  rule: "denied-source" | "too-few-sources" | "no-authoritative-source";
   source: string;
 }
 
@@ -35,6 +40,41 @@ const DENIED_DOMAINS = new Set([
   // Gossip / SEO content farms.
   "tmz.com",
   "popsugar.com",
+]);
+
+// Curated authority allowlist: outlets credible enough that one of them, cited,
+// vouches for a blurb (model b, ADR-0008/0009 "one top-tier source can stand in
+// for corroboration"). A blurb needs at least one source from this set; its
+// other sources need only avoid the denylist. Starts with global music
+// journalism, the major chart bodies, and a few strong regional outlets so
+// non-English tracks are not starved. It grows from the source pass/fail log
+// (ADR-0009) as the drafting pass shows which credible outlets it reaches for.
+export const AUTHORITY_ALLOWLIST = new Set([
+  // Global music journalism.
+  "billboard.com",
+  "pitchfork.com",
+  "rollingstone.com",
+  "nme.com",
+  "stereogum.com",
+  "consequence.net",
+  "spin.com",
+  "thefader.com",
+  "complex.com",
+  "xxlmag.com",
+  "vulture.com",
+  "variety.com",
+  // General press with established music desks.
+  "theguardian.com",
+  "npr.org",
+  "bbc.com",
+  "bbc.co.uk",
+  // Industry trades and chart bodies.
+  "musicbusinessworldwide.com",
+  "officialcharts.com",
+  "pollstar.com",
+  // Regional outlets, so non-English tracks can clear the bar.
+  "soompi.com",
+  "remezcla.com",
 ]);
 
 /**
@@ -62,6 +102,15 @@ function isDenied(domain: string): boolean {
   return false;
 }
 
+function isAllowed(domain: string): boolean {
+  if (AUTHORITY_ALLOWLIST.has(domain)) return true;
+  // A subdomain of an allowlisted outlet counts too (music.theguardian.com).
+  for (const allowed of AUTHORITY_ALLOWLIST) {
+    if (domain.endsWith(`.${allowed}`)) return true;
+  }
+  return false;
+}
+
 /** Every source-authority violation across a commentary entry's sources. */
 export function findSourceViolations(entry: Commentary): SourceViolation[] {
   const violations: SourceViolation[] = [];
@@ -77,6 +126,17 @@ export function findSourceViolations(entry: Commentary): SourceViolation[] {
     violations.push({
       rule: "too-few-sources",
       source: `${entry.sources.length} of ${MIN_SOURCES} required`,
+    });
+  }
+
+  const hasAuthority = entry.sources.some((source) => {
+    const domain = registrableDomain(source);
+    return domain !== null && isAllowed(domain);
+  });
+  if (!hasAuthority) {
+    violations.push({
+      rule: "no-authoritative-source",
+      source: `none of ${entry.sources.length} source(s) is on the authority allowlist`,
     });
   }
 

--- a/src/lib/tier-consistency-lint.test.ts
+++ b/src/lib/tier-consistency-lint.test.ts
@@ -38,19 +38,16 @@ test("findTierSignals leaves a stable descriptive note alone", () => {
   expect(findTierSignals(text)).toEqual([]);
 });
 
-test("findTierSignals leaves a descriptive 'named after' alone", () => {
-  const text = "A ballad named after the singer's hometown.";
+test("findTierSignals leaves a stable 'following' as album sequence alone", () => {
+  const text = "Their first full-length in two years, following 2024's album.";
 
   expect(findTierSignals(text)).toEqual([]);
 });
 
-test("findTierSignals flags a causal 'after'", () => {
-  const text = "It took off after the World Cup broadcast.";
+test("findTierSignals leaves a bare 'after' in stable prose alone", () => {
+  const text = "A ballad named after the singer's hometown.";
 
-  expect(findTierSignals(text)).toContainEqual({
-    rule: "causal-language",
-    marker: "after",
-  });
+  expect(findTierSignals(text)).toEqual([]);
 });
 
 test("findTierSignals leaves a descriptive 'debut album' alone", () => {

--- a/src/lib/tier-consistency-lint.ts
+++ b/src/lib/tier-consistency-lint.ts
@@ -9,11 +9,11 @@ import type { Commentary } from "./chart-schema";
  * can be routed to human review rather than auto-published under the wrong tier.
  *
  * It only ever flags `what-it-is`; the same language is allowed (and expected)
- * in `why-charting`. Like the no-lyric lint, the vocabulary is tuned to flag
- * rather than miss: a false flag costs a reviewer a glance, a mislabelled blurb
- * that slips through lets a risky time-sensitive claim auto-publish as if it
- * were stable. This is a FLAG-FOR-REVIEW signal, not a publish-blocking gate;
- * the routing that consumes it is the gate classifier, a later slice.
+ * in `why-charting`. The gate classifier drops a flagged blurb rather than
+ * routing it to a person (ADR-0009), so the vocabulary is tuned for PRECISION:
+ * a false flag no longer costs a reviewer a glance, it discards a good card.
+ * Grounding, not this lint, is the correctness gate; this only keeps a
+ * time-sensitive claim from auto-publishing under the stable tier.
  */
 
 export interface TierConsistencyViolation {
@@ -30,7 +30,6 @@ const CAUSAL_MARKERS = [
   "because",
   "due to",
   "thanks to",
-  "following",
   "sparked",
   "drove",
   "driven by",
@@ -70,13 +69,16 @@ const TEMPORAL_MARKERS = [
 
 /**
  * To extend either list: add a phrase a why-charting blurb would use and a
- * stable what-it-is note would not. Prefer over-inclusion; a false flag is
- * cheap, a missed mislabel is not. Keep entries lowercase; matching is
- * case-insensitive and on word boundaries, so a marker never fires on a
- * substring inside another word ("surge" will not match "resurgence"). A word
- * that reads both ways (like "debut", stable in "debut album" but charting in
- * "debuted at #2") belongs as a charting-context PHRASE, not a bare word, or as
- * a context-sensitive check like `after` below.
+ * stable what-it-is note would not. Prefer PRECISION over reach: a flagged
+ * what-it-is blurb is dropped, not reviewed (ADR-0009), so a marker that fires
+ * on benign stable prose costs a good card. This is why bare "after" and
+ * "following" are absent — they read as plain sequence in stable notes ("their
+ * album after X", "following their debut") far more often than as a charting
+ * cause. Keep entries lowercase; matching is case-insensitive and on word
+ * boundaries, so a marker never fires on a substring inside another word
+ * ("surge" will not match "resurgence"). A word that reads both ways (like
+ * "debut", stable in "debut album" but charting in "debuted at #2") belongs as
+ * a charting-context PHRASE, not a bare word.
  */
 
 function escapeForRegExp(literal: string): string {
@@ -99,30 +101,12 @@ function findMarkers(
     .map((marker) => ({ rule, marker }));
 }
 
-/**
- * "after" asserts a cause in charting prose ("it surged after the final") but
- * is just as often a plain descriptive idiom ("named after a city", "after
- * all"). A bare-word match over-flags, so strip the known idioms first and only
- * count an "after" that survives. This is the one context-sensitive marker: the
- * surrounding words, not the word alone, decide whether it is a why-charting cue.
- */
-const AFTER_IDIOMS =
-  /\b(?:named|modell?ed|patterned|fashioned|look(?:ing|ed)?|sought)\s+after\b|\bafter\s+(?:all|hours|school)\b|\bafter[-\s]?part(?:y|ies)\b/gi;
-
-function hasCausalAfter(text: string): boolean {
-  return /\bafter\b/i.test(text.replace(AFTER_IDIOMS, " "));
-}
-
 /** Every tier-consistency signal in a single block of text. */
 export function findTierSignals(text: string): TierConsistencyViolation[] {
-  const violations = [
+  return [
     ...findMarkers(text, CAUSAL_MARKERS, "causal-language"),
     ...findMarkers(text, TEMPORAL_MARKERS, "temporal-language"),
   ];
-  if (hasCausalAfter(text)) {
-    violations.push({ rule: "causal-language", marker: "after" });
-  }
-  return violations;
 }
 
 /**


### PR DESCRIPTION
## What
Auto-drafting (#121): a claude -p drafter researches a charting track with web search and returns a candidate blurb, which routes through the existing publish gate. Only gate-passing drafts merge into the live store; failures drop with reasons. The drafter sits behind an injectable DraftClient seam (mirroring grounding), so the backend swaps (claude -p now, SDK key later) without touching drafting or gate logic. Closes #121.

## How it went
The first live run drove the three fix commits on top of the build:
- Web research was never on: `--tools` makes WebSearch/WebFetch available but not permitted; `--allowedTools` enables them.
- The drafter restated our chart ranks as its claim, which no outlet reports, so grounding could never pass. The prompt now frames chart data as internal signal and steers the claim to a stable, press-backed fact.
- tier-consistency over-flagged (tuned for a human reviewer ADR-0009 removed); a benign "following" dropped a good blurb. Re-tuned for precision.
- A bad existing-store read wiped live blurbs: the strict schema voids the whole store on one bad entry. Reading raw, aborting on a failed read, and a shrink guard make a wipe impossible.

## Test plan
- typecheck / lint / test (344) green.
- First live run published a real grounded blurb (aespa LEMONADE) end to end.
- Store-read fix verified against the live store; the strict failure mode reproduced and guarded.

## Follow-ups (not in this diff)
- Migrated the 22 pre-existing blurbs (missing the claim field since #118) to valid claim as an operational fix, restoring production commentary.
- Allowlist regional expansion; hardening the crawl's all-or-nothing commentary read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated commentary generation with batch processing capabilities for chart entries.
  * Added source authority validation requiring at least one authoritative source per entry.

* **Improvements**
  * Refined tier consistency checking with improved causal language detection.

* **Tests**
  * Comprehensive test coverage for the new commentary drafting and validation pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->