### PR TITLE
feat(globe): snap to a country faster after a fling

### DIFF
--- a/docs/adr/0011-globe-as-output-gesture-model.md
+++ b/docs/adr/0011-globe-as-output-gesture-model.md
@@ -53,7 +53,7 @@ The `?cc=` contract means any control that writes it is a complete, equal select
 
 ### Feel values
 
-The model's tuned constants — sensitivity 1.4, friction 2.5, bounce 0.6, 2D spin, fairness on — ship as **named constants**, not a user setting and not a retained dev panel. The spike's sliders were a tool for finding the values, not a product feature. Re-tuning, if ever needed, reruns the preserved spike branch.
+The model's tuned constants — sensitivity 1.4, friction 2.5, bounce 0.45, a quick settle (a fling hands off to the snap spring at 2 rad/s, spring frequency 17), 2D spin, fairness on — ship as **named constants**, not a user setting and not a retained dev panel. The spike's sliders were a tool for finding the values, not a product feature. Re-tuning, if ever needed, reruns the preserved spike branch.
 
 ### Scope
 

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -24,7 +24,7 @@ const ISO_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c.isoNum]));
 // Locked feel values from the gesture spike (ADR-0011). Named, not tunable.
 const SPIN_SENSITIVITY = 1.4;
 const SPIN_FRICTION = 2.5;
-const SPIN_BOUNCE = 0.6;
+const SPIN_BOUNCE = 0.45;
 const SPIN_HORIZONTAL_LOCK = false;
 const SPIN_FAIR = true;
 const FALLBACK_CODE = "us";

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -17,8 +17,8 @@ const DEG = Math.PI / 180;
 const RADIUS = 3.5;
 const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slider
 const EL_LIMIT = 75 * DEG; // stop short of the poles so the view never flips
-const SETTLE_VEL = 0.6; // rad/s under which a fling hands off to the snap spring
-const SNAP_OMEGA = 10; // snap spring frequency: higher settles faster
+const SETTLE_VEL = 2; // rad/s under which a fling hands off to the snap spring
+const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
 const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
 const TAP_HIT_PX = 44; // a tap beyond this from every country pin selects nothing
 


### PR DESCRIPTION
Live globe felt slow to settle after a fling. Selection only fired once the spin decayed to 0.6 rad/s, so the inertial tail dragged before a country was chosen.

Hand off to the snap spring at 2 rad/s and raise the spring frequency to 17 so the selection fires sooner and lands tighter; soften bounce to 0.45. Friction stays 2.5 to keep the real-globe momentum.

**Before → after (Coast)**
- `SETTLE_VEL` 0.6 → 2
- `SNAP_OMEGA` 10 → 17
- `SPIN_BOUNCE` 0.6 → 0.45
- `SPIN_FRICTION` 2.5 (unchanged)

ADR-0011 feel-values note updated to match.

**Test plan**
- typecheck / lint / test (410) / build all pass locally
- Feel confirmed against a 1:1 port of the prod settle physics, comparing the old values vs the new by flick-and-release latency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the globe’s spin and snap behavior for a smoother, more responsive feel.
  * Reduced bounce in globe interactions and tuned the settling motion so spins land more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->