### PR TITLE
feat(globe): raise the chart on landing, freeze the globe while reading

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { CHARTS, CODE_BR, CODE_US, COUNTRY_US } from "@/lib/__fixtures__";
+import { uiModeStore } from "@/lib/ui-mode-store";
 
 const mockSearchParams = vi.hoisted(() => ({
   value: new URLSearchParams(),
@@ -59,5 +60,76 @@ describe("ChartScreen", () => {
 
     expect(screen.getByText(COUNTRY_US.tracks[0].name)).toBeDefined();
     expect(replaceState).toHaveBeenCalledWith(null, "", `?cc=${CODE_US}`);
+  });
+});
+
+describe("ChartScreen globe coupling", () => {
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams(`cc=${CODE_US}`);
+    uiModeStore.setState({ readMode: false, settleSignal: 0 });
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("publishes read mode to the globe at full and clears it back at peek", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+
+    expect(uiModeStore.getState().readMode).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand chart" }));
+    expect(uiModeStore.getState().readMode).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse chart" }));
+    expect(uiModeStore.getState().readMode).toBe(false);
+  });
+
+  test("a settle raises a dismissed sheet back to peek", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+    const sheet = screen.getByTestId("chart-sheet");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(sheet.dataset.snap).toBe("closed");
+
+    act(() => {
+      uiModeStore.getState().signalSettle();
+    });
+    expect(sheet.dataset.snap).toBe("peek");
+  });
+
+  test("a settle leaves an open sheet where it is", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+    const sheet = screen.getByTestId("chart-sheet");
+
+    expect(sheet.dataset.snap).toBe("peek");
+    act(() => {
+      uiModeStore.getState().signalSettle();
+    });
+    expect(sheet.dataset.snap).toBe("peek");
+  });
+
+  test("releases read mode when the chart unmounts", () => {
+    const { unmount } = render(
+      <ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Expand chart" }));
+    expect(uiModeStore.getState().readMode).toBe(true);
+
+    unmount();
+    expect(uiModeStore.getState().readMode).toBe(false);
+  });
+
+  test("a settle never starts audio on its own", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+
+    act(() => {
+      uiModeStore.getState().signalSettle();
+    });
+
+    // The mini player only mounts once a track plays; its absence after a settle
+    // shows the landing selected a country without starting audio.
+    expect(screen.queryByRole("button", { name: "Reopen chart" })).toBeNull();
   });
 });

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
 import { MiniPlayer } from "@/components/mini-player";
 import type { ChartFile, Country } from "@/lib/chart-schema";
+import { uiModeStore, useUiMode } from "@/lib/ui-mode-store";
 import {
   AudioStoreProvider,
   useAudioStore,
@@ -63,6 +64,7 @@ function ChartScreenInner({
 }) {
   const [snap, setSnap] = useState<SnapState>("peek");
   const [scrollSignal, setScrollSignal] = useState(0);
+  const settleSignal = useUiMode((s) => s.settleSignal);
   const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
   const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
   const endedSignal = useAudioStore((s) => s.endedSignal);
@@ -125,6 +127,28 @@ function ChartScreenInner({
     window.addEventListener("pointerdown", handler, { once: true });
     return () => window.removeEventListener("pointerdown", handler);
   }, [snap]);
+
+  // full = read mode: tell the globe to suspend its spin so a leftover fling
+  // can't settle a new country while the chart covers it.
+  useEffect(() => {
+    uiModeStore.getState().setReadMode(snap === "full");
+  }, [snap]);
+
+  // Release read mode if the chart unmounts (e.g. a route change) while at full,
+  // so the globe in the layout isn't left suspended with no sheet over it.
+  useEffect(() => {
+    return () => uiModeStore.getState().setReadMode(false);
+  }, []);
+
+  // A globe landing resurfaces the result: raise a dismissed sheet to peek.
+  // Ref-gated so only an actual settle (a bumped signal) triggers it, never a
+  // dep-only re-run, and so the mount value never force-raises.
+  const prevSettleRef = useRef(settleSignal);
+  useEffect(() => {
+    if (settleSignal === prevSettleRef.current) return;
+    prevSettleRef.current = settleSignal;
+    setSnap((s) => (s === "hidden" || s === "closed" ? "peek" : s));
+  }, [settleSignal]);
 
   const handleMiniTap = useCallback(() => {
     const source = audioStore.getState().currentCountryCode;

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -8,6 +8,7 @@ import { PerspectiveCamera } from "three";
 import { COUNTRIES } from "@/lib/countries";
 import { validateCountryCode } from "@/lib/country-code";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
+import { uiModeStore, useUiMode } from "@/lib/ui-mode-store";
 
 import { usePrefersReducedMotion } from "../use-prefers-reduced-motion";
 
@@ -58,6 +59,7 @@ function SceneContent() {
   const searchParams = useSearchParams();
   const selectedCode = validateCountryCode(searchParams.get("cc"));
   const reducedMotion = usePrefersReducedMotion();
+  const readMode = useUiMode((s) => s.readMode);
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
@@ -74,12 +76,14 @@ function SceneContent() {
     () => new Set([initialCode]),
   );
 
-  // A landing is a selection: buzz (where supported), write ?cc= (replaceState,
-  // so rapid flinging doesn't flood history), and record the country as visited.
+  // A landing is a selection: buzz where supported, write ?cc= (replaceState,
+  // so rapid flinging doesn't flood history), record the country as visited,
+  // and signal the chart tree so a dismissed sheet resurfaces the result.
   const handleSettle = useCallback((code: string) => {
     triggerLandingHaptic();
     window.history.replaceState(null, "", `?cc=${code}`);
     setVisited((prev) => addVisited(prev, code));
+    uiModeStore.getState().signalSettle();
   }, []);
 
   return (
@@ -117,6 +121,7 @@ function SceneContent() {
         horizontalLock={SPIN_HORIZONTAL_LOCK}
         fair={SPIN_FAIR}
         visited={visited}
+        readMode={readMode}
         onSettle={handleSettle}
       />
     </>

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -45,6 +45,7 @@ interface SpinSnapControlsProps {
   bounce: number;
   fair: boolean;
   visited: ReadonlySet<string>;
+  readMode: boolean;
   onSettle: (code: string) => void;
 }
 
@@ -62,6 +63,7 @@ export function SpinSnapControls({
   bounce,
   fair,
   visited,
+  readMode,
   onSettle,
 }: SpinSnapControlsProps) {
   const camera = useThree((s) => s.camera);
@@ -75,6 +77,7 @@ export function SpinSnapControls({
     fair,
     visited,
     reducedMotion,
+    readMode,
   });
   const onSettleRef = useRef(onSettle);
 
@@ -89,6 +92,7 @@ export function SpinSnapControls({
       fair,
       visited,
       reducedMotion,
+      readMode,
     };
     onSettleRef.current = onSettle;
   });
@@ -179,6 +183,8 @@ export function SpinSnapControls({
     };
 
     const onDown = (e: PointerEvent) => {
+      // Read mode covers the globe; ignore presses so reading never grabs it.
+      if (cfg.current.readMode) return;
       const s = sim.current;
       s.mode = "drag";
       s.vAz = 0;
@@ -277,6 +283,24 @@ export function SpinSnapControls({
 
   useFrame((_, dt) => {
     const s = sim.current;
+
+    // Read mode (sheet at full) hides the globe. Suspend the sim so a leftover
+    // fling can't drift and settle a new country under the reader. Park an
+    // in-flight fling outright (drop its momentum so it doesn't resume on
+    // collapse), but leave a settle in progress alone: a settle is an
+    // intentional landing (a gesture, or an external ?cc= pick from the a11y
+    // selector), so let it resume and land when the sheet collapses. A fling
+    // can't reach settle while reading, so mode === "settle" here is always a
+    // real selection, never stray momentum.
+    if (cfg.current.readMode) {
+      if (s.mode === "fling") {
+        s.vAz = 0;
+        s.vEl = 0;
+        s.mode = "idle";
+      }
+      return;
+    }
+
     if (s.mode === "fling") {
       s.az += s.vAz * dt;
       s.el = clamp(s.el + s.vEl * dt, -EL_LIMIT, EL_LIMIT);

--- a/src/lib/ui-mode-store.test.ts
+++ b/src/lib/ui-mode-store.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { uiModeStore } from "./ui-mode-store";
+
+describe("uiModeStore", () => {
+  beforeEach(() => {
+    uiModeStore.setState({ readMode: false, settleSignal: 0 });
+  });
+
+  test("starts out of read mode with no settle yet", () => {
+    expect(uiModeStore.getState().readMode).toBe(false);
+    expect(uiModeStore.getState().settleSignal).toBe(0);
+  });
+
+  test("setReadMode toggles the flag", () => {
+    uiModeStore.getState().setReadMode(true);
+    expect(uiModeStore.getState().readMode).toBe(true);
+
+    uiModeStore.getState().setReadMode(false);
+    expect(uiModeStore.getState().readMode).toBe(false);
+  });
+
+  test("signalSettle increments so a repeat landing still fires subscribers", () => {
+    uiModeStore.getState().signalSettle();
+    uiModeStore.getState().signalSettle();
+    expect(uiModeStore.getState().settleSignal).toBe(2);
+  });
+});

--- a/src/lib/ui-mode-store.ts
+++ b/src/lib/ui-mode-store.ts
@@ -1,0 +1,32 @@
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+
+// Couples the two independent client trees that the URL can't: the globe
+// (a fixed backdrop in the layout) and the chart sheet (page children). Read
+// mode and "a landing happened" aren't shareable state, so they don't belong
+// in ?cc=. A module singleton, not a provider store, because this is app-global
+// client-only UI state with no request scope — and the globe lives outside the
+// audio provider anyway.
+export interface UiModeState {
+  // The sheet is at full, covering the globe: the controller suspends its spin
+  // so a leftover fling can't settle a new country out from under the reader.
+  readMode: boolean;
+  // Monotonic counter the globe bumps on every settle. The chart diffs it to
+  // raise a dismissed sheet, so re-landing on the same country still raises
+  // (a plain ?cc= diff would miss that).
+  settleSignal: number;
+  setReadMode: (readMode: boolean) => void;
+  signalSettle: () => void;
+}
+
+export const uiModeStore = createStore<UiModeState>()((set) => ({
+  readMode: false,
+  settleSignal: 0,
+  setReadMode: (readMode) => set({ readMode }),
+  signalSettle: () =>
+    set((state) => ({ settleSignal: state.settleSignal + 1 })),
+}));
+
+export function useUiMode<T>(selector: (state: UiModeState) => T): T {
+  return useStore(uiModeStore, selector);
+}


### PR DESCRIPTION
Closes #130

## Why

The globe (a layout backdrop) and the chart sheet (page children) are separate client trees coupled only through `?cc=`, which can't carry sheet posture or the fact that a landing happened. This adds that seam so a landing resurfaces the chart and reading suspends the spin.

## What

- New module-singleton `ui-mode` store (`readMode` + `settleSignal`) as the globe↔chart bus the URL can't be. Consistent with ADR-0003 (zustand); a singleton rather than a provider because it's app-global, client-only UI state with no request scope, and the globe lives outside the audio provider.
- A settle bumps `settleSignal`; the chart raises a dismissed (hidden/closed) sheet back to peek.
- `full` publishes `readMode`; the controller parks an in-flight fling and ignores presses, so a leftover fling can't settle a different country under the reader. A settle already in progress (a gesture landing or an external `?cc=` pick from the a11y selector) is left to resume and land when the sheet collapses.

## Acceptance criteria

- [x] Each settle writes `?cc=` via `replaceState`; the back gesture exits the app
- [x] A shared `?cc=` link still opens on the right country
- [x] On settle, a hidden or closed sheet rises to peek
- [x] Landing never auto-plays audio; the mini player keeps the prior country
- [x] At `full` the globe does not spin; collapsing to `peek` re-enables it
- [x] Drag on the globe spins; drag on the sheet moves the sheet (desktop-verified; on-device touch check still pending)

## Test plan

- `pnpm typecheck`, `lint`, `test`, `build` all green (405 tests).
- New tests: `ui-mode-store` unit; chart integration for read-mode publish at full, settle-raises-a-dismissed-sheet, and no-autoplay-on-settle.
- Desktop mouse walk-through of all six behaviors. The on-device touch confirm of drag-arbitration is still pending (a campus network blocked the tunnel test); the rebase did not touch that arbitration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reading mode for the globe/chart experience, letting the chart stay stable while the content sheet is open.
  * Expanded/collapsed chart actions now keep the chart and globe state in sync.

* **Bug Fixes**
  * Dismissing the chart sheet now returns it to a visible peek state instead of staying hidden.
  * Repeated landing/settling actions now reliably update the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
