### PR TITLE
feat(globe): selection math + fairness draw for the spin gesture

### DIFF
--- a/src/components/globe/spin-select.test.ts
+++ b/src/components/globe/spin-select.test.ts
@@ -136,6 +136,17 @@ test("pickSnapCountry returns a country from the nearest pool when fairness is o
   expect(nearestPool(el, az, 10)).toContain(result);
 });
 
+test("pickSnapCountry fair draw is deterministic under an injected rng", () => {
+  const target = COUNTRIES[0];
+  const el = target.lat * DEG;
+  const az = target.lon * DEG;
+  const pool = nearestPool(el, az, 10);
+
+  // No visits → uniform weights, so r maps linearly across the pool.
+  expect(pickSnapCountry(el, az, new Set(), true, () => 0)).toBe(pool[0]);
+  expect(pickSnapCountry(el, az, new Set(), true, () => 0.95)).toBe(pool[9]);
+});
+
 test("every country appears in some nearest pool over the reachable sphere", () => {
   const POOL_SIZE = 10; // mirrors the snap pool size in spin-select.ts
   const EL_LIMIT = 75 * DEG; // the spin elevation clamp

--- a/src/components/globe/spin-select.test.ts
+++ b/src/components/globe/spin-select.test.ts
@@ -1,0 +1,157 @@
+import { PerspectiveCamera, Vector3 } from "three";
+import { expect, test } from "vitest";
+
+import { COUNTRIES, type CountryEntry } from "@/lib/countries";
+import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
+
+import {
+  nearestPool,
+  pickNearestToPoint,
+  pickSnapCountry,
+  projectFrontCountries,
+  weightedDraw,
+} from "./spin-select";
+
+const GLOBE_RADIUS = 3.5;
+const DEG = Math.PI / 180;
+
+function directionOf(code: string): Vector3 {
+  const country = COUNTRIES.find((c) => c.code === code);
+  if (!country) throw new Error(`unknown country code: ${code}`);
+  return latLonToVec3(country.lat, country.lon, 1).normalize();
+}
+
+// A camera looking at the globe centre from `direction`, with its matrices
+// updated so projection math is valid.
+function cameraFacing(direction: Vector3): PerspectiveCamera {
+  const camera = new PerspectiveCamera(45, 1, 0.1, 100);
+  camera.position.copy(
+    direction.clone().normalize().multiplyScalar(GLOBE_RADIUS),
+  );
+  camera.lookAt(0, 0, 0);
+  camera.updateMatrixWorld();
+  camera.updateProjectionMatrix();
+  return camera;
+}
+
+function farthestFrom(direction: Vector3): string {
+  let farthest = COUNTRIES[0].code;
+  let minDot = Infinity;
+  for (const country of COUNTRIES) {
+    const dot = directionOf(country.code).dot(direction);
+    if (dot < minDot) {
+      minDot = dot;
+      farthest = country.code;
+    }
+  }
+  return farthest;
+}
+
+function screenAt(country: CountryEntry, sx: number, sy: number) {
+  return { country, sx, sy };
+}
+
+test("projectFrontCountries keeps the faced country and drops its far-side opposite", () => {
+  const faced = COUNTRIES[0];
+  const facedDirection = directionOf(faced.code);
+  const opposite = farthestFrom(facedDirection);
+
+  const codes = projectFrontCountries(
+    cameraFacing(facedDirection),
+    800,
+    600,
+  ).map((screen) => screen.country.code);
+
+  expect(codes).toContain(faced.code);
+  expect(codes).not.toContain(opposite);
+});
+
+test("pickNearestToPoint returns the candidate closest to the tap point", () => {
+  const [near, mid, far] = COUNTRIES;
+  const candidates = [
+    screenAt(near, 100, 100),
+    screenAt(mid, 300, 300),
+    screenAt(far, 500, 100),
+  ];
+
+  expect(pickNearestToPoint(candidates, 290, 310)).toBe(mid.code);
+});
+
+test("pickNearestToPoint returns null when no candidates are given", () => {
+  expect(pickNearestToPoint([], 0, 0)).toBeNull();
+});
+
+test("nearestPool ranks the country under the rest direction first", () => {
+  const target = COUNTRIES[0];
+
+  const pool = nearestPool(target.lat * DEG, target.lon * DEG, 10);
+
+  expect(pool[0]).toBe(target.code);
+});
+
+test("nearestPool caps the pool at n", () => {
+  expect(nearestPool(0, 0, 10)).toHaveLength(10);
+  expect(nearestPool(0, 0, 5)).toHaveLength(5);
+});
+
+test("weightedDraw overwhelmingly prefers an unvisited country in the pool", () => {
+  const [seen, unseen] = COUNTRIES;
+  const pool = [seen.code, unseen.code];
+  const visited = new Set([seen.code]);
+
+  for (const r of [0.1, 0.5, 0.9]) {
+    expect(weightedDraw(pool, visited, r)).toBe(unseen.code);
+  }
+});
+
+test("weightedDraw flattens to a uniform draw once every pool member is visited", () => {
+  const [first, second] = COUNTRIES;
+  const pool = [first.code, second.code];
+  const visited = new Set([first.code, second.code]);
+
+  expect(weightedDraw(pool, visited, 0.25)).toBe(first.code);
+  expect(weightedDraw(pool, visited, 0.75)).toBe(second.code);
+});
+
+test("pickSnapCountry returns the literal nearest country when fairness is off", () => {
+  const target = COUNTRIES[0];
+
+  const result = pickSnapCountry(
+    target.lat * DEG,
+    target.lon * DEG,
+    new Set(),
+    false,
+  );
+
+  expect(result).toBe(target.code);
+});
+
+test("pickSnapCountry returns a country from the nearest pool when fairness is on", () => {
+  const target = COUNTRIES[0];
+  const el = target.lat * DEG;
+  const az = target.lon * DEG;
+
+  const result = pickSnapCountry(el, az, new Set(), true);
+
+  expect(nearestPool(el, az, 10)).toContain(result);
+});
+
+test("every country appears in some nearest pool over the reachable sphere", () => {
+  const POOL_SIZE = 10; // mirrors the snap pool size in spin-select.ts
+  const EL_LIMIT = 75 * DEG; // the spin elevation clamp
+  const STEP = 1.5 * DEG;
+  const reached = new Set<string>();
+
+  for (let el = -EL_LIMIT; el <= EL_LIMIT; el += STEP) {
+    for (let az = -Math.PI; az < Math.PI; az += STEP) {
+      for (const code of nearestPool(el, az, POOL_SIZE)) {
+        reached.add(code);
+      }
+    }
+  }
+
+  const unreachable = COUNTRIES.filter((c) => !reached.has(c.code)).map(
+    (c) => c.code,
+  );
+  expect(unreachable).toEqual([]);
+});

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -105,15 +105,16 @@ const SNAP_POOL = 10; // candidate countries near the rest point for a fair snap
 
 // Fling target. Fairness off: the literal nearest country to the rest direction.
 // Fairness on: a deck-weighted draw from the nearest pool, so a small country
-// wedged between big neighbours still gets its turn. The one random draw lives
-// here at the boundary, keeping nearestPool and weightedDraw pure.
+// wedged between big neighbours still gets its turn. Randomness enters here via
+// `rng` (defaults to Math.random), injected so the fair path stays testable too.
 export function pickSnapCountry(
   el: number,
   az: number,
   visited: ReadonlySet<string>,
   fair: boolean,
+  rng: () => number = Math.random,
 ): string {
   const pool = nearestPool(el, az, SNAP_POOL);
   if (!fair) return pool[0];
-  return weightedDraw(pool, visited, Math.random());
+  return weightedDraw(pool, visited, rng());
 }

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -1,0 +1,119 @@
+import type { Camera } from "three";
+import { Vector3 } from "three";
+
+import { COUNTRIES, type CountryEntry } from "@/lib/countries";
+import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
+
+const DEG = Math.PI / 180;
+const PIN_ELEVATION = 1.015;
+// Drop pins near or behind the limb: their projection overlaps the front face.
+const FRONT_DOT_MIN = 0.1;
+
+const WORLD_BY_CODE = new Map<string, Vector3>(
+  COUNTRIES.map((c) => [c.code, latLonToVec3(c.lat, c.lon, PIN_ELEVATION)]),
+);
+
+export interface ScreenCountry {
+  country: CountryEntry;
+  sx: number;
+  sy: number;
+}
+
+// Countries on the camera-facing hemisphere, projected to canvas pixel space
+// (origin top-left, y down) so a tap point and a pin share one frame.
+export function projectFrontCountries(
+  camera: Camera,
+  width: number,
+  height: number,
+): ScreenCountry[] {
+  const camDir = camera.position.clone().normalize();
+  const result: ScreenCountry[] = [];
+  for (const country of COUNTRIES) {
+    const world = WORLD_BY_CODE.get(country.code);
+    if (!world) continue;
+    if (world.clone().normalize().dot(camDir) <= FRONT_DOT_MIN) continue;
+    const ndc = world.clone().project(camera);
+    result.push({
+      country,
+      sx: ((ndc.x + 1) / 2) * width,
+      sy: ((1 - ndc.y) / 2) * height,
+    });
+  }
+  return result;
+}
+
+// Tap target: the front-facing country whose pin is nearest the tap point.
+export function pickNearestToPoint(
+  candidates: readonly ScreenCountry[],
+  px: number,
+  py: number,
+): string | null {
+  let best: string | null = null;
+  let bestDist = Infinity;
+  for (const c of candidates) {
+    const d = (c.sx - px) ** 2 + (c.sy - py) ** 2;
+    if (d < bestDist) {
+      bestDist = d;
+      best = c.country.code;
+    }
+  }
+  return best;
+}
+
+// Country codes ranked by how closely they face the rest direction (el, az in
+// radians), nearest first, capped at `n`. This is the fling's candidate pool:
+// geography narrows the choice to a neighbourhood before fairness picks within it.
+export function nearestPool(el: number, az: number, n: number): string[] {
+  const cx = Math.cos(el) * Math.sin(az);
+  const cy = Math.sin(el);
+  const cz = Math.cos(el) * Math.cos(az);
+  return COUNTRIES.map((c) => {
+    const lat = c.lat * DEG;
+    const lon = c.lon * DEG;
+    const dot =
+      Math.cos(lat) * Math.sin(lon) * cx +
+      Math.sin(lat) * cy +
+      Math.cos(lat) * Math.cos(lon) * cz;
+    return { code: c.code, dot };
+  })
+    .sort((a, b) => b.dot - a.dot)
+    .slice(0, n)
+    .map((entry) => entry.code);
+}
+
+const VISITED_WEIGHT = 0.08; // how strongly an already-seen country is avoided
+
+// Weighted random draw from `pool`, biased away from already-visited countries
+// so the same few do not repeat. `r` (in [0, 1)) is the injected draw position,
+// so the bias stays testable without stubbing Math.random.
+export function weightedDraw(
+  pool: readonly string[],
+  visited: ReadonlySet<string>,
+  r: number,
+): string {
+  const weights = pool.map((code) => (visited.has(code) ? VISITED_WEIGHT : 1));
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  let position = r * total;
+  for (let i = 0; i < pool.length; i++) {
+    position -= weights[i];
+    if (position <= 0) return pool[i];
+  }
+  return pool[pool.length - 1];
+}
+
+const SNAP_POOL = 10; // candidate countries near the rest point for a fair snap
+
+// Fling target. Fairness off: the literal nearest country to the rest direction.
+// Fairness on: a deck-weighted draw from the nearest pool, so a small country
+// wedged between big neighbours still gets its turn. The one random draw lives
+// here at the boundary, keeping nearestPool and weightedDraw pure.
+export function pickSnapCountry(
+  el: number,
+  az: number,
+  visited: ReadonlySet<string>,
+  fair: boolean,
+): string {
+  const pool = nearestPool(el, az, SNAP_POOL);
+  if (!fair) return pool[0];
+  return weightedDraw(pool, visited, Math.random());
+}


### PR DESCRIPTION
The pure, tested selection module the v2.0.0 globe-as-output gesture is built on (ADR-0011). No React, no Three.js side effects: inputs in, a country code out.

## What's here
- `projectFrontCountries` — countries on the camera-facing hemisphere, projected to screen space (the tap frame).
- `pickNearestToPoint` — the tap target: the nearest front-facing country to a screen point.
- `nearestPool` — the fling's candidate pool: the nearest N countries to the rest direction.
- `weightedDraw` — the anti-repeat fairness draw: a weighted pick within the pool biased toward not-yet-visited countries. Randomness is injected (the caller passes it), so the bias is unit-tested deterministically.
- `pickSnapCountry` — composes them: fairness-off returns the literal nearest; fairness-on draws from the pool.

## Scope
- Closes #127 — selection math as a tested pure module, plus the standing reachability test.
- Advances #129: this is its fairness algorithm and unit tests. The remaining #129 criteria — the per-session `visited` set lifecycle (resets on reload) and settle updating that set — are wired in the controller slice, so #129 closes there, not here.
- Part of the #125 PRD.

## Test plan
- `pnpm test` — 358 pass, including 10 new tests for this module.
- Standing reachability test sweeps 24,240 rest points (1.5° grid, |el| ≤ 75°) and asserts all 63 countries appear in some nearest-N pool, promoting ADR-0011's offline check into CI.
- `pnpm typecheck`, `pnpm lint`, `pnpm build` — all green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved country selection on interactive globe for tap and drag interactions
  * Added fairness mode to avoid selecting the same country repeatedly in quick succession

* **Tests**
  * Comprehensive test coverage for country selection utilities and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->