### PR TITLE
chore(commentary): detail no-lyric drops and defer the quoted-span judge

### DIFF
--- a/docs/adr/0007-out-of-band-human-curated-commentary.md
+++ b/docs/adr/0007-out-of-band-human-curated-commentary.md
@@ -1,6 +1,6 @@
 # ADR-0007: Out-of-band human-curated commentary
 
-**Status:** Accepted (2026-06-15). Trust model partially superseded by [ADR-0008](0008-risk-tiered-commentary-gate.md) (2026-06-16): the primary guard moves from a uniform human read-through to a risk-tiered code gate. The rest of this record (out-of-band generation, the Blob sidecar, the crawl contract, the significance trigger, the no-lyric lint) stands.
+**Status:** Accepted (2026-06-15). Trust model partially superseded by [ADR-0008](0008-risk-tiered-commentary-gate.md) (2026-06-16): the primary guard moves from a uniform human read-through to a risk-tiered code gate. The rest of this record (out-of-band generation, the Blob sidecar, the crawl contract, the significance trigger, the no-lyric lint) stands. An LLM-adjudicated relaxation of the no-lyric lint's `quoted-span` rule was proposed and DEFERRED by [ADR-0010](0010-defer-quoted-span-lyric-judge.md) (2026-06-20): the rule still hard-drops, pending data on how often it false-positives on long titles.
 
 ## Context
 

--- a/docs/adr/0010-defer-quoted-span-lyric-judge.md
+++ b/docs/adr/0010-defer-quoted-span-lyric-judge.md
@@ -1,0 +1,36 @@
+# ADR-0010: Defer an LLM judge for the no-lyric lint's quoted-span rule
+
+**Status:** Accepted (2026-06-20). Records a decision to DEFER a proposed change to [ADR-0007](0007-out-of-band-human-curated-commentary.md)'s no-lyric lint. The lint is unchanged; `quoted-span` still hard-drops.
+
+## Context
+
+The no-lyric lint (ADR-0007) backstops against reproducing lyrics, carried into the automated gate (ADR-0009). Its `quoted-span` rule hard-drops any double-quoted run longer than six words as reproduced lyric. The rule keys on punctuation and length, not meaning, so it cannot tell a reproduced lyric line from a long title. Under the human read-through ADR-0007 assumed, a false positive cost the editor one glance; ADR-0009 removed the human, so the same false positive silently drops a card.
+
+The first bulk-draft pass hit this once: a blurb on a single charting in over thirty countries was dropped because its lead quoted a ten-word album title. A fix was designed: turn `quoted-span` into a trigger that calls a cheap-tier LLM title-versus-lyric judge (tri-state, fail-safe like the grounding check), while the structural rules (`verse-lines`, `repeated-line`) stay a deterministic floor.
+
+## Decision
+
+Do not build the judge now. Keep `quoted-span` as a deterministic hard-drop. Instead, add drop-reason detail (the failing sub-rule and the excerpt) to the publish route, so a batch's no-lyric drops self-classify: a `quoted-span` on a long title reads as a false positive, a verse-shaped run as a real catch. Revisit the judge only if that logging shows `quoted-span` false positives are common.
+
+### Why defer (measure-first)
+
+The trigger was one card. The next twenty-item batch fired the no-lyric lint zero times; across twenty-five gated drafts the `quoted-span` false-positive rate is about one. Building an LLM judge to fix a roughly four-percent event is premature, and it is not free: it adds prompt surface, a second "an LLM checking an LLM" call, and correlated-error risk with the drafter (same model family may reproduce a lyric and then wave it through). The cost of the false positive today is one dropped card, which the carry-forward contract (ADR-0007) already renders as no card, never a wrong public claim. Instrument first; build only if the data turns.
+
+### Why the judge is the right shape if revisited
+
+Title-versus-lyric is a semantic distinction, and length cannot draw it: a quoted lyric hook and a long title can both exceed six words. A deterministic cue-word carve-out (skip a span after "album" or "single") is brittle against titles with no cue word and non-English titles. ADR-0009 already accepts an LLM judge for the analogous "does the source state this claim" question, so the pattern fits. The deferred design, for the record: `quoted-span` triggers the judge; only a confident "title" clears the span; "lyric", "uncertain", and malformed verdicts drop; it runs on a cheaper tier than grounding; the structural rules remain a model-independent floor.
+
+## Consequences
+
+**Positive**
+
+- No new LLM surface or cost now, and the `quoted-span` backstop stays strict.
+- The enriched drop-log turns any future revisit into a data decision, not a guess.
+
+**Negative**
+
+- The known false positive persists: a blurb that quotes a long title in double quotes still drops until the drafter avoids that shape or the judge is built. The meantime lever is drafting (do not quote long titles), not loosening the lint.
+
+**Neutral**
+
+- ADR-0007's lint and ADR-0009's gate are untouched. This is the first ADR here that defers a change rather than adopting one.

--- a/scripts/commentary/route.test.ts
+++ b/scripts/commentary/route.test.ts
@@ -75,6 +75,20 @@ describe("routeStore", () => {
     expect(ground).not.toHaveBeenCalled();
   });
 
+  test("a no-lyric drop names the failing sub-rule and quotes the excerpt", async () => {
+    const quoted = '"na na na la la oh oh my my my"';
+    const store = {
+      [KEY]: entry({ lead: `The hook repeats ${quoted} throughout.` }),
+    };
+
+    const result = await routeStore(store, { ground: grounds });
+
+    expect(result.published).toEqual({});
+    expect(result.dropped).toEqual([
+      { key: KEY, reasons: [`no-lyric: quoted-span ${quoted}`] },
+    ]);
+  });
+
   test("routes each entry independently: a dropped card never blocks a clean one", async () => {
     const store = {
       [KEY]: entry(),

--- a/scripts/commentary/route.ts
+++ b/scripts/commentary/route.ts
@@ -6,6 +6,7 @@ import {
   type GateChecks,
 } from "../../src/lib/gate-classifier";
 import type { GroundingVerdict } from "../../src/lib/grounding";
+import { lintCommentary } from "../../src/lib/no-lyric-lint";
 
 /**
  * Per-entry routing: the publish-side half of the gate (ADR-0009). It runs each
@@ -31,10 +32,23 @@ export interface RouteResult {
   dropped: DropRecord[];
 }
 
-/** Names the deterministic checks an entry failed, for the drop log. */
-function failedDeterministic(checks: Omit<GateChecks, "grounding">): string[] {
+/**
+ * Names the deterministic checks an entry failed, for the drop log. The
+ * no-lyric failure also carries its sub-rule and excerpt so a batch's drops
+ * self-classify: a quoted-span on a long title reads as a false positive, a
+ * verse-shaped run as a real catch.
+ */
+function failedDeterministic(
+  entry: Commentary,
+  checks: Omit<GateChecks, "grounding">,
+): string[] {
   const failed: string[] = [];
-  if (!checks.noLyric) failed.push("no-lyric");
+  if (!checks.noLyric) {
+    const detail = lintCommentary(entry)
+      .map((risk) => `${risk.rule} ${risk.excerpt}`)
+      .join("; ");
+    failed.push(detail ? `no-lyric: ${detail}` : "no-lyric");
+  }
   if (!checks.sourceAuthority) failed.push("source-authority");
   if (!checks.tierConsistency) failed.push("tier-consistency");
   return failed;
@@ -49,7 +63,7 @@ export async function routeStore(
 
   for (const [key, entry] of Object.entries(store)) {
     const det = deterministicChecks(entry);
-    const detFailures = failedDeterministic(det);
+    const detFailures = failedDeterministic(entry, det);
 
     // Grounding is a network call and a model turn; the gate ANDs every check,
     // so an entry already failing a deterministic check is doomed. Skip the


### PR DESCRIPTION
## What

Two changes from investigating a no-lyric false positive surfaced during bulk-drafting:

1. **Enriched drop log** (`route.ts`): a no-lyric drop now records the failing sub-rule and the offending excerpt, e.g. `no-lyric: quoted-span "You Seem Pretty Sad for a Girl So in Love."`, instead of a bare `no-lyric`.
2. **ADR-0010** (new): records the decision to **defer** an LLM title-versus-lyric judge for the `quoted-span` rule, with the measure-first reasoning. The lint is unchanged; `quoted-span` still hard-drops.

## Why

The automated gate (ADR-0009) drops a card on any no-lyric hit with no human to see why, so a long quoted **title** can silently kill a good blurb (a marquee single was dropped this way because its lead quoted a 10-word album title). A fix was designed (quoted-span triggers an LLM judge), but the next 20-item batch fired no-lyric **zero** times: the false-positive rate is ~1 in 25, too rare to justify a second LLM call now. So we instrument instead of building: the enriched log lets future batches self-classify quoted-span (title false positive) vs verse/repeat (real lyric), and ADR-0010 records the deferral plus the trigger to revisit.

ADR-0007's status pointer is updated to reflect "proposed and deferred," not "amended."

## Test plan

- `pnpm typecheck` — clean
- `pnpm test` — 347 pass (route + no-lyric suites included)
- Pre-commit hook (prettier + eslint --fix + typecheck on staged) passed
- Behavior: the drop **decision** is unchanged (same entries drop); only the drop **reason string** gains detail. No new schema or gate logic.

## Scope

Docs + one diagnostic-logging change. No product-facing behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision documenting a deferral plan for potential AI-driven validation enhancements, scheduled for future review based on real-world data.
  * Updated existing architectural decision with cross-reference to deferred enhancement plan.

* **New Features**
  * Enhanced validation error messages to include specific failing rules and content excerpts, enabling users to better diagnose and classify validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->