### PR TITLE
[demo] Spin-snap gesture preview (do not merge)

### DIFF
--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, use, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { OrbitControls } from "@react-three/drei";
 import { Canvas, useThree } from "@react-three/fiber";
 import { PerspectiveCamera } from "three";
 
@@ -14,10 +13,18 @@ import { cameraForViewport } from "./camera-fit";
 import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
+import { SpinSnapControls } from "./spin-snap-controls";
 import { StarBackdrop } from "./star-backdrop";
-import { useCameraArc } from "./use-camera-arc";
 
 const ISO_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c.isoNum]));
+
+// Locked feel values from the gesture spike (ADR-0011). Named, not tunable.
+const SPIN_SENSITIVITY = 1.4;
+const SPIN_FRICTION = 2.5;
+const SPIN_BOUNCE = 0.6;
+const SPIN_HORIZONTAL_LOCK = false;
+const SPIN_FAIR = true;
+const FALLBACK_CODE = "us";
 
 function CountryLayers({
   hoveredIsoNum,
@@ -51,15 +58,24 @@ function SceneContent() {
   const selectedIsoNum =
     selectedCode !== null ? (ISO_BY_CODE.get(selectedCode) ?? null) : null;
 
-  const { isAnimating } = useCameraArc({ targetCode: selectedCode });
-
-  const handleSelect = useCallback(
-    (code: string) => {
-      if (isAnimating) return;
-      window.history.pushState(null, "", `?cc=${code}`);
-    },
-    [isAnimating],
+  // Per-session anti-repeat memory for the fairness-weighted fling; resets on
+  // reload. Seeded once with whatever the globe first centered on.
+  const [initialCode] = useState(() => selectedCode ?? FALLBACK_CODE);
+  const [visited, setVisited] = useState<ReadonlySet<string>>(
+    () => new Set([initialCode]),
   );
+
+  // A landing is a selection: write ?cc= (replaceState, so rapid flinging
+  // doesn't flood history) and record the country as visited.
+  const handleSettle = useCallback((code: string) => {
+    window.history.replaceState(null, "", `?cc=${code}`);
+    setVisited((prev) => {
+      if (prev.has(code)) return prev;
+      const next = new Set(prev);
+      next.add(code);
+      return next;
+    });
+  }, []);
 
   return (
     <>
@@ -83,17 +99,18 @@ function SceneContent() {
       <CountryPins
         selectedCode={selectedCode}
         hoveredCode={hoveredCode}
-        onSelect={handleSelect}
+        onSelect={() => {}}
         onHoverChange={setHoveredCode}
       />
-      <OrbitControls
-        autoRotate={selectedCode === null}
-        autoRotateSpeed={0.4}
-        enableZoom={false}
-        enablePan={false}
-        enableRotate={!isAnimating}
-        enableDamping
-        makeDefault
+      <SpinSnapControls
+        initialCode={initialCode}
+        sensitivity={SPIN_SENSITIVITY}
+        friction={SPIN_FRICTION}
+        bounce={SPIN_BOUNCE}
+        horizontalLock={SPIN_HORIZONTAL_LOCK}
+        fair={SPIN_FAIR}
+        visited={visited}
+        onSettle={handleSettle}
       />
     </>
   );
@@ -126,6 +143,7 @@ export function GlobeScene() {
       dpr={[1, 2]}
       gl={{ antialias: true }}
       onCreated={() => setReady(true)}
+      style={{ touchAction: "none" }}
       className={`transition-opacity duration-700 ease-out ${
         ready ? "opacity-100" : "opacity-0"
       }`}

--- a/src/components/globe/spin-feel.ts
+++ b/src/components/globe/spin-feel.ts
@@ -1,0 +1,7 @@
+// Maps the flick speed at release (screen px per ms, signed) to the globe's
+// initial spin speed (radians per second, signed). This is the heart of the
+// swipe feel: how a hard fling versus a gentle nudge translates into travel.
+// Linear for now; an eased or capped curve is one lever to tune by hand.
+export function flickToSpin(flickPxPerMs: number): number {
+  return flickPxPerMs * 6;
+}

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -1,0 +1,101 @@
+import type { Camera } from "three";
+import { Vector3 } from "three";
+
+import { COUNTRIES, type CountryEntry } from "@/lib/countries";
+import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
+
+const DEG = Math.PI / 180;
+const PIN_ELEVATION = 1.015;
+// Drop pins near or behind the limb: their projection overlaps the front face.
+const FRONT_DOT_MIN = 0.1;
+
+const WORLD_BY_CODE = new Map<string, Vector3>(
+  COUNTRIES.map((c) => [c.code, latLonToVec3(c.lat, c.lon, PIN_ELEVATION)]),
+);
+
+export interface ScreenCountry {
+  country: CountryEntry;
+  sx: number;
+  sy: number;
+}
+
+// Countries on the camera-facing hemisphere, projected to canvas pixel space
+// (origin top-left, y down) so a tap point and a pin share one frame.
+export function projectFrontCountries(
+  camera: Camera,
+  width: number,
+  height: number,
+): ScreenCountry[] {
+  const camDir = camera.position.clone().normalize();
+  const result: ScreenCountry[] = [];
+  for (const country of COUNTRIES) {
+    const world = WORLD_BY_CODE.get(country.code);
+    if (!world) continue;
+    if (world.clone().normalize().dot(camDir) <= FRONT_DOT_MIN) continue;
+    const ndc = world.clone().project(camera);
+    result.push({
+      country,
+      sx: ((ndc.x + 1) / 2) * width,
+      sy: ((1 - ndc.y) / 2) * height,
+    });
+  }
+  return result;
+}
+
+// Tap target: the front-facing country whose pin is nearest the tap point.
+export function pickNearestToPoint(
+  candidates: readonly ScreenCountry[],
+  px: number,
+  py: number,
+): string | null {
+  let best: string | null = null;
+  let bestDist = Infinity;
+  for (const c of candidates) {
+    const d = (c.sx - px) ** 2 + (c.sy - py) ** 2;
+    if (d < bestDist) {
+      bestDist = d;
+      best = c.country.code;
+    }
+  }
+  return best;
+}
+
+const SNAP_POOL = 10; // countries near the rest point considered for a fair snap
+const VISITED_WEIGHT = 0.08; // how strongly an already-seen country is avoided
+
+// Snap target at the end of a fling. Ranks countries by nearness to the point
+// the camera faces (el, az radians). With fairness off, returns the literal
+// nearest. With fairness on, draws from the nearest pool weighted away from
+// already-visited countries, so a tiny country wedged between big neighbours
+// still gets its turn instead of always losing to them.
+export function pickSnapCountry(
+  el: number,
+  az: number,
+  visited: ReadonlySet<string>,
+  fair: boolean,
+): string {
+  const cx = Math.cos(el) * Math.sin(az);
+  const cy = Math.sin(el);
+  const cz = Math.cos(el) * Math.cos(az);
+  const ranked = COUNTRIES.map((c) => {
+    const lat = c.lat * DEG;
+    const lon = c.lon * DEG;
+    const dot =
+      Math.cos(lat) * Math.sin(lon) * cx +
+      Math.sin(lat) * cy +
+      Math.cos(lat) * Math.cos(lon) * cz;
+    return { code: c.code, dot };
+  }).sort((a, b) => b.dot - a.dot);
+
+  if (!fair) return ranked[0].code;
+
+  const pool = ranked.slice(0, SNAP_POOL);
+  const weights = pool.map((p) => (visited.has(p.code) ? VISITED_WEIGHT : 1));
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < pool.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return pool[i].code;
+  }
+  return pool[0].code;
+}

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+
+import { COUNTRIES } from "@/lib/countries";
+
+import { flickToSpin } from "./spin-feel";
+import {
+  pickNearestToPoint,
+  pickSnapCountry,
+  projectFrontCountries,
+} from "./spin-select";
+
+const DEG = Math.PI / 180;
+const RADIUS = 3.5;
+const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slider
+const EL_LIMIT = 75 * DEG; // stop short of the poles so the view never flips
+const SETTLE_VEL = 0.6; // rad/s under which a fling hands off to the snap spring
+const SNAP_OMEGA = 10; // snap spring frequency: higher settles faster
+const TAP_MAX_PX = 8;
+
+const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, v));
+
+// Shortest signed angle to rotate `from` onto `to`, so settling never unwinds
+// the long way around the globe.
+const shortestAngle = (delta: number) =>
+  Math.atan2(Math.sin(delta), Math.cos(delta));
+
+interface SpinSnapControlsProps {
+  initialCode: string;
+  sensitivity: number;
+  friction: number;
+  horizontalLock: boolean;
+  bounce: number;
+  fair: boolean;
+  visited: ReadonlySet<string>;
+  onSettle: (code: string) => void;
+}
+
+// Drives the camera as a spun globe: drag to rotate, release to fling with
+// momentum, and on coming to rest snap to the nearest country. A tap jumps
+// straight to the nearest country. There is no free-rotate; it never rests on
+// open ocean.
+export function SpinSnapControls({
+  initialCode,
+  sensitivity,
+  friction,
+  horizontalLock,
+  bounce,
+  fair,
+  visited,
+  onSettle,
+}: SpinSnapControlsProps) {
+  const camera = useThree((s) => s.camera);
+  const gl = useThree((s) => s.gl);
+
+  const cfg = useRef({
+    sensitivity,
+    friction,
+    horizontalLock,
+    bounce,
+    fair,
+    visited,
+  });
+  const onSettleRef = useRef(onSettle);
+
+  // Keep the long-lived pointer handlers and per-frame loop reading the latest
+  // props without re-subscribing. Written in an effect, never during render.
+  useEffect(() => {
+    cfg.current = {
+      sensitivity,
+      friction,
+      horizontalLock,
+      bounce,
+      fair,
+      visited,
+    };
+    onSettleRef.current = onSettle;
+  });
+
+  const sim = useRef(
+    (() => {
+      const start = COUNTRY_BY_CODE.get(initialCode);
+      return {
+        az: start ? start.lon * DEG : 0,
+        el: start ? start.lat * DEG : 0,
+        vAz: 0,
+        vEl: 0,
+        mode: "idle" as "idle" | "drag" | "fling" | "settle",
+        settleAz: 0,
+        settleEl: 0,
+        settledCode: initialCode,
+      };
+    })(),
+  );
+
+  const applyCamera = () => {
+    const s = sim.current;
+    camera.position.set(
+      RADIUS * Math.cos(s.el) * Math.sin(s.az),
+      RADIUS * Math.sin(s.el),
+      RADIUS * Math.cos(s.el) * Math.cos(s.az),
+    );
+    camera.lookAt(0, 0, 0);
+  };
+
+  const settleTo = (code: string | null) => {
+    const s = sim.current;
+    const country = code ? COUNTRY_BY_CODE.get(code) : null;
+    if (!country) {
+      s.mode = "idle";
+      return;
+    }
+    s.settleAz = country.lon * DEG;
+    s.settleEl = country.lat * DEG;
+    s.mode = "settle";
+    if (s.settledCode !== country.code) {
+      s.settledCode = country.code;
+      onSettleRef.current(country.code);
+    }
+  };
+
+  useEffect(() => {
+    const el = gl.domElement;
+
+    // Gesture tracking held on one mutable object (not reassigned render-scope
+    // locals): pointer position, release velocity, drag distance, drag state.
+    const g = {
+      lastX: 0,
+      lastY: 0,
+      lastT: 0,
+      moved: 0,
+      vx: 0,
+      vy: 0,
+      dragging: false,
+    };
+
+    const onDown = (e: PointerEvent) => {
+      const s = sim.current;
+      s.mode = "drag";
+      s.vAz = 0;
+      s.vEl = 0;
+      g.dragging = true;
+      g.lastX = e.clientX;
+      g.lastY = e.clientY;
+      g.lastT = e.timeStamp;
+      g.moved = 0;
+      g.vx = 0;
+      g.vy = 0;
+      el.setPointerCapture?.(e.pointerId);
+    };
+
+    const onMove = (e: PointerEvent) => {
+      if (!g.dragging) return;
+      const s = sim.current;
+      const dx = e.clientX - g.lastX;
+      const dy = e.clientY - g.lastY;
+      const dt = Math.max(1, e.timeStamp - g.lastT);
+      const gain = DRAG_RAD_PER_PX * cfg.current.sensitivity;
+
+      s.az -= dx * gain;
+      if (!cfg.current.horizontalLock) {
+        s.el = clamp(s.el + dy * gain, -EL_LIMIT, EL_LIMIT);
+      }
+      g.vx = dx / dt;
+      g.vy = dy / dt;
+      g.moved += Math.hypot(dx, dy);
+      g.lastX = e.clientX;
+      g.lastY = e.clientY;
+      g.lastT = e.timeStamp;
+    };
+
+    const onUp = (e: PointerEvent) => {
+      if (!g.dragging) return;
+      g.dragging = false;
+      el.releasePointerCapture?.(e.pointerId);
+      const s = sim.current;
+
+      if (g.moved < TAP_MAX_PX) {
+        const rect = el.getBoundingClientRect();
+        const candidates = projectFrontCountries(
+          camera,
+          rect.width,
+          rect.height,
+        );
+        settleTo(
+          pickNearestToPoint(
+            candidates,
+            e.clientX - rect.left,
+            e.clientY - rect.top,
+          ),
+        );
+        return;
+      }
+
+      const sens = cfg.current.sensitivity;
+      s.vAz = -flickToSpin(g.vx) * sens;
+      s.vEl = cfg.current.horizontalLock ? 0 : flickToSpin(g.vy) * sens;
+      s.mode = "fling";
+    };
+
+    el.addEventListener("pointerdown", onDown);
+    el.addEventListener("pointermove", onMove);
+    el.addEventListener("pointerup", onUp);
+    return () => {
+      el.removeEventListener("pointerdown", onDown);
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerup", onUp);
+    };
+  }, [gl, camera]);
+
+  useFrame((_, dt) => {
+    const s = sim.current;
+    if (s.mode === "fling") {
+      s.az += s.vAz * dt;
+      s.el = clamp(s.el + s.vEl * dt, -EL_LIMIT, EL_LIMIT);
+      const decay = Math.exp(-cfg.current.friction * dt);
+      s.vAz *= decay;
+      s.vEl *= decay;
+      if (Math.hypot(s.vAz, s.vEl) < SETTLE_VEL) {
+        settleTo(
+          pickSnapCountry(s.el, s.az, cfg.current.visited, cfg.current.fair),
+        );
+      }
+    } else if (s.mode === "settle") {
+      // Under-damped spring: the view glides past the target country and
+      // springs back. Bounce lowers the damping ratio for more overshoot.
+      const dtc = Math.min(dt, 0.05);
+      const zeta = clamp(1 - 0.7 * cfg.current.bounce, 0.2, 1);
+      const dAz = shortestAngle(s.settleAz - s.az);
+      const dEl = s.settleEl - s.el;
+      s.vAz +=
+        (SNAP_OMEGA * SNAP_OMEGA * dAz - 2 * zeta * SNAP_OMEGA * s.vAz) * dtc;
+      s.vEl +=
+        (SNAP_OMEGA * SNAP_OMEGA * dEl - 2 * zeta * SNAP_OMEGA * s.vEl) * dtc;
+      s.az += s.vAz * dtc;
+      s.el += s.vEl * dtc;
+      if (
+        Math.abs(shortestAngle(s.settleAz - s.az)) < 0.002 &&
+        Math.abs(s.settleEl - s.el) < 0.002 &&
+        Math.hypot(s.vAz, s.vEl) < 0.02
+      ) {
+        s.az = s.settleAz;
+        s.el = s.settleEl;
+        s.vAz = 0;
+        s.vEl = 0;
+        s.mode = "idle";
+      }
+    }
+    applyCamera();
+  });
+
+  return null;
+}


### PR DESCRIPTION
## ⚠️ Preview-only — do not merge

A throwaway branch to get a **Vercel Preview URL** for testing the gesture feel on real devices tonight. The production implementation is sliced under #125 (sub-issues #126–#132). This branch will be closed, not merged.

## What this is

Ports the validated gesture spike into the real globe on the home route:

- **Free-rotate removed** — OrbitControls dropped; a spin-snap controller owns the camera (globe is output).
- **Fling** — drag-and-release spins with inertia, then spring-snaps (with overshoot) onto a country.
- **Fairness hybrid** — a fling lands on a not-yet-visited country near where you pushed (per-session visited set, resets on reload).
- **Tap** — jump to the nearest country, works on open ocean (no pin to hit).
- Feel values are locked named constants (sensitivity 1.4, friction 2.5, bounce 0.6, 2D, fairness on), per [ADR-0011](https://github.com/taewanu/sounds-abroad/blob/demo/gesture-preview/docs/adr/0011-globe-as-output-gesture-model.md).

## Not included (later slices)

Accessibility list, reduced-motion cut, haptics, the pure-module test extraction, `replaceState` history nuance — these land in #126–#132.

## Test plan

- Open the Preview URL on a phone, spin/fling/tap the globe, confirm it always settles on a country and the chart sheet follows.
- Verify build (env-backed) on Vercel; local `pnpm typecheck` / `lint` / `build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned globe interaction system with enhanced gesture controls including drag rotation, tap-to-snap, and fling gestures with realistic physics-based spinning, friction, and bounce dynamics.
  * Added automatic country snapping that orients the globe toward selected countries and tracks visited countries within the session to prevent repeated selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->