### PR TITLE
feat(globe): settle on the nearest coast instead of lurching across open water

### DIFF
--- a/src/components/globe/spin-select.test.ts
+++ b/src/components/globe/spin-select.test.ts
@@ -6,10 +6,10 @@ import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
 
 import {
   addVisited,
-  nearestPool,
   pickNearestToPoint,
   pickSnapCountry,
   projectFrontCountries,
+  rankNearest,
   weightedDraw,
 } from "./spin-select";
 
@@ -89,17 +89,17 @@ test("pickNearestToPoint returns null when no candidates are given", () => {
   expect(pickNearestToPoint([], 0, 0, 44)).toBeNull();
 });
 
-test("nearestPool ranks the country under the rest direction first", () => {
+test("rankNearest ranks the country under the rest direction first", () => {
   const target = COUNTRIES[0];
 
-  const pool = nearestPool(target.lat * DEG, target.lon * DEG, 10);
+  const pool = rankNearest(target.lat * DEG, target.lon * DEG, 10);
 
-  expect(pool[0]).toBe(target.code);
+  expect(pool[0].code).toBe(target.code);
 });
 
-test("nearestPool caps the pool at n", () => {
-  expect(nearestPool(0, 0, 10)).toHaveLength(10);
-  expect(nearestPool(0, 0, 5)).toHaveLength(5);
+test("rankNearest caps the pool at n", () => {
+  expect(rankNearest(0, 0, 10)).toHaveLength(10);
+  expect(rankNearest(0, 0, 5)).toHaveLength(5);
 });
 
 test("weightedDraw overwhelmingly prefers an unvisited country in the pool", () => {
@@ -141,18 +141,33 @@ test("pickSnapCountry returns a country from the nearest pool when fairness is o
 
   const result = pickSnapCountry(el, az, new Set(), true);
 
-  expect(nearestPool(el, az, 10)).toContain(result);
+  expect(rankNearest(el, az, 10).map((e) => e.code)).toContain(result);
 });
 
 test("pickSnapCountry fair draw is deterministic under an injected rng", () => {
-  const target = COUNTRIES[0];
+  // A dense region (the European cluster) keeps the whole pool inside the
+  // fairness radius, so the injected draw maps linearly across all of it.
+  const target = COUNTRIES.find((c) => c.code === "de")!;
   const el = target.lat * DEG;
   const az = target.lon * DEG;
-  const pool = nearestPool(el, az, 10);
+  const pool = rankNearest(el, az, 10).map((e) => e.code);
 
   // No visits → uniform weights, so r maps linearly across the pool.
   expect(pickSnapCountry(el, az, new Set(), true, () => 0)).toBe(pool[0]);
   expect(pickSnapCountry(el, az, new Set(), true, () => 0.95)).toBe(pool[9]);
+});
+
+test("over open water the fair snap holds the nearest country, never a far shore", () => {
+  // A mid-ocean rest point: every country is well beyond the fairness radius,
+  // so the pool straddles both coasts. The draw must collapse to the single
+  // nearest rather than randomly lurching across to the far shore.
+  const el = 10 * DEG;
+  const az = -150 * DEG;
+  const nearest = rankNearest(el, az, 10)[0].code;
+
+  for (let r = 0; r < 1; r += 0.1) {
+    expect(pickSnapCountry(el, az, new Set(), true, () => r)).toBe(nearest);
+  }
 });
 
 test("every country appears in some nearest pool over the reachable sphere", () => {
@@ -163,8 +178,8 @@ test("every country appears in some nearest pool over the reachable sphere", () 
 
   for (let el = -EL_LIMIT; el <= EL_LIMIT; el += STEP) {
     for (let az = -Math.PI; az < Math.PI; az += STEP) {
-      for (const code of nearestPool(el, az, POOL_SIZE)) {
-        reached.add(code);
+      for (const entry of rankNearest(el, az, POOL_SIZE)) {
+        reached.add(entry.code);
       }
     }
   }

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -65,10 +65,18 @@ export function pickNearestToPoint(
   return bestDist <= maxPx ** 2 ? best : null;
 }
 
-// Country codes ranked by how closely they face the rest direction (el, az in
-// radians), nearest first, capped at `n`. This is the fling's candidate pool:
-// geography narrows the choice to a neighbourhood before fairness picks within it.
-export function nearestPool(el: number, az: number, n: number): string[] {
+export interface PoolEntry {
+  code: string;
+  // Angular distance (radians) from the rest direction; 0 means dead centre.
+  angle: number;
+}
+
+// Countries ranked by how closely they face the rest direction (el, az in
+// radians), nearest first, capped at `n`, each tagged with its angular
+// distance. This is the fling's candidate pool: geography narrows the choice
+// to a neighbourhood, and the distance lets fairness pick only within a genuine
+// cluster instead of across open water.
+export function rankNearest(el: number, az: number, n: number): PoolEntry[] {
   const cx = Math.cos(el) * Math.sin(az);
   const cy = Math.sin(el);
   const cz = Math.cos(el) * Math.cos(az);
@@ -79,11 +87,11 @@ export function nearestPool(el: number, az: number, n: number): string[] {
       Math.cos(lat) * Math.sin(lon) * cx +
       Math.sin(lat) * cy +
       Math.cos(lat) * Math.cos(lon) * cz;
-    return { code: c.code, dot };
+    // dot is cos(angle) for unit vectors; clamp guards acos against fp drift.
+    return { code: c.code, angle: Math.acos(Math.min(1, Math.max(-1, dot))) };
   })
-    .sort((a, b) => b.dot - a.dot)
-    .slice(0, n)
-    .map((entry) => entry.code);
+    .sort((a, b) => a.angle - b.angle)
+    .slice(0, n);
 }
 
 const VISITED_WEIGHT = 0.08; // how strongly an already-seen country is avoided
@@ -120,6 +128,11 @@ export function addVisited(
 }
 
 const SNAP_POOL = 10; // candidate countries near the rest point for a fair snap
+// Past this angle (radians) from the rest direction a country is across open
+// water, not a near neighbour. Beyond it fairness has no genuine cluster to
+// randomise over, so the snap takes the single nearest and never lurches across
+// an ocean to the far shore.
+const SNAP_NEAR = 18 * DEG;
 
 // Fling target. Fairness off: the literal nearest country to the rest direction.
 // Fairness on: a deck-weighted draw from the nearest pool, so a small country
@@ -132,7 +145,18 @@ export function pickSnapCountry(
   fair: boolean,
   rng: () => number = Math.random,
 ): string {
-  const pool = nearestPool(el, az, SNAP_POOL);
-  if (!fair) return pool[0];
-  return weightedDraw(pool, visited, rng());
+  const ranked = rankNearest(el, az, SNAP_POOL);
+  if (!fair) return ranked[0].code;
+
+  // Fairness only randomises within a genuine neighbourhood. Over open water
+  // nothing sits within SNAP_NEAR, so the pool would straddle both shores;
+  // there we take the single nearest for a predictable in-place landing rather
+  // than a random lurch to the far coast.
+  const near = ranked.filter((e) => e.angle <= SNAP_NEAR);
+  if (near.length === 0) return ranked[0].code;
+  return weightedDraw(
+    near.map((e) => e.code),
+    visited,
+    rng(),
+  );
 }


### PR DESCRIPTION
## Why

A fling that decelerated over open ocean could snap to a country on the **far shore**: the fair draw randomised across a nearest-pool that straddled both coasts (mid-Pacific rest point: `mx 50°` … `jp 68°` are opposite rims), and the snap spring then accelerated the view across to it. #152's faster, stiffer snap made the lurch more pronounced — it was decelerating, then sped back up and crossed the sea.

## What

Gate the fair draw to countries within `SNAP_NEAR` (18°) of the rest direction. Over open water — nothing within range, so the pool would straddle both shores — take the single nearest for a predictable in-place landing instead of a random far jump. Fairness is unchanged on land, where the pool is a genuine neighbourhood and small countries still get their turn.

Threshold is data-backed: at mid-Atlantic / mid-Pacific / central-Indian rest points zero countries fall within 18° (→ nearest fallback), while a dense region keeps the whole pool (→ full fair draw).

Refactor along the way: `nearestPool` → `rankNearest`, which now tags each candidate with its angular distance (the gate needs it). The now-unused code-only wrapper was removed and tests target the real function.

## Test plan

- `pnpm test` (411 pass, incl. a new "over open water … never a far shore" invariant), `typecheck`, `lint`, `build` — all green locally.
- Manual: flick into mid-Pacific / mid-Atlantic → settles on the nearest coast with no cross-ocean re-acceleration; flicks onto dense land (Europe) still distribute fairly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved globe snap selection so nearby countries are chosen more accurately.
  * Fair selection now stays within the closest local candidates, reducing unexpected jumps to distant countries.
  * When no nearby options are available, snapping now falls back to the single closest country more reliably.

* **New Features**
  * Added more consistent ranking for country targets based on angular proximity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->