### PR TITLE
chore: release v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` to `1.4.0` to cut the **automated commentary gate + auto-drafting** release. Per the ADR-0005 checklist (#88), the annotated `v1.4.0` tag and the GitHub Release follow this squash merge.

## What ships in v1.4.0

The commentary publish gate moves from a uniform human read-through to a code-only gate, and auto-drafting feeds it so the release actually fills cards rather than shipping an empty gate. A blurb auto-publishes only when it clears every deterministic guard (no-lyric, source-authority, tier-consistency) and an LLM grounding check; any failure drops the card, with no human in the publish path. Both claim tiers run the identical gate, the tier selecting only how strictly a claim must be sourced. ADR-0009 supersedes ADR-0008's human-disposition split; the rest of ADR-0008 (code as the primary gate, the explicit claim tier, the deterministic checks, the grounding check) stands.

**Foundation**
- #113 — land ADR-0008 (risk-tiered commentary gate)
- #114 — wire `COMMENTARY_BLOB_URL` into the cron crawl

**The gate**
- #115 — require a claim risk tier on every blurb
- #116 — source-authority guard at publish
- #117 — skip thin-market chart noise in the worklist
- #118 — tier-consistency lint
- #119 — grounding check
- #120 — gate classifier (publish/drop router)

**Auto-drafting**
- #122 — auto-draft worklist blurbs through the gate (closes #121)

## Verified live

The end-to-end pipeline (research → draft → gate → merge → upload) was validated against a real worklist mover (aespa — LEMONADE), which drafted, cited two allowlisted article URLs, passed grounding, and merged into the store.

## Test plan

- `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm build` green (CI matrix)
- Version-only change; no runtime code touched
