### PR TITLE
chore: release v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` 2.0.0 → 2.1.0 to cut the v2.1.0 release. Additive batch, so a minor (ADR-0005).

## Scope (since v2.0.0)

- #155 first-run onboarding coach-mark tour
- #152 faster post-fling snap
- #153 settle on the nearest coast
- #157 re-signal a settle that re-lands the same country (sheet resurfaces, tour hint re-arms)
- #156 one-time chevron pulse hinting commentary

## After merge

Tag `v2.1.0` at the merge commit, publish the GitHub Release, close the `v2.1.0` milestone, move the summary into the roadmap (#88) Shipped section.

## Test plan

Version-only change. CI (Lint/Typecheck/Test/Build) covers it; the feature commits each shipped green on their own PRs.