### PR TITLE
chore: release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps the version to 2.0.0, marking the globe-as-output Version (gesture spin + snap-select, a11y selector, touch-feel polish, badge recede). Per ADR-0005 a Version is a major bump.

The full v2.0.0 changelog ships as the GitHub Release on the `v2.0.0` tag after this merges; this PR is just the manifest bump.