### PR TITLE
feat(chart): hint commentary with a one-time chevron pulse

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -655,10 +655,64 @@
   animation: tour-tap-ripple 1.8s var(--ease-out) infinite;
 }
 
+/* One-time commentary discovery hint: an aurora ring draws the eye while the
+   chevron wrapper bobs down to say "open". Fires once, then the JS clears the
+   attribute and the chevron returns to rest. Animate the wrapper, not the SVG,
+   so the transform is hardware-accelerated. */
+@keyframes commentary-hint-ring {
+  from {
+    box-shadow: 0 0 0 0 rgba(107, 229, 197, 0.7);
+  }
+  to {
+    box-shadow: 0 0 0 18px rgba(107, 229, 197, 0);
+  }
+}
+/* One transform timeline: the chevron grows (the signal), then the first bob
+   begins while the grow is still easing back, so the swell flows into three
+   "open me" bobs as one gesture. scale and translateY share transform, so they
+   must blend within a single keyframe rather than run as two animations. */
+@keyframes commentary-hint-pop {
+  0% {
+    transform: translateY(0px) scale(1);
+  }
+  14% {
+    transform: translateY(0px) scale(1.32);
+  }
+  26% {
+    transform: translateY(4px) scale(1.046);
+  }
+  41% {
+    transform: translateY(0px) scale(1);
+  }
+  56% {
+    transform: translateY(4px) scale(1);
+  }
+  70% {
+    transform: translateY(0px) scale(1);
+  }
+  85% {
+    transform: translateY(4px) scale(1);
+  }
+  100% {
+    transform: translateY(0px) scale(1);
+  }
+}
+[data-commentary-hint] {
+  border-radius: var(--radius-pill);
+  animation:
+    commentary-hint-ring 850ms var(--ease-out),
+    commentary-hint-pop 1150ms var(--ease-out);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .eq,
   .eq span {
     animation: none;
+  }
+  /* Hint degrades to a static sunrise ring: the cue stays, the motion drops. */
+  [data-commentary-hint] {
+    animation: none;
+    box-shadow: 0 0 0 2px rgba(255, 107, 71, 0.45);
   }
   .eq span {
     transform: scaleY(0.7);

--- a/src/components/chart-sheet/first-commentary-rank.test.ts
+++ b/src/components/chart-sheet/first-commentary-rank.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import type { Track } from "@/lib/chart-schema";
+
+import { firstCommentaryRank } from "./first-commentary-rank";
+
+function track(rank: number, hasCommentary: boolean): Track {
+  return {
+    rank,
+    name: `Track ${rank}`,
+    artist: `Artist ${rank}`,
+    previewUrl: "https://example.com/preview.m4a",
+    artworkUrl: "https://example.com/art.jpg",
+    appleUrl: "https://example.com/apple",
+    spotifySearchUrl: "https://example.com/spotify",
+    commentary: hasCommentary
+      ? {
+          lead: "lead",
+          tag: "tag",
+          claim: "what-it-is",
+          sources: ["https://example.com/source"],
+          generatedAt: "2026-01-01T00:00:00Z",
+        }
+      : null,
+  };
+}
+
+describe("firstCommentaryRank", () => {
+  test("returns null when the list is empty", () => {
+    expect(firstCommentaryRank([])).toBeNull();
+  });
+
+  test("returns null when no track carries commentary", () => {
+    const tracks = [track(1, false), track(2, false), track(3, false)];
+
+    expect(firstCommentaryRank(tracks)).toBeNull();
+  });
+
+  test("returns the rank of the first commentary-bearing track, not rank 1", () => {
+    const tracks = [
+      track(1, false),
+      track(2, false),
+      track(3, true),
+      track(4, true),
+    ];
+
+    expect(firstCommentaryRank(tracks)).toBe(3);
+  });
+
+  test("treats a missing commentary field as no commentary", () => {
+    const withoutField = track(1, false);
+    delete withoutField.commentary;
+    const tracks = [withoutField, track(2, true)];
+
+    expect(firstCommentaryRank(tracks)).toBe(2);
+  });
+});

--- a/src/components/chart-sheet/first-commentary-rank.ts
+++ b/src/components/chart-sheet/first-commentary-rank.ts
@@ -1,0 +1,10 @@
+import type { Track } from "@/lib/chart-schema";
+
+// Picks which row gets the one-time commentary pulse: the first track that
+// actually carries commentary. Deliberately not a fixed rank — commentary is
+// gated per track (published or dropped at authoring time), so the top of the
+// list may have none and the set shifts as charts refresh. The tracks array is
+// already in rank order. Returns null when no track here has commentary.
+export function firstCommentaryRank(tracks: Track[]): number | null {
+  return tracks.find((track) => track.commentary)?.rank ?? null;
+}

--- a/src/components/chart-sheet/seen-commentary-hint.ts
+++ b/src/components/chart-sheet/seen-commentary-hint.ts
@@ -1,0 +1,39 @@
+// One-time gate for the commentary-discovery pulse, persisted across sessions
+// and kept separate from the tour's flag so each surfaces on its own schedule.
+// The :v1 suffix lets a redesigned hint re-trigger everyone by bumping the key,
+// with no migration code, mirroring the tour flag.
+const SEEN_KEY = "sounds-abroad:commentary-hint-seen:v1";
+
+type HintStorage = Pick<Storage, "getItem" | "setItem">;
+
+function defaultStorage(): HintStorage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    // Touching localStorage can throw outright (sandboxed iframe, hard-blocked
+    // cookies), not just on read. Treat that as "no storage".
+    return null;
+  }
+}
+
+// Reads tolerantly: any failure means "not seen", so a storage hiccup lets the
+// hint run rather than silently suppressing it.
+export function hasSeenCommentaryHint(storage = defaultStorage()): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(SEEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+// Best-effort write: if persisting fails (quota, private mode), the worst case
+// is the hint pulses again next visit, which is harmless.
+export function markCommentaryHintSeen(storage = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(SEEN_KEY, "1");
+  } catch {
+    return;
+  }
+}

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -4,6 +4,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -11,6 +12,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 
 import type { Country } from "@/lib/chart-schema";
 
+import { firstCommentaryRank } from "./first-commentary-rank";
 import { TrackRow } from "./track-row";
 
 export type SnapState = "hidden" | "closed" | "peek" | "full";
@@ -112,6 +114,13 @@ export function ChartSheet({
 }: ChartSheetProps) {
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const olRef = useRef<HTMLOListElement | null>(null);
+
+  // The one row eligible for the commentary discovery pulse, recomputed per
+  // country (the <ol> remounts on country change, resetting the hint).
+  const hintRank = useMemo(
+    () => firstCommentaryRank(country.tracks),
+    [country.tracks],
+  );
 
   // Lifts the peek max-height clamp so the list fills the sheet while it's
   // dragged; only toggled at gesture start/end, never per frame.
@@ -504,6 +513,7 @@ export function ChartSheet({
                 key={track.rank}
                 track={track}
                 countryCode={countryCode}
+                isHintTarget={track.rank === hintRank}
               />
             ))}
           </ol>

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -11,6 +11,8 @@ import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import type { Track } from "@/lib/chart-schema";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
+import { useCommentaryHintPulse } from "./use-commentary-hint-pulse";
+
 // Cited sources show as bare hostnames; drop a leading www. for scannability.
 const WWW_PREFIX = /^www\./;
 function sourceLabel(url: string): string {
@@ -21,12 +23,39 @@ function sourceLabel(url: string): string {
   }
 }
 
+function ChevronGlyph({ expanded }: { expanded: boolean }) {
+  return (
+    <ChevronDownIcon
+      data-expanded={expanded || undefined}
+      className="text-fg-3 h-4 w-4 transition-transform duration-200 ease-[var(--ease-out)] data-[expanded]:rotate-180 motion-reduce:transition-none"
+    />
+  );
+}
+
+// Only mounted on the single hint-target row, so its store reads and observer
+// are paid once. The pulse animates this wrapper, not the SVG inside it.
+function HintedChevron({ expanded }: { expanded: boolean }) {
+  const { chevronRef, pulsing } = useCommentaryHintPulse();
+  return (
+    <span
+      ref={chevronRef}
+      data-commentary-hint={pulsing || undefined}
+      className="inline-flex shrink-0 items-center justify-center"
+    >
+      <ChevronGlyph expanded={expanded} />
+    </span>
+  );
+}
+
 export interface TrackRowProps {
   track: Track;
   countryCode: string;
+  // True on the first commentary-bearing row of the current country: the one
+  // row eligible for the one-time discovery pulse.
+  isHintTarget?: boolean;
 }
 
-export function TrackRow({ track, countryCode }: TrackRowProps) {
+export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
   const isCurrent = useAudioStore(
     (s) =>
       s.currentTrack?.previewUrl === track.previewUrl &&
@@ -173,10 +202,13 @@ export function TrackRow({ track, countryCode }: TrackRowProps) {
             <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
               {commentary.lead}
             </span>
-            <ChevronDownIcon
-              data-expanded={expanded || undefined}
-              className="text-fg-3 h-4 w-4 shrink-0 transition-transform duration-200 ease-[var(--ease-out)] data-[expanded]:rotate-180 motion-reduce:transition-none"
-            />
+            {isHintTarget ? (
+              <HintedChevron expanded={expanded} />
+            ) : (
+              <span className="inline-flex shrink-0 items-center justify-center">
+                <ChevronGlyph expanded={expanded} />
+              </span>
+            )}
           </button>
           <div
             id={panelId}

--- a/src/components/chart-sheet/use-commentary-hint-pulse.ts
+++ b/src/components/chart-sheet/use-commentary-hint-pulse.ts
@@ -50,8 +50,6 @@ export function useCommentaryHintPulse(): CommentaryHintPulse {
     if (!el) return;
 
     let observer: IntersectionObserver | null = null;
-    let clearTimer: ReturnType<typeof setTimeout> | null = null;
-
     const armTimer = setTimeout(() => {
       observer = new IntersectionObserver(
         ([entry]) => {
@@ -61,7 +59,6 @@ export function useCommentaryHintPulse(): CommentaryHintPulse {
           markSeen();
           setPulsing(true);
           observer?.disconnect();
-          clearTimer = setTimeout(() => setPulsing(false), PULSE_MS);
         },
         { threshold: [VISIBLE_RATIO] },
       );
@@ -70,10 +67,19 @@ export function useCommentaryHintPulse(): CommentaryHintPulse {
 
     return () => {
       clearTimeout(armTimer);
-      if (clearTimer) clearTimeout(clearTimer);
       observer?.disconnect();
     };
   }, [armable, markSeen]);
+
+  // Clear the pulse on its own timer, not the observer's. Firing flips `armable`
+  // false (markSeen), which tears down the observer effect; bundling the reset
+  // there would cancel it and strand the cue on (notably the reduced-motion
+  // static ring).
+  useEffect(() => {
+    if (!pulsing) return;
+    const timer = setTimeout(() => setPulsing(false), PULSE_MS);
+    return () => clearTimeout(timer);
+  }, [pulsing]);
 
   return { chevronRef, pulsing };
 }

--- a/src/components/chart-sheet/use-commentary-hint-pulse.ts
+++ b/src/components/chart-sheet/use-commentary-hint-pulse.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+
+import { hasSeenTour, subscribeSeenTour } from "@/components/tour/seen-tour";
+
+import { useCommentaryHintSeen } from "./use-commentary-hint-seen";
+
+// Reactive read of the tour-done gate. Unlike useSeenTour's no-op subscribe,
+// the hint outlives the tour, so it must re-render when markTourSeen flips the
+// flag mid-session, not just read it once at mount.
+const tourServerSnapshot = (): boolean | null => null;
+
+// Wait a beat after the gate opens so the pulse reads as its own moment rather
+// than a continuation of the just-dismissed tour.
+const ARM_DELAY_MS = 600;
+// Fraction of the chevron that must be on screen before it counts as seen. Above
+// isIntersecting's 1px floor, so a row half-clipped at the peek snap doesn't
+// trigger it.
+const VISIBLE_RATIO = 0.6;
+// How long the pulse attribute stays on: covers the full grow-into-bobs
+// timeline, then clears so the chevron (and the reduced-motion static cue)
+// returns to rest.
+const PULSE_MS = 1250;
+
+export interface CommentaryHintPulse {
+  chevronRef: React.RefObject<HTMLSpanElement | null>;
+  pulsing: boolean;
+}
+
+// Drives the one-time discovery pulse for the single target row. Mounted only on
+// that row, so its store reads and observer cost are paid once, not per row.
+export function useCommentaryHintPulse(): CommentaryHintPulse {
+  const tourSeen = useSyncExternalStore(
+    subscribeSeenTour,
+    hasSeenTour,
+    tourServerSnapshot,
+  );
+  const { seen: hintSeen, markSeen } = useCommentaryHintSeen();
+  const chevronRef = useRef<HTMLSpanElement>(null);
+  const [pulsing, setPulsing] = useState(false);
+
+  // Both flags are booleans (null during SSR), so the effect keys off a single
+  // primitive: only arm once the tour is done and the hint hasn't fired.
+  const armable = tourSeen === true && hintSeen === false;
+
+  useEffect(() => {
+    if (!armable) return;
+    const el = chevronRef.current;
+    if (!el) return;
+
+    let observer: IntersectionObserver | null = null;
+    let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const armTimer = setTimeout(() => {
+      observer = new IntersectionObserver(
+        ([entry]) => {
+          // The initial callback on observe() reports the current ratio, so a
+          // row already on screen fires here without waiting for a scroll.
+          if (entry.intersectionRatio < VISIBLE_RATIO) return;
+          markSeen();
+          setPulsing(true);
+          observer?.disconnect();
+          clearTimer = setTimeout(() => setPulsing(false), PULSE_MS);
+        },
+        { threshold: [VISIBLE_RATIO] },
+      );
+      observer.observe(el);
+    }, ARM_DELAY_MS);
+
+    return () => {
+      clearTimeout(armTimer);
+      if (clearTimer) clearTimeout(clearTimer);
+      observer?.disconnect();
+    };
+  }, [armable, markSeen]);
+
+  return { chevronRef, pulsing };
+}

--- a/src/components/chart-sheet/use-commentary-hint-seen.ts
+++ b/src/components/chart-sheet/use-commentary-hint-seen.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+import {
+  hasSeenCommentaryHint,
+  markCommentaryHintSeen,
+} from "./seen-commentary-hint";
+
+export interface CommentaryHintSeen {
+  // null only during SSR, where localStorage is unreadable; the real value on
+  // the client's first paint, so a returning user never flashes the pulse.
+  seen: boolean | null;
+  markSeen: () => void;
+}
+
+// The flag changes only via markSeen, paired with the single target row's own
+// fire-and-disconnect, so nothing needs to react to a later change: a no-op
+// subscribe, the same shape as useSeenTour.
+const subscribe = () => () => {};
+const serverSnapshot = (): boolean | null => null;
+
+export function useCommentaryHintSeen(): CommentaryHintSeen {
+  const seen = useSyncExternalStore<boolean | null>(
+    subscribe,
+    hasSeenCommentaryHint,
+    serverSnapshot,
+  );
+  const markSeen = useCallback(() => markCommentaryHintSeen(), []);
+  return { seen, markSeen };
+}

--- a/src/components/tour/seen-tour.test.ts
+++ b/src/components/tour/seen-tour.test.ts
@@ -95,6 +95,33 @@ describe("subscribeSeenTour", () => {
   });
 });
 
+describe("falls back to the in-memory mirror when localStorage throws", () => {
+  test("round-trips through the mirror when access throws (private mode)", () => {
+    // Restore in finally, not afterEach: a leaked spy would make the next
+    // suite's localStorage throw and read the mirror instead.
+    const getSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const setSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    try {
+      expect(hasSeenTour()).toBe(false);
+
+      markTourSeen();
+
+      expect(hasSeenTour()).toBe(true);
+    } finally {
+      getSpy.mockRestore();
+      setSpy.mockRestore();
+    }
+  });
+});
+
 describe("seen-tour through the real localStorage", () => {
   afterEach(() => {
     localStorage.clear();

--- a/src/components/tour/seen-tour.test.ts
+++ b/src/components/tour/seen-tour.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { hasSeenTour, markTourSeen } from "./seen-tour";
+import { hasSeenTour, markTourSeen, subscribeSeenTour } from "./seen-tour";
 
 const KEY = "sounds-abroad:tour-seen:v1";
 
@@ -55,6 +55,43 @@ describe("markTourSeen", () => {
     };
 
     expect(() => markTourSeen(hostile)).not.toThrow();
+  });
+});
+
+describe("subscribeSeenTour", () => {
+  test("notifies a subscriber when the tour is marked seen", () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeSeenTour(onChange);
+
+    markTourSeen(fakeStorage());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("notifies even when persisting the flag throws, so the handoff fires", () => {
+    const hostile = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+    const onChange = vi.fn();
+    const unsubscribe = subscribeSeenTour(onChange);
+
+    markTourSeen(hostile);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("stops notifying after unsubscribe", () => {
+    const onChange = vi.fn();
+
+    subscribeSeenTour(onChange)();
+    markTourSeen(fakeStorage());
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/tour/seen-tour.ts
+++ b/src/components/tour/seen-tour.ts
@@ -26,6 +26,16 @@ export function hasSeenTour(storage = defaultStorage()): boolean {
   }
 }
 
+// Same-tab subscribers to the flag flipping. A localStorage write fires no
+// storage event in the writing tab, so a consumer that outlives the tour (the
+// commentary hint) can't otherwise notice the gate opening.
+const seenListeners = new Set<() => void>();
+
+export function subscribeSeenTour(onChange: () => void): () => void {
+  seenListeners.add(onChange);
+  return () => seenListeners.delete(onChange);
+}
+
 // Best-effort write: if persisting fails (quota, private mode), the worst case
 // is the tour shows again next visit, which is harmless.
 export function markTourSeen(storage = defaultStorage()): void {
@@ -35,4 +45,5 @@ export function markTourSeen(storage = defaultStorage()): void {
   } catch {
     return;
   }
+  for (const listener of seenListeners) listener();
 }

--- a/src/components/tour/seen-tour.ts
+++ b/src/components/tour/seen-tour.ts
@@ -5,20 +5,41 @@ const SEEN_KEY = "sounds-abroad:tour-seen:v1";
 
 type TourStorage = Pick<Storage, "getItem" | "setItem">;
 
-function defaultStorage(): TourStorage | null {
-  try {
-    return typeof localStorage === "undefined" ? null : localStorage;
-  } catch {
-    // Touching localStorage can throw outright (sandboxed iframe, hard-blocked
-    // cookies), not just on read. Treat that as "no storage".
-    return null;
-  }
+// In-memory mirror for the default storage, so the same-tab handoff survives a
+// localStorage that's unavailable or throwing (private mode, blocked cookies,
+// quota): the write still records here and reads fall back to it even when it
+// can't persist. Injected storages (tests) never touch this, staying isolated.
+const memory = new Map<string, string>();
+
+function defaultStorage(): TourStorage {
+  return {
+    getItem(key) {
+      try {
+        // Accessible localStorage is authoritative, even when it returns null
+        // (a real "not set"), so clearing it isn't shadowed by the mirror.
+        if (typeof localStorage !== "undefined")
+          return localStorage.getItem(key);
+      } catch {
+        // Touching localStorage can throw outright (sandboxed iframe,
+        // hard-blocked cookies); only then fall back to the in-memory mirror.
+      }
+      return memory.get(key) ?? null;
+    },
+    setItem(key, value) {
+      memory.set(key, value);
+      try {
+        if (typeof localStorage !== "undefined")
+          localStorage.setItem(key, value);
+      } catch {
+        // Best-effort persistence; the in-memory mirror already holds it.
+      }
+    },
+  };
 }
 
 // Reads tolerantly: any failure means "not seen", so a storage hiccup makes the
 // tour run rather than silently suppressing it.
 export function hasSeenTour(storage = defaultStorage()): boolean {
-  if (!storage) return false;
   try {
     return storage.getItem(SEEN_KEY) === "1";
   } catch {
@@ -36,14 +57,13 @@ export function subscribeSeenTour(onChange: () => void): () => void {
   return () => seenListeners.delete(onChange);
 }
 
-// Best-effort write: if persisting fails (quota, private mode), the worst case
-// is the tour shows again next visit, which is harmless.
+// Records the flag (best-effort to disk, always to the in-memory mirror) and
+// notifies same-tab subscribers, so the handoff fires even when persisting fails.
 export function markTourSeen(storage = defaultStorage()): void {
-  if (!storage) return;
   try {
     storage.setItem(SEEN_KEY, "1");
   } catch {
-    return;
+    // An injected storage may throw; the default's mirror already recorded it.
   }
   for (const listener of seenListeners) listener();
 }


### PR DESCRIPTION
## What

A track row's AI commentary hides behind a conventional chevron that many users never try. After the onboarding tour, the first commentary-bearing row that scrolls into view pulses its chevron once (a grow and aurora ring, then a few bobs), then never again.

## When it fires

Two gates, both required:

1. The onboarding tour is done (`seen === true`).
2. The first commentary-bearing row of the current country is at least 60% visible.

Armed ~600ms after the gate opens so it reads as its own moment, not a continuation of the tour. One-time, persisted in `localStorage` (`sounds-abroad:commentary-hint-seen:v1`), separate from the tour flag. Reduced motion shows a static sunrise ring instead of the animation.

## Design notes

- Target is the first row that actually carries commentary, not a fixed rank: commentary is gated per track, so the top of the list may have none and the set shifts as charts refresh.
- IntersectionObserver, not a scroll listener: its initial callback reports current visibility, so a row already on screen when the gate opens still fires.
- `markTourSeen` now notifies same-tab subscribers so the hint reacts to the live tour-to-chart handoff. `useSeenTour`'s no-op subscribe froze a stale `false` at mount; the hint outlives the tour and needs the live flip.
- The hook mounts only on the single target row (not all 25), so its store reads and observer cost are paid once.

## Test plan

- `pnpm typecheck` / `pnpm lint` / `pnpm test` (468 passed) / `pnpm build`: all green.
- Unit test `first-commentary-rank`: empty list, no commentary, first-not-rank-1, missing field.
- Manual: completed the live tour, confirmed the pulse fires on the first commentary row afterward; `?cc=cl` (rank 4) confirms dynamic targeting; reduced-motion shows the static ring; reload after firing shows no repeat.

Closes #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time commentary discovery hint that highlights a track’s expand chevron after the tour is completed.
  * The hint now appears on the first track with commentary and is shown only once per user.

* **Bug Fixes**
  * Improved reduced-motion behavior so the hint falls back to a static visual style instead of animating.
  * Added safer handling for missing commentary data and storage issues, preventing the hint from breaking in unsupported environments.

* **Tests**
  * Added coverage for selecting the first commentary track and handling empty or commentary-free track lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->