### PR TITLE
perf(crawl): parallelize Spotify resolve, raise crawl timeout

### DIFF
--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -8,7 +8,8 @@ on:
     - cron: "17 4,11,16,22 * * *" # UTC; ADR-0002. Minute off :00 to avoid GH Actions scheduler peak.
   workflow_dispatch:
 
-# A run takes ~50 minutes; never cancel an in-flight run for a superseding trigger.
+# A run is long (a large share of its timeout); never cancel an in-flight run
+# for a superseding trigger — that would forfeit the chart refresh it's mid-way through.
 concurrency:
   group: cron-crawl
   cancel-in-progress: false
@@ -17,7 +18,7 @@ jobs:
   crawl:
     name: Crawl + Publish + Revalidate
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - name: Checkout

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -102,6 +102,31 @@ async function spotifyUrlFor(
   }
 }
 
+/**
+ * Resolves the track's audio preview: the iTunes `previewUrl` when the lookup
+ * succeeds, else null. Best-effort, mirroring spotifyUrlFor — any
+ * ItunesLookupError degrades to a null preview so one bad track never aborts
+ * the crawl; any other error propagates.
+ */
+async function previewUrlFor(
+  id: string,
+  rank: number,
+  cc: string,
+  lookupTrack: CrawlCountryDeps["lookupTrack"],
+  throttle: Throttle,
+): Promise<string | null> {
+  try {
+    const lookup = await throttle(() => lookupTrack(id, cc));
+    return lookup.previewUrl;
+  } catch (err) {
+    if (!(err instanceof ItunesLookupError)) throw err;
+    console.warn(
+      `[crawl ${cc}] lookup ${err.kind} for rank ${rank} id=${id}: ${err.message}`,
+    );
+    return null;
+  }
+}
+
 export async function crawlCountry(
   deps: CrawlCountryDeps,
 ): Promise<CrawlCountryResult> {
@@ -118,17 +143,10 @@ export async function crawlCountry(
 
   const tracks: Track[] = [];
   for (const rss of rssTracks) {
-    let previewUrl: string | null;
-    try {
-      const lookup = await throttle(() => lookupTrack(rss.id, cc));
-      previewUrl = lookup.previewUrl;
-    } catch (err) {
-      if (!(err instanceof ItunesLookupError)) throw err;
-      console.warn(
-        `[crawl ${cc}] lookup ${err.kind} for rank ${rss.rank} id=${rss.id}: ${err.message}`,
-      );
-      previewUrl = null;
-    }
+    const [previewUrl, spotifyUrl] = await Promise.all([
+      previewUrlFor(rss.id, rss.rank, cc, lookupTrack, throttle),
+      spotifyUrlFor(rss.name, rss.artist, cc, spotify),
+    ]);
     tracks.push({
       rank: rss.rank,
       name: rss.name,
@@ -136,7 +154,7 @@ export async function crawlCountry(
       previewUrl,
       artworkUrl: rss.artworkUrl,
       appleUrl: rss.appleUrl,
-      spotifyUrl: await spotifyUrlFor(rss.name, rss.artist, cc, spotify),
+      spotifyUrl,
     });
   }
 


### PR DESCRIPTION
## What

Two changes that take the cron crawl off the edge of its timeout:

1. **Parallelize per-track resolution** — Spotify link resolution was `await`ed *after* each track's iTunes lookup, so its latency spilled past the 3s iTunes throttle gap and added ~4 min to the run. Both resolvers now run concurrently via `Promise.all`. They use separate throttles (iTunes 3s, Spotify 200ms), so there's no contention — resolution overlaps iTunes' idle window instead of trailing it.
2. **Raise the job timeout 90 → 120 min.** The ~82 min floor is intrinsic to the single shared 3s iTunes throttle (63 RSS + 1575 lookups ≈ 1638 serialized calls) and grows ~75s per added country. Parallelization recovers the Spotify overhang but can't move that floor, so the timeout bump is the durable headroom (also matches the Sentry `maxRuntime`).

## Why

Last 6 crawls succeeded at ~84 min against the 90 min timeout — passing, but the margin was thin against a floor that climbs with every new country and spikes on iTunes latency variance.

## Test plan

- `pnpm lint` / `pnpm format` / `pnpm typecheck` — clean
- `pnpm test` — 497/497 pass
- Live `pnpm crawl ca` dry-run: 25/25 tracks resolved with both `previewUrl` and `/track/{id}` Spotify deeplinks; runtime 76s ≈ the 26-call iTunes floor, confirming Spotify overhang ≈ 0 (fully overlapped).

Refs #80.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved music track crawling so preview links are resolved more reliably; tracks with unavailable lookups now continue to load instead of failing the full crawl.
  - Speeded up track data fetching by resolving related links in parallel, which should make crawls complete faster.
- **Chores**
  - Extended scheduled job runtime to better support longer-running crawl runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->