### PR TITLE
fix(globe): re-signal a settle that re-lands the same country

### DIFF
--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -80,12 +80,15 @@ function SceneContent() {
   // A landing is a selection: buzz where supported, write ?cc= (replaceState,
   // so rapid flinging doesn't flood history), record the country as visited,
   // and signal the chart tree so a dismissed sheet resurfaces the result.
-  const handleSettle = useCallback((code: string) => {
+  const handleSettle = useCallback((code: string, changed: boolean) => {
+    // Every settle resurfaces the result (raises a dismissed sheet, re-arms the
+    // tour hint), even when the country is unchanged.
+    globeChartStore.getState().signalSettle();
+    if (!changed) return;
     triggerLandingHaptic();
     globeChartStore.getState().setSelectedCountry(code);
     window.history.replaceState(null, "", `?cc=${code}`);
     setVisited((prev) => addVisited(prev, code));
-    globeChartStore.getState().signalSettle();
   }, []);
 
   return (

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -46,7 +46,9 @@ interface SpinSnapControlsProps {
   fair: boolean;
   visited: ReadonlySet<string>;
   readMode: boolean;
-  onSettle: (code: string) => void;
+  // `changed` is false when the settle re-lands the country already shown, so
+  // the caller can fire on every settle but gate country-change side effects.
+  onSettle: (code: string, changed: boolean) => void;
 }
 
 // Drives the camera as a spun globe: drag to rotate, release to fling with
@@ -136,10 +138,12 @@ export function SpinSnapControls({
     }
     s.settleAz = country.lon * DEG;
     s.settleEl = country.lat * DEG;
-    if (s.settledCode !== country.code) {
-      s.settledCode = country.code;
-      onSettleRef.current(country.code);
-    }
+    // Notify on every settle, even re-landing the same country, so the chart
+    // resurfaces and the tour re-arms its hint; the `changed` flag lets the
+    // caller gate the country-change side effects (?cc=, visited, haptic).
+    const changed = s.settledCode !== country.code;
+    s.settledCode = country.code;
+    onSettleRef.current(country.code, changed);
 
     if (cfg.current.reducedMotion) {
       // Instant cut: jump straight to the spring's end state so the next


### PR DESCRIPTION
## What

The globe signalled a settle only when the landing changed countries. A gentle spin or a tap that re-landed the country already shown went silent, breaking two features that ride the settle signal:

- the onboarding flick hint never re-armed after a no-op grab (the hand vanished and the card got stuck)
- a dismissed chart sheet didn't resurface when the globe re-landed where it already was

## Fix

`settleTo` now notifies on every settle and passes a `changed` flag. The settle signal (`signalSettle`) fires unconditionally; the country-change side effects (`?cc=`, the visited set, the landing haptic) stay gated on `changed`. This restores the store's documented "bumps on every settle" contract, which the consumers (the tour's flick-hint re-arm and the chart's sheet resurface) already assumed.

## Test plan

- `pnpm typecheck` / `pnpm lint` / `pnpm test` (464) / `pnpm build`: green.
- Manual, during the onboarding tour's gesture beat: a tap on the globe (a same-country settle) re-arms the flick hint instead of leaving it stranded.
- Manual: dismiss the chart sheet, then tap the globe; it resurfaces to peek.
- Manual regression: flinging to a different country still updates `?cc=`, records visited, and buzzes once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Globe settling now behaves more consistently when landing on the same country again.
  * Haptic feedback, country selection updates, URL updates, and visited-state changes now only happen when the selected country actually changes.
  * The globe now always registers a settle event, even if the country stays the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->