### PR TITLE
fix(globe): follow the selected country on load instead of freezing on US

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -66,12 +66,32 @@ describe("ChartScreen", () => {
 describe("ChartScreen globe coupling", () => {
   beforeEach(() => {
     mockSearchParams.value = new URLSearchParams(`cc=${CODE_US}`);
-    uiModeStore.setState({ readMode: false, settleSignal: 0 });
+    uiModeStore.setState({
+      readMode: false,
+      settleSignal: 0,
+      selectedCountry: null,
+    });
     vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  test("publishes the resolved ?cc= country to the globe", () => {
+    mockSearchParams.value = new URLSearchParams(`cc=${CODE_US}`);
+
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+
+    expect(uiModeStore.getState().selectedCountry).toBe(CODE_US);
+  });
+
+  test("publishes the default country to the globe when ?cc= is absent", () => {
+    mockSearchParams.value = new URLSearchParams();
+
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+
+    expect(uiModeStore.getState().selectedCountry).toBe(CODE_BR);
   });
 
   test("publishes read mode to the globe at full and clears it back at peek", () => {

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -35,12 +35,18 @@ export function ChartScreen({ charts, defaultCountryCode }: ChartScreenProps) {
 
   // Write the resolved code into the URL when it isn't already there (bare `/`,
   // an invalid cc, or a non-canonical case). replaceState relabels the URL with
-  // no navigation, so there's no refetch or flicker; Next keeps it in sync with
-  // useSearchParams, so the globe reads the same code.
+  // no navigation, so there's no refetch or flicker.
   useEffect(() => {
     if (rawCc === countryCode) return;
     window.history.replaceState(null, "", `?cc=${countryCode}`);
   }, [rawCc, countryCode]);
+
+  // Publish the resolved country to the globe. The globe is a layout backdrop,
+  // so its own useSearchParams never sees a client-side ?cc= change; this page
+  // child does, and forwards it across the ui-mode seam.
+  useEffect(() => {
+    uiModeStore.getState().setSelectedCountry(countryCode);
+  }, [countryCode]);
 
   return (
     <AudioStoreProvider>

--- a/src/components/country-selector.test.tsx
+++ b/src/components/country-selector.test.tsx
@@ -1,13 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-const mockSearchParams = vi.hoisted(() => ({
-  value: new URLSearchParams(),
-}));
-
-vi.mock("next/navigation", () => ({
-  useSearchParams: () => mockSearchParams.value,
-}));
+import { uiModeStore } from "@/lib/ui-mode-store";
 
 import { CountrySelector } from "./country-selector";
 
@@ -18,13 +12,14 @@ describe("CountrySelector", () => {
   let replaceState: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    mockSearchParams.value = new URLSearchParams("cc=br");
+    uiModeStore.setState({ selectedCountry: "br" });
     replaceState = vi
       .spyOn(window.history, "replaceState")
       .mockImplementation(() => {});
   });
 
   afterEach(() => {
+    uiModeStore.setState({ selectedCountry: null });
     replaceState.mockRestore();
   });
 
@@ -62,12 +57,13 @@ describe("CountrySelector", () => {
     }
   });
 
-  test("selecting a country writes ?cc= via replaceState and announces it", () => {
+  test("selecting a country drives the globe via the store, mirrors ?cc=, and announces it", () => {
     render(<CountrySelector />);
     openList();
 
     fireEvent.click(screen.getByRole("button", { name: "France" }));
 
+    expect(uiModeStore.getState().selectedCountry).toBe("fr");
     expect(replaceState).toHaveBeenCalledWith(null, "", "?cc=fr");
     expect(screen.getByRole("status").textContent).toContain("France");
   });

--- a/src/components/country-selector.tsx
+++ b/src/components/country-selector.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
 
 import { COUNTRIES } from "@/lib/countries";
-import { countryByCode, validateCountryCode } from "@/lib/country-code";
+import { countryByCode } from "@/lib/country-code";
+import { uiModeStore, useUiMode } from "@/lib/ui-mode-store";
 
 // Group the grid by continent, west-to-east so it mirrors the globe's eastward
 // spin; alphabetical within each region.
@@ -35,12 +35,14 @@ function flagEmoji(code: string): string {
 }
 
 // A keyboard- and screen-reader-first way to pick a country, equal to the globe
-// gesture: a labeled landmark of named country buttons that write ?cc=. The
-// globe follows ?cc=, so selecting here drives the globe too. The grid stays
-// open after a pick so you can keep hopping between countries.
+// gesture: a labeled landmark of named country buttons. A pick drives the globe
+// through the ui-mode store; the grid stays open so you can keep hopping.
 export function CountrySelector() {
-  const searchParams = useSearchParams();
-  const currentCode = validateCountryCode(searchParams.get("cc"));
+  // The selected country comes from the store, not useSearchParams: this badge
+  // is a layout backdrop, where that hook is frozen to its first value and
+  // never sees a client-side ?cc= change. The chart publishes the resolved
+  // country to the store; the globe and this badge read it from there.
+  const currentCode = useUiMode((s) => s.selectedCountry);
   const current = currentCode ? countryByCode(currentCode) : null;
 
   const [open, setOpen] = useState(false);
@@ -54,8 +56,10 @@ export function CountrySelector() {
   };
 
   const handleSelect = (code: string, name: string) => {
-    // Same channel the gesture uses: replaceState keeps rapid hops out of
-    // history. Stay open so the grid is still there to keep exploring.
+    // Same channels the gesture uses: the store reaches the layout globe (whose
+    // useSearchParams can't see this), replaceState keeps the shareable URL in
+    // step without flooding history. Stay open so the grid is still there.
+    uiModeStore.getState().setSelectedCountry(code);
     window.history.replaceState(null, "", `?cc=${code}`);
     setAnnouncement(`Now showing ${name}`);
   };

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { Suspense, use, useCallback, useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
 import { Canvas, useThree } from "@react-three/fiber";
 import { PerspectiveCamera } from "three";
 
 import { COUNTRIES } from "@/lib/countries";
-import { validateCountryCode } from "@/lib/country-code";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 import { uiModeStore, useUiMode } from "@/lib/ui-mode-store";
 
@@ -56,8 +54,10 @@ function CountryLayers({
 }
 
 function SceneContent() {
-  const searchParams = useSearchParams();
-  const selectedCode = validateCountryCode(searchParams.get("cc"));
+  // Not useSearchParams: the globe is a layout backdrop, where that hook is
+  // frozen to its first value and never sees a client-side ?cc= change. The
+  // chart (a page child) resolves cc and publishes it here.
+  const selectedCode = useUiMode((s) => s.selectedCountry);
   const reducedMotion = usePrefersReducedMotion();
   const readMode = useUiMode((s) => s.readMode);
 
@@ -81,6 +81,7 @@ function SceneContent() {
   // and signal the chart tree so a dismissed sheet resurfaces the result.
   const handleSettle = useCallback((code: string) => {
     triggerLandingHaptic();
+    uiModeStore.getState().setSelectedCountry(code);
     window.history.replaceState(null, "", `?cc=${code}`);
     setVisited((prev) => addVisited(prev, code));
     uiModeStore.getState().signalSettle();

--- a/src/lib/ui-mode-store.ts
+++ b/src/lib/ui-mode-store.ts
@@ -8,6 +8,12 @@ import { createStore } from "zustand/vanilla";
 // client-only UI state with no request scope — and the globe lives outside the
 // audio provider anyway.
 export interface UiModeState {
+  // The resolved country the globe centers on. The URL ?cc= is the shareable
+  // mirror, but a layout component's useSearchParams is frozen to its first
+  // value (it never re-renders on a client-side replaceState), so the globe
+  // can't read the URL back. The chart, a page child, resolves cc (?cc= or the
+  // default) and publishes it here; the globe reads it across the layout seam.
+  selectedCountry: string | null;
   // The sheet is at full, covering the globe: the controller suspends its spin
   // so a leftover fling can't settle a new country out from under the reader.
   readMode: boolean;
@@ -15,13 +21,16 @@ export interface UiModeState {
   // raise a dismissed sheet, so re-landing on the same country still raises
   // (a plain ?cc= diff would miss that).
   settleSignal: number;
+  setSelectedCountry: (code: string | null) => void;
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
 }
 
 export const uiModeStore = createStore<UiModeState>()((set) => ({
+  selectedCountry: null,
   readMode: false,
   settleSignal: 0,
+  setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),
   signalSettle: () =>
     set((state) => ({ settleSignal: state.settleSignal + 1 })),


### PR DESCRIPTION
## What
On load the globe centers on the selected country (?cc= or the page default)
instead of sitting on a hardcoded "us". The keyboard/screen-reader selector
badge and the globe stay in sync, and picking from the badge drives the globe.

## Why
The globe is a fixed backdrop mounted in `layout.tsx`. A client component there
reads `useSearchParams()` once and never re-renders on a client-side `?cc=`
change, so the globe never saw the chart's resolved country and fell back to its
hardcoded `FALLBACK_CODE = "us"`. The chart (a page child) resolves `cc`
correctly, so the two disagreed.

Latent since the globe moved into the layout (#73); the old OrbitControls
autorotate masked it (the globe looked alive at `/`), and #138 removed the
autorotate, exposing the freeze on the US.

## How
Route the selected country through the existing `ui-mode` store that already
couples the layout globe to the page chart for read-mode and settle signals:
the chart publishes its resolved country code, the globe and the selector badge
subscribe to it (instead of `useSearchParams`), the globe settle and a selector
pick write it directly, and `?cc=` stays as the shareable URL mirror.

## Test plan
- typecheck / lint / unit (408, +2 regression) / production build — all pass.
- macOS Chrome: bare `/` lands globe + badge on the default; `/?cc=ar` lands on
  Argentina; selecting from the badge drives the globe.

Closes #147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Country selection now stays in sync across the chart, globe, and selector views.
  * Selecting a country updates the app’s shared selection state, keeping the highlighted country consistent.

* **Bug Fixes**
  * Improved handling of the `?cc=` country parameter so the chosen country is correctly reflected when the page loads.
  * Restored consistent selection behavior when no country parameter is present, using the default country.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->