### PR TITLE
feat(globe): keyboard country selector + reduced-motion cut (#131)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 
+import { CountrySelector } from "@/components/country-selector";
 import { GlobeMount } from "@/components/globe/globe-mount";
 import { SITE_URL } from "@/lib/site-url";
 
@@ -82,6 +84,9 @@ export default function RootLayout({
         <div className="fixed inset-0">
           <GlobeMount />
         </div>
+        <Suspense fallback={null}>
+          <CountrySelector />
+        </Suspense>
         {children}
       </body>
     </html>

--- a/src/components/country-selector.test.tsx
+++ b/src/components/country-selector.test.tsx
@@ -78,4 +78,26 @@ describe("CountrySelector", () => {
     expect(screen.queryByRole("navigation", { name: "Countries" })).toBeNull();
     expect(document.activeElement).toBe(toggle);
   });
+
+  test("the close button closes the list and returns focus to the toggle", () => {
+    render(<CountrySelector />);
+    const toggle = screen.getByRole("button", { name: /choose a country/i });
+    fireEvent.click(toggle);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /close country list/i }),
+    );
+
+    expect(screen.queryByRole("navigation", { name: "Countries" })).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  test("tapping the scrim closes the list", () => {
+    render(<CountrySelector />);
+    openList();
+
+    fireEvent.click(screen.getByTestId("country-scrim"));
+
+    expect(screen.queryByRole("navigation", { name: "Countries" })).toBeNull();
+  });
 });

--- a/src/components/country-selector.test.tsx
+++ b/src/components/country-selector.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockSearchParams = vi.hoisted(() => ({
+  value: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams.value,
+}));
+
+import { CountrySelector } from "./country-selector";
+
+const openList = () =>
+  fireEvent.click(screen.getByRole("button", { name: /choose a country/i }));
+
+describe("CountrySelector", () => {
+  let replaceState: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams("cc=br");
+    replaceState = vi
+      .spyOn(window.history, "replaceState")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    replaceState.mockRestore();
+  });
+
+  test("labels the toggle with the current country and starts collapsed", () => {
+    render(<CountrySelector />);
+
+    const toggle = screen.getByRole("button", {
+      name: /currently showing Brazil/i,
+    });
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("navigation", { name: "Countries" })).toBeNull();
+  });
+
+  test("opens a Countries landmark of named country buttons", () => {
+    render(<CountrySelector />);
+
+    openList();
+
+    const nav = screen.getByRole("navigation", { name: "Countries" });
+    expect(within(nav).getByRole("button", { name: "France" })).toBeDefined();
+    expect(within(nav).getByRole("button", { name: "Japan" })).toBeDefined();
+  });
+
+  test("selecting a country writes ?cc= via replaceState and announces it", () => {
+    render(<CountrySelector />);
+    openList();
+
+    fireEvent.click(screen.getByRole("button", { name: "France" }));
+
+    expect(replaceState).toHaveBeenCalledWith(null, "", "?cc=fr");
+    expect(screen.getByRole("status").textContent).toContain("France");
+  });
+
+  test("stays open after selecting so exploration can continue", () => {
+    render(<CountrySelector />);
+    openList();
+
+    fireEvent.click(screen.getByRole("button", { name: "France" }));
+
+    expect(screen.getByRole("navigation", { name: "Countries" })).toBeDefined();
+  });
+
+  test("Escape closes the list and returns focus to the toggle", () => {
+    render(<CountrySelector />);
+    const toggle = screen.getByRole("button", { name: /choose a country/i });
+    fireEvent.click(toggle);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.queryByRole("navigation", { name: "Countries" })).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+});

--- a/src/components/country-selector.test.tsx
+++ b/src/components/country-selector.test.tsx
@@ -49,6 +49,19 @@ describe("CountrySelector", () => {
     expect(within(nav).getByRole("button", { name: "Japan" })).toBeDefined();
   });
 
+  test("groups the countries into labeled continent regions", () => {
+    render(<CountrySelector />);
+    openList();
+
+    const americas = screen.getByRole("group", { name: "Americas" });
+    expect(
+      within(americas).getByRole("button", { name: "Brazil" }),
+    ).toBeDefined();
+    for (const region of ["Americas", "Europe", "Africa", "Asia", "Oceania"]) {
+      expect(screen.getByRole("group", { name: region })).toBeDefined();
+    }
+  });
+
   test("selecting a country writes ?cc= via replaceState and announces it", () => {
     render(<CountrySelector />);
     openList();

--- a/src/components/country-selector.tsx
+++ b/src/components/country-selector.tsx
@@ -6,11 +6,22 @@ import { useSearchParams } from "next/navigation";
 import { COUNTRIES } from "@/lib/countries";
 import { countryByCode, validateCountryCode } from "@/lib/country-code";
 
-// Alphabetical so the grid is predictable to scan and tab through; the globe's
-// own COUNTRIES order is region-grouped for the gesture, not for reading.
-const SORTED_COUNTRIES = COUNTRIES.toSorted((a, b) =>
-  a.name.localeCompare(b.name),
-);
+// Group the grid by continent, west-to-east so it mirrors the globe's eastward
+// spin; alphabetical within each region.
+const REGION_ORDER = [
+  "Americas",
+  "Europe",
+  "Africa",
+  "Asia",
+  "Oceania",
+] as const;
+
+const COUNTRIES_BY_REGION = REGION_ORDER.map((region) => ({
+  region,
+  countries: COUNTRIES.filter((c) => c.region === region).toSorted((a, b) =>
+    a.name.localeCompare(b.name),
+  ),
+}));
 
 // ISO 3166-1 alpha-2 → regional-indicator flag emoji. Decorative only (the
 // country name carries the meaning); degrades to the letter pair on platforms
@@ -122,23 +133,45 @@ export function CountrySelector() {
               ✕
             </button>
           </div>
-          <ul className="flex flex-wrap content-start gap-1.5 overflow-y-auto p-2.5">
-            {SORTED_COUNTRIES.map((c) => (
-              <li key={c.code}>
-                <button
-                  type="button"
-                  onClick={() => handleSelect(c.code, c.name)}
-                  aria-current={c.code === currentCode ? "true" : undefined}
-                  className="border-fg-1/15 bg-dusk text-fg-2 hover:text-fg-1 hover:border-fg-3 focus-visible:outline-aurora aria-[current=true]:border-aurora aria-[current=true]:bg-aurora/10 aria-[current=true]:text-fg-1 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[11px] transition-colors focus-visible:outline-2 focus-visible:outline-offset-1"
+          <div className="overflow-y-auto p-2.5">
+            {COUNTRIES_BY_REGION.map(({ region, countries }) => (
+              <div
+                key={region}
+                role="group"
+                aria-label={region}
+                className="mt-3 first:mt-0"
+              >
+                <p
+                  aria-hidden="true"
+                  className="text-aurora px-1 pb-1.5 text-[10px] font-medium tracking-wider uppercase"
                 >
-                  <span aria-hidden="true" className="text-sm leading-none">
-                    {flagEmoji(c.code)}
-                  </span>
-                  <span className="whitespace-nowrap">{c.name}</span>
-                </button>
-              </li>
+                  {region}
+                </p>
+                <ul className="flex flex-wrap content-start gap-1.5">
+                  {countries.map((c) => (
+                    <li key={c.code}>
+                      <button
+                        type="button"
+                        onClick={() => handleSelect(c.code, c.name)}
+                        aria-current={
+                          c.code === currentCode ? "true" : undefined
+                        }
+                        className="border-fg-1/15 bg-dusk text-fg-2 hover:text-fg-1 hover:border-fg-3 focus-visible:outline-aurora aria-[current=true]:border-aurora aria-[current=true]:bg-aurora/10 aria-[current=true]:text-fg-1 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[11px] transition-colors focus-visible:outline-2 focus-visible:outline-offset-1"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="text-sm leading-none"
+                        >
+                          {flagEmoji(c.code)}
+                        </span>
+                        <span className="whitespace-nowrap">{c.name}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
-          </ul>
+          </div>
         </nav>
       </div>
 

--- a/src/components/country-selector.tsx
+++ b/src/components/country-selector.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { COUNTRIES } from "@/lib/countries";
 import { countryByCode, validateCountryCode } from "@/lib/country-code";
 
-// Alphabetical so the list is predictable to scan and tab through; the globe's
+// Alphabetical so the grid is predictable to scan and tab through; the globe's
 // own COUNTRIES order is region-grouped for the gesture, not for reading.
 const SORTED_COUNTRIES = COUNTRIES.toSorted((a, b) =>
   a.name.localeCompare(b.name),
@@ -25,7 +25,8 @@ function flagEmoji(code: string): string {
 
 // A keyboard- and screen-reader-first way to pick a country, equal to the globe
 // gesture: a labeled landmark of named country buttons that write ?cc=. The
-// globe follows ?cc=, so selecting here drives the globe too.
+// globe follows ?cc=, so selecting here drives the globe too. The grid stays
+// open after a pick so you can keep hopping between countries.
 export function CountrySelector() {
   const searchParams = useSearchParams();
   const currentCode = validateCountryCode(searchParams.get("cc"));
@@ -33,112 +34,117 @@ export function CountrySelector() {
 
   const [open, setOpen] = useState(false);
   const [announcement, setAnnouncement] = useState("");
-  const rootRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const navId = useId();
 
+  const close = (returnFocus: boolean) => {
+    setOpen(false);
+    if (returnFocus) toggleRef.current?.focus();
+  };
+
   const handleSelect = (code: string, name: string) => {
     // Same channel the gesture uses: replaceState keeps rapid hops out of
-    // history. Stay open so the list is still there to keep exploring.
+    // history. Stay open so the grid is still there to keep exploring.
     window.history.replaceState(null, "", `?cc=${code}`);
     setAnnouncement(`Now showing ${name}`);
   };
 
-  // Escape closes the list and returns focus to the toggle — the one focus move
-  // a disclosure needs. (No focus trap; tab order alone walks in and out.)
+  // Escape closes and returns focus to the toggle — the one focus move a
+  // disclosure needs. (No focus trap; tab order alone walks in and out.)
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        toggleRef.current?.focus();
-      }
+      if (e.key === "Escape") close(true);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open]);
 
-  // A pointer down anywhere outside dismisses the list, including grabbing the
-  // globe to spin it.
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (e: PointerEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    window.addEventListener("pointerdown", onPointerDown);
-    return () => window.removeEventListener("pointerdown", onPointerDown);
-  }, [open]);
-
   return (
-    <div
-      ref={rootRef}
-      className="fixed top-[max(env(safe-area-inset-top),16px)] left-4 z-40"
-    >
-      <button
-        ref={toggleRef}
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-controls={navId}
-        aria-label={
-          current
-            ? `Choose a country, currently showing ${current.name}`
-            : "Choose a country"
-        }
-        className="bg-void/70 border-aurora/40 text-fg-1 text-small focus-visible:outline-aurora flex max-w-[60vw] items-center gap-2 rounded-full border px-3.5 py-2.5 font-medium backdrop-blur-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
-      >
-        {current ? (
-          <span aria-hidden="true" className="text-base leading-none">
-            {flagEmoji(current.code)}
-          </span>
-        ) : (
-          <span aria-hidden="true" className="text-base leading-none">
-            🌐
-          </span>
-        )}
-        <span className="min-w-0 truncate">
-          {current ? current.name : "Countries"}
-        </span>
-        <span
+    <>
+      {/* Scrim: dims the globe, is the big easy tap-to-dismiss target, and
+          intercepts the pointer so a dismiss tap never spins the globe. */}
+      {open ? (
+        <div
+          data-testid="country-scrim"
           aria-hidden="true"
-          className={`text-fg-3 transition-transform duration-200 ${
-            open ? "rotate-180" : ""
-          }`}
-        >
-          ▾
-        </span>
-      </button>
+          onClick={() => close(false)}
+          className="fixed inset-0 z-30 bg-[rgba(5,6,8,0.5)] backdrop-blur-[1px]"
+        />
+      ) : null}
 
-      <nav
-        id={navId}
-        aria-label="Countries"
-        hidden={!open}
-        className="bg-night/95 border-fg-1/10 absolute top-[calc(100%+8px)] left-0 max-h-[60vh] w-[min(78vw,320px)] overflow-y-auto rounded-2xl border p-2 shadow-lg backdrop-blur-lg"
-      >
-        <ul className="flex flex-col gap-0.5">
-          {SORTED_COUNTRIES.map((c) => (
-            <li key={c.code}>
-              <button
-                type="button"
-                onClick={() => handleSelect(c.code, c.name)}
-                aria-current={c.code === currentCode ? "true" : undefined}
-                className="text-fg-2 text-small hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora aria-[current=true]:bg-aurora/10 aria-[current=true]:text-fg-1 flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2"
-              >
-                <span aria-hidden="true" className="text-base leading-none">
-                  {flagEmoji(c.code)}
-                </span>
-                <span className="min-w-0 truncate">{c.name}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      </nav>
+      <div className="fixed top-[max(env(safe-area-inset-top),16px)] left-4 z-40">
+        <button
+          ref={toggleRef}
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls={navId}
+          aria-label={
+            current
+              ? `Choose a country, currently showing ${current.name}`
+              : "Choose a country"
+          }
+          className="bg-void/70 border-aurora/40 text-fg-1 text-small focus-visible:outline-aurora flex max-w-[60vw] items-center gap-2 rounded-full border px-3.5 py-2.5 font-medium backdrop-blur-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          <span aria-hidden="true" className="text-base leading-none">
+            {current ? flagEmoji(current.code) : "🌐"}
+          </span>
+          <span className="min-w-0 truncate">
+            {current ? current.name : "Countries"}
+          </span>
+          <span
+            aria-hidden="true"
+            className={`text-fg-3 transition-transform duration-200 ${
+              open ? "rotate-180" : ""
+            }`}
+          >
+            ▾
+          </span>
+        </button>
+
+        <nav
+          id={navId}
+          aria-label="Countries"
+          hidden={!open}
+          className="bg-night/95 border-fg-1/10 absolute top-[calc(100%+8px)] left-0 flex max-h-[58vh] w-[min(86vw,360px)] flex-col overflow-hidden rounded-2xl border shadow-lg backdrop-blur-lg"
+        >
+          <div className="border-fg-1/10 flex flex-none items-center justify-between border-b px-3 py-2">
+            <span className="text-fg-3 text-[10px] font-medium tracking-wider uppercase">
+              Jump to a country
+            </span>
+            <button
+              type="button"
+              onClick={() => close(true)}
+              aria-label="Close country list"
+              className="bg-orbit text-fg-2 hover:text-fg-1 focus-visible:outline-aurora flex h-6 w-6 items-center justify-center rounded-full text-xs leading-none focus-visible:outline-2 focus-visible:outline-offset-1"
+            >
+              ✕
+            </button>
+          </div>
+          <ul className="flex flex-wrap content-start gap-1.5 overflow-y-auto p-2.5">
+            {SORTED_COUNTRIES.map((c) => (
+              <li key={c.code}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(c.code, c.name)}
+                  aria-current={c.code === currentCode ? "true" : undefined}
+                  className="border-fg-1/15 bg-dusk text-fg-2 hover:text-fg-1 hover:border-fg-3 focus-visible:outline-aurora aria-[current=true]:border-aurora aria-[current=true]:bg-aurora/10 aria-[current=true]:text-fg-1 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[11px] transition-colors focus-visible:outline-2 focus-visible:outline-offset-1"
+                >
+                  <span aria-hidden="true" className="text-sm leading-none">
+                    {flagEmoji(c.code)}
+                  </span>
+                  <span className="whitespace-nowrap">{c.name}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
 
       <div className="sr-only" role="status" aria-live="polite">
         {announcement}
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/country-selector.tsx
+++ b/src/components/country-selector.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+import { COUNTRIES } from "@/lib/countries";
+import { countryByCode, validateCountryCode } from "@/lib/country-code";
+
+// Alphabetical so the list is predictable to scan and tab through; the globe's
+// own COUNTRIES order is region-grouped for the gesture, not for reading.
+const SORTED_COUNTRIES = COUNTRIES.toSorted((a, b) =>
+  a.name.localeCompare(b.name),
+);
+
+// ISO 3166-1 alpha-2 → regional-indicator flag emoji. Decorative only (the
+// country name carries the meaning); degrades to the letter pair on platforms
+// without flag glyphs (e.g. Windows).
+function flagEmoji(code: string): string {
+  const offset = 0x1f1e6 - "a".charCodeAt(0);
+  return String.fromCodePoint(
+    code.charCodeAt(0) + offset,
+    code.charCodeAt(1) + offset,
+  );
+}
+
+// A keyboard- and screen-reader-first way to pick a country, equal to the globe
+// gesture: a labeled landmark of named country buttons that write ?cc=. The
+// globe follows ?cc=, so selecting here drives the globe too.
+export function CountrySelector() {
+  const searchParams = useSearchParams();
+  const currentCode = validateCountryCode(searchParams.get("cc"));
+  const current = currentCode ? countryByCode(currentCode) : null;
+
+  const [open, setOpen] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const navId = useId();
+
+  const handleSelect = (code: string, name: string) => {
+    // Same channel the gesture uses: replaceState keeps rapid hops out of
+    // history. Stay open so the list is still there to keep exploring.
+    window.history.replaceState(null, "", `?cc=${code}`);
+    setAnnouncement(`Now showing ${name}`);
+  };
+
+  // Escape closes the list and returns focus to the toggle — the one focus move
+  // a disclosure needs. (No focus trap; tab order alone walks in and out.)
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        toggleRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  // A pointer down anywhere outside dismisses the list, including grabbing the
+  // globe to spin it.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => window.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="fixed top-[max(env(safe-area-inset-top),16px)] left-4 z-40"
+    >
+      <button
+        ref={toggleRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={navId}
+        aria-label={
+          current
+            ? `Choose a country, currently showing ${current.name}`
+            : "Choose a country"
+        }
+        className="bg-void/70 border-aurora/40 text-fg-1 text-small focus-visible:outline-aurora flex max-w-[60vw] items-center gap-2 rounded-full border px-3.5 py-2.5 font-medium backdrop-blur-md transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+      >
+        {current ? (
+          <span aria-hidden="true" className="text-base leading-none">
+            {flagEmoji(current.code)}
+          </span>
+        ) : (
+          <span aria-hidden="true" className="text-base leading-none">
+            🌐
+          </span>
+        )}
+        <span className="min-w-0 truncate">
+          {current ? current.name : "Countries"}
+        </span>
+        <span
+          aria-hidden="true"
+          className={`text-fg-3 transition-transform duration-200 ${
+            open ? "rotate-180" : ""
+          }`}
+        >
+          ▾
+        </span>
+      </button>
+
+      <nav
+        id={navId}
+        aria-label="Countries"
+        hidden={!open}
+        className="bg-night/95 border-fg-1/10 absolute top-[calc(100%+8px)] left-0 max-h-[60vh] w-[min(78vw,320px)] overflow-y-auto rounded-2xl border p-2 shadow-lg backdrop-blur-lg"
+      >
+        <ul className="flex flex-col gap-0.5">
+          {SORTED_COUNTRIES.map((c) => (
+            <li key={c.code}>
+              <button
+                type="button"
+                onClick={() => handleSelect(c.code, c.name)}
+                aria-current={c.code === currentCode ? "true" : undefined}
+                className="text-fg-2 text-small hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora aria-[current=true]:bg-aurora/10 aria-[current=true]:text-fg-1 flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2"
+              >
+                <span aria-hidden="true" className="text-base leading-none">
+                  {flagEmoji(c.code)}
+                </span>
+                <span className="min-w-0 truncate">{c.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="sr-only" role="status" aria-live="polite">
+        {announcement}
+      </div>
+    </div>
+  );
+}

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -9,6 +9,8 @@ import { COUNTRIES } from "@/lib/countries";
 import { validateCountryCode } from "@/lib/country-code";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 
+import { usePrefersReducedMotion } from "../use-prefers-reduced-motion";
+
 import { cameraForViewport } from "./camera-fit";
 import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
@@ -54,6 +56,7 @@ function CountryLayers({
 function SceneContent() {
   const searchParams = useSearchParams();
   const selectedCode = validateCountryCode(searchParams.get("cc"));
+  const reducedMotion = usePrefersReducedMotion();
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
@@ -104,6 +107,8 @@ function SceneContent() {
       />
       <SpinSnapControls
         initialCode={initialCode}
+        targetCode={selectedCode}
+        reducedMotion={reducedMotion}
         sensitivity={SPIN_SENSITIVITY}
         friction={SPIN_FRICTION}
         bounce={SPIN_BOUNCE}

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -32,6 +32,11 @@ const shortestAngle = (delta: number) =>
 
 interface SpinSnapControlsProps {
   initialCode: string;
+  // The externally-selected country (?cc=); the globe settles to it when it
+  // changes, so the a11y list and shared links drive the globe like a gesture.
+  targetCode: string | null;
+  // OS "reduce motion": replaces the snap spring with an instant cut.
+  reducedMotion: boolean;
   sensitivity: number;
   friction: number;
   horizontalLock: boolean;
@@ -47,6 +52,8 @@ interface SpinSnapControlsProps {
 // open ocean.
 export function SpinSnapControls({
   initialCode,
+  targetCode,
+  reducedMotion,
   sensitivity,
   friction,
   horizontalLock,
@@ -65,6 +72,7 @@ export function SpinSnapControls({
     bounce,
     fair,
     visited,
+    reducedMotion,
   });
   const onSettleRef = useRef(onSettle);
 
@@ -78,6 +86,7 @@ export function SpinSnapControls({
       bounce,
       fair,
       visited,
+      reducedMotion,
     };
     onSettleRef.current = onSettle;
   });
@@ -108,6 +117,10 @@ export function SpinSnapControls({
     camera.lookAt(0, 0, 0);
   };
 
+  // Aim the camera at a country. Records the landing and notifies once via
+  // onSettle no matter how we got here (fling, tap, or an external ?cc=
+  // change), then either cuts instantly (reduced motion) or hands off to the
+  // snap spring in useFrame.
   const settleTo = (code: string | null) => {
     const s = sim.current;
     const country = code ? COUNTRY_BY_CODE.get(code) : null;
@@ -117,12 +130,33 @@ export function SpinSnapControls({
     }
     s.settleAz = country.lon * DEG;
     s.settleEl = country.lat * DEG;
-    s.mode = "settle";
     if (s.settledCode !== country.code) {
       s.settledCode = country.code;
       onSettleRef.current(country.code);
     }
+
+    if (cfg.current.reducedMotion) {
+      // Instant cut: jump straight to the spring's end state so the next
+      // applyCamera draws the target country with no in-between frames.
+      s.az = s.settleAz;
+      s.el = s.settleEl;
+      s.vAz = 0;
+      s.vEl = 0;
+      s.mode = "idle";
+    } else {
+      s.mode = "settle";
+    }
   };
+
+  // Follow external selection: when ?cc= changes (the a11y country list, a
+  // shared link) and we aren't already there, settle to it like a gesture
+  // would. A gesture's own settle writes ?cc=, so targetCode === settledCode by
+  // the time this runs — it no-ops, no feedback loop.
+  useEffect(() => {
+    if (targetCode && targetCode !== sim.current.settledCode) {
+      settleTo(targetCode);
+    }
+  }, [targetCode]);
 
   useEffect(() => {
     const el = gl.domElement;

--- a/src/components/use-overflow-marquee.ts
+++ b/src/components/use-overflow-marquee.ts
@@ -6,23 +6,14 @@ import {
   useEffect,
   useRef,
   useState,
-  useSyncExternalStore,
 } from "react";
+
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
 
 // Scroll pacing: duration scales with the overflow distance so the title moves
 // at a roughly constant speed no matter how far it has to travel.
 const MS_PER_PX = 45;
 const MIN_DURATION_MS = 4000;
-
-function subscribeReducedMotion(onChange: () => void) {
-  const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-  query.addEventListener("change", onChange);
-  return () => query.removeEventListener("change", onChange);
-}
-
-function getReducedMotion() {
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-}
 
 export interface UseOverflowMarqueeOptions {
   // Restrict scrolling to the moments the spec allows (current track, hover).
@@ -45,11 +36,7 @@ export function useOverflowMarquee<T extends HTMLElement = HTMLSpanElement>({
 }: UseOverflowMarqueeOptions): OverflowMarquee<T> {
   const ref = useRef<T>(null);
   const [distance, setDistance] = useState(0);
-  const reducedMotion = useSyncExternalStore(
-    subscribeReducedMotion,
-    getReducedMotion,
-    () => false,
-  );
+  const reducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     const el = ref.current;

--- a/src/components/use-prefers-reduced-motion.test.tsx
+++ b/src/components/use-prefers-reduced-motion.test.tsx
@@ -1,0 +1,71 @@
+import { act, render } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+
+let changeListener: (() => void) | null = null;
+let currentMatches = false;
+
+function stubMatchMedia(initial: boolean) {
+  currentMatches = initial;
+  changeListener = null;
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query: string) =>
+      ({
+        get matches() {
+          return query.includes("reduce") ? currentMatches : false;
+        },
+        media: query,
+        addEventListener: (_type: string, cb: () => void) => {
+          changeListener = cb;
+        },
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList,
+  );
+}
+
+function Harness() {
+  const reduced = usePrefersReducedMotion();
+  return <span data-testid="probe" data-reduced={reduced || undefined} />;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("usePrefersReducedMotion", () => {
+  test("is false when the OS allows motion", () => {
+    stubMatchMedia(false);
+
+    const { getByTestId } = render(<Harness />);
+
+    expect(getByTestId("probe").getAttribute("data-reduced")).toBeNull();
+  });
+
+  test("is true when the OS prefers reduced motion", () => {
+    stubMatchMedia(true);
+
+    const { getByTestId } = render(<Harness />);
+
+    expect(getByTestId("probe").getAttribute("data-reduced")).toBe("true");
+  });
+
+  test("updates when the OS setting changes", () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<Harness />);
+
+    act(() => {
+      currentMatches = true;
+      changeListener?.();
+    });
+
+    expect(getByTestId("probe").getAttribute("data-reduced")).toBe("true");
+  });
+
+  test("assumes motion is allowed when rendered without matchMedia (SSR)", () => {
+    const html = renderToString(<Harness />);
+
+    expect(html).not.toContain("data-reduced");
+  });
+});

--- a/src/components/use-prefers-reduced-motion.ts
+++ b/src/components/use-prefers-reduced-motion.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(onChange: () => void) {
+  const query = window.matchMedia(QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+// Tracks the OS "reduce motion" setting as a live boolean. Server has no
+// matchMedia, so the SSR snapshot assumes motion is allowed; the store corrects
+// it on hydration if the user prefers reduced motion.
+export function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}


### PR DESCRIPTION
## What

Keyboard and screen-reader users could only reach a country through the spin gesture. This adds a labeled, keyboard-first country selector and honors `prefers-reduced-motion`, completing the accessibility floor for the globe-as-output model (ADR-0011).

## Changes

- **Reduced-motion hook** — extracted `usePrefersReducedMotion` (`useSyncExternalStore`) out of `use-overflow-marquee` into a shared hook; the marquee now consumes it.
- **Globe follows `?cc=`** — `SpinSnapControls` gains a reactive `targetCode` effect, so selecting a country anywhere drives the globe like a gesture. `settleTo` forks on reduced motion: an instant cut (snap to the spring's end state) vs the snap spring. Every selection path (gesture, tap, list, shared link) funnels through `settleTo`, so the cut applies regardless of which control made the selection.
- **Country selector** — `<nav aria-label="Countries">` disclosure: a flag+name toggle (`aria-expanded` / `aria-controls`), 63 named country buttons that write `?cc=` via `replaceState`, stay-open after select (cheap to dismiss, good for exploration), Esc returns focus to the toggle, outside-tap closes, and an `aria-live` "Now showing X" announcement. Mounted in `layout.tsx` under `Suspense`.

## AC coverage (#131)

| AC | Evidence |
|----|----------|
| 1 — keyboard selects via `?cc=` | selector buttons + `replaceState`; unit + live-app verified |
| 2 — SR reaches named controls | `<nav>` landmark + 63 named buttons; unit + live |
| 3 — reduced-motion = instant cut | `settleTo` fork; logic unit-tested |
| 4 — cut regardless of control | single `settleTo` chokepoint |

## Tests

- New: `use-prefers-reduced-motion.test.tsx` (4), `country-selector.test.tsx` (5).
- Full matrix green locally: typecheck, lint, 387 tests, `build` (no CSR bailout — `useSearchParams` is under `Suspense`).
- Drove the running app headless with real clicks: toggle reflects `?cc=`, opens the 63-country list, France select → `?cc=fr` + toggle relabel + chart swap + list stays open, reduced-motion select does not crash.

## Device-test before merge (needs a GPU — headless can't render the globe)

- [ ] Globe rotates to the picked country (list + gesture)
- [ ] Reduced-motion ON → instant cut, no arc
- [ ] Flag emoji + long names render on a phone

## Not in this PR

Selection → autoplay is a separate next slice (all paths, fire only when nothing is already playing, with an ADR-0011 addendum).

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a country selector dropdown that syncs with the `cc` query parameter and supports grouped, alphabetized country navigation.

* **Improvements**
  * Globe motion (spin/settling and overflow marquee) now respects the user’s system “reduced motion” preference.

* **Tests**
  * Added coverage for the country selector interactions/accessibility and for reduced-motion detection behavior (including SSR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->