### PR TITLE
feat(globe): wobble-robust tap-vs-spin + landing haptic

### DIFF
--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -150,7 +150,15 @@ export function GlobeScene() {
       dpr={[1, 2]}
       gl={{ antialias: true }}
       onCreated={() => setReady(true)}
-      style={{ touchAction: "none" }}
+      // touchAction stops scroll/zoom hijacking the drag; the user-select and
+      // touch-callout resets stop a long press from raising iOS Safari's text
+      // selection / callout over the canvas mid-gesture.
+      style={{
+        touchAction: "none",
+        userSelect: "none",
+        WebkitUserSelect: "none",
+        WebkitTouchCallout: "none",
+      }}
       className={`transition-opacity duration-700 ease-out ${
         ready ? "opacity-100" : "opacity-0"
       }`}

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -15,6 +15,7 @@ import { cameraForViewport } from "./camera-fit";
 import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
+import { triggerLandingHaptic } from "./landing-haptic";
 import { addVisited } from "./spin-select";
 import { SpinSnapControls } from "./spin-snap-controls";
 import { StarBackdrop } from "./star-backdrop";
@@ -73,9 +74,10 @@ function SceneContent() {
     () => new Set([initialCode]),
   );
 
-  // A landing is a selection: write ?cc= (replaceState, so rapid flinging
-  // doesn't flood history) and record the country as visited.
+  // A landing is a selection: buzz (where supported), write ?cc= (replaceState,
+  // so rapid flinging doesn't flood history), and record the country as visited.
   const handleSettle = useCallback((code: string) => {
+    triggerLandingHaptic();
     window.history.replaceState(null, "", `?cc=${code}`);
     setVisited((prev) => addVisited(prev, code));
   }, []);

--- a/src/components/globe/landing-haptic.test.ts
+++ b/src/components/globe/landing-haptic.test.ts
@@ -1,0 +1,23 @@
+import { expect, test, vi } from "vitest";
+
+import { triggerLandingHaptic } from "./landing-haptic";
+
+test("triggerLandingHaptic buzzes once on a device that supports vibration", () => {
+  const vibrate = vi.fn(() => true);
+  const nav = { vibrate } as unknown as Navigator;
+
+  triggerLandingHaptic(nav);
+
+  expect(vibrate).toHaveBeenCalledTimes(1);
+  expect(vibrate).toHaveBeenCalledWith(expect.any(Number));
+});
+
+test("triggerLandingHaptic is a no-op when the Vibration API is absent", () => {
+  const nav = {} as Navigator;
+
+  expect(() => triggerLandingHaptic(nav)).not.toThrow();
+});
+
+test("triggerLandingHaptic is a no-op with no navigator (server render)", () => {
+  expect(() => triggerLandingHaptic(undefined)).not.toThrow();
+});

--- a/src/components/globe/landing-haptic.ts
+++ b/src/components/globe/landing-haptic.ts
@@ -1,0 +1,23 @@
+// Fires a short tactile pulse when the globe lands on a country. Progressive
+// enhancement: only devices that expose the Vibration API (Android Chrome) buzz;
+// where it is absent (iOS Safari, desktop) this is a silent no-op and the visual
+// settle remains the primary landing signal. The vibration motor needs a recent
+// user gesture, so a tap or fling buzzes but a programmatic settle on load does
+// not — which is the behaviour we want.
+const LANDING_PULSE_MS = 10;
+
+type Vibrator = { vibrate: (pattern: number | number[]) => boolean };
+
+const supportsVibration = (
+  nav: Navigator | undefined,
+): nav is Navigator & Vibrator =>
+  typeof nav !== "undefined" && typeof nav.vibrate === "function";
+
+export function triggerLandingHaptic(
+  nav: Navigator | undefined = typeof navigator === "undefined"
+    ? undefined
+    : navigator,
+): void {
+  if (!supportsVibration(nav)) return;
+  nav.vibrate(LANDING_PULSE_MS);
+}

--- a/src/components/globe/spin-select.test.ts
+++ b/src/components/globe/spin-select.test.ts
@@ -75,11 +75,18 @@ test("pickNearestToPoint returns the candidate closest to the tap point", () => 
     screenAt(far, 500, 100),
   ];
 
-  expect(pickNearestToPoint(candidates, 290, 310)).toBe(mid.code);
+  expect(pickNearestToPoint(candidates, 290, 310, 44)).toBe(mid.code);
+});
+
+test("pickNearestToPoint returns null when the nearest pin is beyond maxPx", () => {
+  const [only] = COUNTRIES;
+  const candidates = [screenAt(only, 100, 100)];
+
+  expect(pickNearestToPoint(candidates, 200, 100, 44)).toBeNull();
 });
 
 test("pickNearestToPoint returns null when no candidates are given", () => {
-  expect(pickNearestToPoint([], 0, 0)).toBeNull();
+  expect(pickNearestToPoint([], 0, 0, 44)).toBeNull();
 });
 
 test("nearestPool ranks the country under the rest direction first", () => {

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -42,11 +42,14 @@ export function projectFrontCountries(
   return result;
 }
 
-// Tap target: the front-facing country whose pin is nearest the tap point.
+// Tap target: the front-facing country whose pin is nearest the tap point, or
+// null when even the nearest pin is farther than `maxPx` (a tap on open ocean
+// selects nothing). `bestDist` is a squared pixel distance.
 export function pickNearestToPoint(
   candidates: readonly ScreenCountry[],
   px: number,
   py: number,
+  maxPx: number,
 ): string | null {
   let best: string | null = null;
   let bestDist = Infinity;
@@ -57,7 +60,9 @@ export function pickNearestToPoint(
       best = c.country.code;
     }
   }
-  return best;
+  // Near enough → that country; beyond the radius → nothing. Comparison stays
+  // in squared space (bestDist is squared) to skip a sqrt.
+  return bestDist <= maxPx ** 2 ? best : null;
 }
 
 // Country codes ranked by how closely they face the rest direction (el, az in

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -11,6 +11,7 @@ import {
   pickSnapCountry,
   projectFrontCountries,
 } from "./spin-select";
+import { isTap } from "./tap-detect";
 
 const DEG = Math.PI / 180;
 const RADIUS = 3.5;
@@ -162,12 +163,15 @@ export function SpinSnapControls({
     const el = gl.domElement;
 
     // Gesture tracking held on one mutable object (not reassigned render-scope
-    // locals): pointer position, release velocity, drag distance, drag state.
+    // locals): press-down point, last pointer position, release velocity, drag
+    // state. The down point anchors tap-vs-spin: we compare it to the release
+    // point, so a jitter that returns near the start stays a tap.
     const g = {
+      downX: 0,
+      downY: 0,
       lastX: 0,
       lastY: 0,
       lastT: 0,
-      moved: 0,
       vx: 0,
       vy: 0,
       dragging: false,
@@ -179,10 +183,11 @@ export function SpinSnapControls({
       s.vAz = 0;
       s.vEl = 0;
       g.dragging = true;
+      g.downX = e.clientX;
+      g.downY = e.clientY;
       g.lastX = e.clientX;
       g.lastY = e.clientY;
       g.lastT = e.timeStamp;
-      g.moved = 0;
       g.vx = 0;
       g.vy = 0;
       el.setPointerCapture?.(e.pointerId);
@@ -202,7 +207,6 @@ export function SpinSnapControls({
       }
       g.vx = dx / dt;
       g.vy = dy / dt;
-      g.moved += Math.hypot(dx, dy);
       g.lastX = e.clientX;
       g.lastY = e.clientY;
       g.lastT = e.timeStamp;
@@ -214,7 +218,13 @@ export function SpinSnapControls({
       el.releasePointerCapture?.(e.pointerId);
       const s = sim.current;
 
-      if (g.moved < TAP_MAX_PX) {
+      if (
+        isTap(
+          { x: g.downX, y: g.downY },
+          { x: e.clientX, y: e.clientY },
+          TAP_MAX_PX,
+        )
+      ) {
         const rect = el.getBoundingClientRect();
         const candidates = projectFrontCountries(
           camera,

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -19,7 +19,8 @@ const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slid
 const EL_LIMIT = 75 * DEG; // stop short of the poles so the view never flips
 const SETTLE_VEL = 0.6; // rad/s under which a fling hands off to the snap spring
 const SNAP_OMEGA = 10; // snap spring frequency: higher settles faster
-const TAP_MAX_PX = 8;
+const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
+const TAP_HIT_PX = 44; // a tap beyond this from every country pin selects nothing
 
 const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
 
@@ -231,13 +232,15 @@ export function SpinSnapControls({
           rect.width,
           rect.height,
         );
-        settleTo(
-          pickNearestToPoint(
-            candidates,
-            e.clientX - rect.left,
-            e.clientY - rect.top,
-          ),
+        const hit = pickNearestToPoint(
+          candidates,
+          e.clientX - rect.left,
+          e.clientY - rect.top,
+          TAP_HIT_PX,
         );
+        // A tap that lands on no country re-centres the current one, so a
+        // mis-aim on open ocean does nothing rather than jumping away.
+        settleTo(hit ?? s.settledCode);
         return;
       }
 

--- a/src/components/globe/tap-detect.test.ts
+++ b/src/components/globe/tap-detect.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+
+import { isTap } from "./tap-detect";
+
+const MAX = 8;
+
+test("isTap treats a still release at the press point as a tap", () => {
+  expect(isTap({ x: 100, y: 100 }, { x: 100, y: 100 }, MAX)).toBe(true);
+});
+
+test("isTap treats a small wobble within the tolerance as a tap", () => {
+  expect(isTap({ x: 100, y: 100 }, { x: 104, y: 103 }, MAX)).toBe(true);
+});
+
+test("isTap treats a release beyond the tolerance as a spin", () => {
+  expect(isTap({ x: 100, y: 100 }, { x: 100, y: 140 }, MAX)).toBe(false);
+});
+
+test("isTap measures straight-line distance, not per-axis", () => {
+  expect(isTap({ x: 100, y: 100 }, { x: 106, y: 106 }, MAX)).toBe(false);
+});

--- a/src/components/globe/tap-detect.ts
+++ b/src/components/globe/tap-detect.ts
@@ -1,0 +1,16 @@
+// Decides whether a pointer gesture was a tap (select the country under the
+// finger) or the start of a spin. The controller compares the press-down point
+// to the release point rather than summing every move in between, so a finger
+// that jitters while held still and lifts near where it landed is read as a tap,
+// not a spin. `maxPx` is the wobble tolerance, tuned on real hardware.
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export function isTap(start: Point, end: Point, maxPx: number): boolean {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+
+  return Math.hypot(dx, dy) <= maxPx;
+}


### PR DESCRIPTION
Closes #132

## Why

The tap-vs-spin split was measured by summing the whole drag path (`g.moved += hypot(dx,dy)`), so a finger that jittered while held in place could accumulate past the 8px threshold and turn an intended tap into a spin. This switches the test to **net displacement from the press-down point** — where the finger ended relative to where it started — so a tremor that returns near the origin still reads as a tap. Adds a landing haptic as progressive enhancement: a short `navigator.vibrate` on the country a gesture settles on.

## What changed

- **`tap-detect.ts`** — pure `isTap(start, end, maxPx)`: straight-line distance vs an 8px tolerance. Replaces accumulated-path tap detection; the controller now anchors on `g.downX/downY` and compares to the release point.
- **`landing-haptic.ts`** — `triggerLandingHaptic()`: feature-detected `navigator.vibrate(10)`. Android buzzes; iOS Safari and desktop are a silent no-op (the vibration motor also needs a recent user gesture, so a tap/fling buzzes but a programmatic settle on load does not). Injectable `nav` for testing.
- **`globe-scene.tsx`** — fires the haptic once from `handleSettle`, the single landing chokepoint (alongside the `?cc=` write).
- **Tap hit-radius (device-test follow-up)** — `pickNearestToPoint` gained a `maxPx` radius and the controller passes `TAP_HIT_PX = 44`. A tap snapped to the nearest country pin no matter how far, so tapping open ocean teleported to the closest country. Now a tap within range of a pin selects it; a tap beyond every pin re-centres the current country, so a mis-aim does nothing.
- All new modules are pure/injectable and unit-tested.

## Test plan

Local CI matrix green: `format:check` · `lint` · `typecheck` · `test:ci` (398) · `build`.

This is a HITL slice — the ACs are device-gated and can't be proven in CI:

- [ ] **AC1** Tap vs spin disambiguated by a movement threshold, verified on a real touch device.
- [ ] **AC2** A tap with minor finger wobble still registers as a tap, not a spin.
- [ ] **AC3** Landing fires `navigator.vibrate` on a supporting device (Android).
- [ ] **AC4** On iOS (no vibrate), landing still reads clearly via the visual settle.

Tuning knobs if the feel is off on hardware: `TAP_MAX_PX` (8px, tap-vs-spin drift), `TAP_HIT_PX` (44px, tap hit-radius / how wide "ocean" is), `LANDING_PULSE_MS` (10ms).

Rationale: ADR-0011.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added landing haptic feedback when a globe country selection settles.
* **Bug Fixes**
  * Improved tap gesture handling with more accurate tap detection and a distance threshold for selecting the nearest country.
  * When a tap is too far, the globe now re-settles instead of selecting an unintended country.
* **Tests**
  * Added/updated unit tests covering landing haptics, tap detection, and nearest-country selection within a pixel radius.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->