### PR TITLE
feat(commentary): tier source authority into journalism and chart-body sets

### DIFF
--- a/docs/adr/0009-fully-automated-commentary-gate.md
+++ b/docs/adr/0009-fully-automated-commentary-gate.md
@@ -50,3 +50,7 @@ Learned reputation (a source's trust rising as it is seen to state facts that ho
 
 - ADR-0007's architecture and ADR-0008's code-primary tiering are untouched; only the human disposition changes.
 - A confidence score and a learned reputation remain available as future work when labels or a verifiable oracle arrive.
+
+## Amendment (2026-06-19): tiered authority allowlist
+
+The curated authority list is realized and split by what a source can vouch for: journalism with editorial accountability vouches a blurb for either claim tier, while chart and certification bodies corroborate a position or metric only and never satisfy the authority rule alone. This closes a gap in the flat seed list shipped with the gate's first cut, where a chart body could vouch a `why-charting` cause it cannot support. Codified as `AUTHORITY_ALLOWLIST` and `CHART_BODY_DOMAINS` in `src/lib/source-authority.ts`, regionally broadened so non-English tracks clear the bar.

--- a/src/lib/source-authority.test.ts
+++ b/src/lib/source-authority.test.ts
@@ -98,6 +98,31 @@ test("findSourceViolations counts an allowlisted subdomain as authoritative", ()
   ).toBe(false);
 });
 
+test("findSourceViolations fails a chart-body-only entry with the chart-body rule", () => {
+  const sources = [
+    "https://www.officialcharts.com/charts/singles-chart",
+    "https://some-music-blog.example/post",
+  ];
+
+  const violations = findSourceViolations(entry(sources));
+
+  expect(
+    violations.some((v) => v.rule === "chart-body-not-authoritative"),
+  ).toBe(true);
+  expect(violations.some((v) => v.rule === "no-authoritative-source")).toBe(
+    false,
+  );
+});
+
+test("findSourceViolations accepts a chart body alongside a journalism source", () => {
+  const sources = [
+    "https://www.billboard.com/music/a",
+    "https://www.officialcharts.com/charts/singles-chart",
+  ];
+
+  expect(findSourceViolations(entry(sources))).toEqual([]);
+});
+
 test("findSourceViolations flags a single source as too few", () => {
   const sources = ["https://www.billboard.com/music/a"];
 

--- a/src/lib/source-authority.ts
+++ b/src/lib/source-authority.ts
@@ -2,20 +2,29 @@ import type { Commentary } from "./chart-schema";
 
 /**
  * Deterministic guard that every claim rests on authoritative sources, part of
- * the code-primary publish gate (ADR-0008). It is tier-independent: it judges
- * where a blurb's sources come from and how many there are, never what the
- * blurb claims. The playbook's source-authority policy is codified here so an
- * under-sourced blurb hard-blocks publish in code, not by a reviewer
- * remembering the policy. Three rules apply: a denylist of known-bad domains,
- * a minimum source count, and (model b, ADR-0008/0009) a requirement that at
- * least one source sits on a curated authority allowlist. A denylist alone
- * cannot vouch for credibility, only block known offenders; the allowlist is
- * what an automated drafting pass needs, since a model picking sources has none
- * of a human author's judgment about which outlets are trustworthy.
+ * the code-primary publish gate (ADR-0008). It judges where a blurb's sources
+ * come from and how many there are, never what the blurb claims. Three rules
+ * apply: a denylist of known-bad domains, a minimum source count, and a
+ * requirement that at least one source sits on the authority allowlist.
+ *
+ * Sources are tiered by what they can vouch for. The authority allowlist is
+ * journalism with editorial accountability: one such source, cited, vouches a
+ * blurb for either claim tier. Chart and certification bodies are separate:
+ * they certify a position or a metric ("debuted at #2"), never a narrative
+ * cause, so they corroborate a blurb but never satisfy the authority rule
+ * alone. A denylist alone cannot vouch credibility, only block known offenders;
+ * the allowlist is what an automated drafting pass needs, since a model picking
+ * sources has none of a human author's judgment about which outlets to trust.
+ * Both lists grow from the source pass/fail log (ADR-0009) as drafting shows
+ * which outlets it reaches for.
  */
 
 export interface SourceViolation {
-  rule: "denied-source" | "too-few-sources" | "no-authoritative-source";
+  rule:
+    | "denied-source"
+    | "too-few-sources"
+    | "no-authoritative-source"
+    | "chart-body-not-authoritative";
   source: string;
 }
 
@@ -42,13 +51,11 @@ const DENIED_DOMAINS = new Set([
   "popsugar.com",
 ]);
 
-// Curated authority allowlist: outlets credible enough that one of them, cited,
-// vouches for a blurb (model b, ADR-0008/0009 "one top-tier source can stand in
-// for corroboration"). A blurb needs at least one source from this set; its
-// other sources need only avoid the denylist. Starts with global music
-// journalism, the major chart bodies, and a few strong regional outlets so
-// non-English tracks are not starved. It grows from the source pass/fail log
-// (ADR-0009) as the drafting pass shows which credible outlets it reaches for.
+// Authority allowlist: journalism credible enough that one source, cited,
+// vouches a blurb for either claim tier (model b, ADR-0008/0009). A blurb needs
+// at least one source from this set; its other sources need only avoid the
+// denylist. Grouped by region so non-English tracks are not starved under
+// fail-closed-drop. Match is on registrable domain; a subdomain counts too.
 export const AUTHORITY_ALLOWLIST = new Set([
   // Global music journalism.
   "billboard.com",
@@ -63,18 +70,105 @@ export const AUTHORITY_ALLOWLIST = new Set([
   "xxlmag.com",
   "vulture.com",
   "variety.com",
+  // Electronic / dance specialists.
+  "residentadvisor.net",
+  "mixmag.net",
+  "djmag.com",
+  "thelineofbestfit.com",
   // General press with established music desks.
   "theguardian.com",
   "npr.org",
   "bbc.com",
   "bbc.co.uk",
-  // Industry trades and chart bodies.
+  // Industry trades.
   "musicbusinessworldwide.com",
-  "officialcharts.com",
   "pollstar.com",
-  // Regional outlets, so non-English tracks can clear the bar.
+  // East Asia.
   "soompi.com",
+  "yna.co.kr",
+  "joins.com",
+  "koreaherald.com",
+  "koreatimes.co.kr",
+  "osen.co.kr",
+  "chosun.com",
+  "starnewskorea.com",
+  "xportsnews.com",
+  "newsen.com",
+  "natalie.mu",
+  "realsound.jp",
+  "asahi.com",
+  "mainichi.jp",
+  "scmp.com",
+  "sixthtone.com",
+  // Southeast Asia.
+  "bandwagon.asia",
+  "billboardphilippines.com",
+  "rappler.com",
+  "inquirer.net",
+  "philstar.com",
+  "nylonmanila.com",
+  "pophariini.com",
+  "thestandard.co",
+  "vietcetera.com",
+  "fungjai.com",
+  // South Asia.
+  "rollingstoneindia.com",
+  "thehindu.com",
+  "hindustantimes.com",
+  "filmcompanion.in",
+  "bollywoodhungama.com",
+  "dawn.com",
+  // Latin America & Iberia.
   "remezcla.com",
+  "indierocks.mx",
+  "shock.co",
+  "indiehoy.com",
+  "rockaxis.com",
+  "lanacion.com.ar",
+  "jenesaispop.com",
+  "mondosonoro.com",
+  // Brazil / Lusophone.
+  "tenhomaisdiscosqueamigos.com",
+  "rollingstone.com.br",
+  "folha.uol.com.br",
+  "globo.com",
+  // Francophone.
+  "abcdrduson.com",
+  "lesinrocks.com",
+  "tsugi.fr",
+  "lemonde.fr",
+  "liberation.fr",
+  "booska-p.com",
+  "konbini.com",
+  "mouv.fr",
+  // MENA.
+  "ma3azef.com",
+  "scenenoise.com",
+  "milleworld.com",
+  // Sub-Saharan Africa.
+  "okayafrica.com",
+  "musicinafrica.net",
+  "pulse.ng",
+  "notjustok.com",
+  "pulse.com.gh",
+  "ghanamusic.com",
+  "texxandthecity.com",
+  "bubblegumclub.co.za",
+]);
+
+// Chart and certification bodies. They are authoritative for a position or a
+// metric, never a cause, so a blurb may cite them as corroboration but cannot
+// rest its authority on them alone. Not denied (they count toward the source
+// floor); simply outside the authority allowlist. Match is on registrable
+// domain; a subdomain counts too.
+export const CHART_BODY_DOMAINS = new Set([
+  "officialcharts.com",
+  "oricon.co.jp",
+  "billboard-japan.com",
+  "circlechart.kr",
+  "snepmusique.com",
+  "turntablecharts.com",
+  "los40.com",
 ]);
 
 /**
@@ -92,23 +186,25 @@ function registrableDomain(url: string): string | null {
   return host.replace(/^www\./, "");
 }
 
-function isDenied(domain: string): boolean {
-  if (DENIED_DOMAINS.has(domain)) return true;
-  // A subdomain of a denied domain is denied too (lyrics.example.com under
-  // example.com), matched on the registrable-domain suffix.
-  for (const denied of DENIED_DOMAINS) {
-    if (domain.endsWith(`.${denied}`)) return true;
+/** Whether a domain is, or sits under, any member of a registrable-domain set. */
+function matchesDomainSet(domain: string, set: Set<string>): boolean {
+  if (set.has(domain)) return true;
+  for (const member of set) {
+    if (domain.endsWith(`.${member}`)) return true;
   }
   return false;
 }
 
+function isDenied(domain: string): boolean {
+  return matchesDomainSet(domain, DENIED_DOMAINS);
+}
+
 function isAllowed(domain: string): boolean {
-  if (AUTHORITY_ALLOWLIST.has(domain)) return true;
-  // A subdomain of an allowlisted outlet counts too (music.theguardian.com).
-  for (const allowed of AUTHORITY_ALLOWLIST) {
-    if (domain.endsWith(`.${allowed}`)) return true;
-  }
-  return false;
+  return matchesDomainSet(domain, AUTHORITY_ALLOWLIST);
+}
+
+function isChartBody(domain: string): boolean {
+  return matchesDomainSet(domain, CHART_BODY_DOMAINS);
 }
 
 /** Every source-authority violation across a commentary entry's sources. */
@@ -129,15 +225,31 @@ export function findSourceViolations(entry: Commentary): SourceViolation[] {
     });
   }
 
-  const hasAuthority = entry.sources.some((source) => {
+  // Authority rule: a blurb needs at least one journalism source. A chart body
+  // corroborates a rank, never a cause, so a chart-body-only blurb still fails
+  // here, with a sharper reason than one that cited nothing credible at all.
+  const hasJournalism = entry.sources.some((source) => {
     const domain = registrableDomain(source);
     return domain !== null && isAllowed(domain);
   });
-  if (!hasAuthority) {
-    violations.push({
-      rule: "no-authoritative-source",
-      source: `none of ${entry.sources.length} source(s) is on the authority allowlist`,
+
+  if (!hasJournalism) {
+    const citedChartBody = entry.sources.some((source) => {
+      const domain = registrableDomain(source);
+      return domain !== null && isChartBody(domain);
     });
+
+    violations.push(
+      citedChartBody
+        ? {
+            rule: "chart-body-not-authoritative",
+            source: "cited a chart body but no journalism source",
+          }
+        : {
+            rule: "no-authoritative-source",
+            source: `none of ${entry.sources.length} source(s) is on the authority allowlist`,
+          },
+    );
   }
 
   return violations;


### PR DESCRIPTION
Splits the publish gate's source allowlist into two tiers by what a source can actually vouch for, and broadens it past the Anglosphere so non-English drafts clear the bar.

## Why

The `no-authoritative-source` check was flat: any allowlisted domain satisfied "≥1 authoritative source" for any claim. With `officialcharts.com` in that set, a `why-charting` blurb (a *cause* claim) citing only a chart page passed source-authority — even though a chart body certifies a *position*, never a cause. That hole was live in production. The grounding check was only a partial backstop; the property belongs structurally in source-authority.

Separately, the allowlist was ~21 Anglosphere-only outlets, so under fail-closed-drop most non-English tracks had no admissible source and silently dropped.

## What changed

- **Two tiers.** `AUTHORITY_ALLOWLIST` (journalism with editorial accountability) vouches a blurb for either claim tier. New `CHART_BODY_DOMAINS` (Oricon, Official Charts, Circle Chart, SNEP, Billboard Japan, TurnTable, los40) corroborate a rank only — not denied, they count toward the source floor, but never satisfy the authority rule alone.
- **Sharper drop reason.** A blurb whose only credible source is a chart body now fails with `chart-body-not-authoritative` ("cited a rank, needs a reason"), distinct from `no-authoritative-source` ("nothing credible at all"). That signal feeds the allowlist on-ramp (ADR-0009).
- **Regional/genre breadth.** ~55 verified outlets added across East/SE/South Asia, LatAm, Iberia, Brazil, Francophone, MENA, Sub-Saharan Africa, and electronic/dance.
- **ADR-0009 amended** to record the realization.

## Membership notes (for review)

- Borderline calls: `los40` → chart body (airplay facts); `billboardphilippines` kept as journalism; `scenenoise`/`notjustok`/`mouv` included despite first-party flags; `bandcampdaily` excluded (purely promotional).
- Skipped the research's flagged-uncertain/gossip/defunct: allkpop, koreaboo, kpopmap, aramajapan, hype.my, juiceonline, radioandmusic, milliblog, cartelurbano, portalpopline, scoreshortreviews, monkeybuzz, RS Indonesia.

No `Closes #N`: this was a session-tracked follow-up, not a filed issue.

## Test plan

- New tests lock the tier split: a chart-body-only blurb fails with `chart-body-not-authoritative`; a chart body alongside journalism passes.
- `pnpm lint` / `pnpm test` (347) / `pnpm typecheck` green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced source validation to require journalism sources for authoritative claims
  * Added distinction between chart body and journalism source types in validation logic
  * Expanded source authority allowlist with regional coverage

* **Documentation**
  * Updated architecture documentation with clarification on tiered source authority rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->