### PR TITLE
chore(schema): drop the legacy spotifySearchUrl migration shim

### DIFF
--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -32,36 +32,6 @@ test("ChartFileSchema accepts null previewUrl (placeholder for lookup-failed tra
   expect(() => ChartFileSchema.parse(withNullPreview)).not.toThrow();
 });
 
-test("ChartFileSchema accepts a legacy spotifySearchUrl blob and maps it to spotifyUrl", () => {
-  const legacy = {
-    lastUpdated: "2026-05-16T00:00:00.000Z",
-    countries: {
-      kr: {
-        name: "South Korea",
-        valid: true,
-        tracks: [
-          {
-            rank: 1,
-            name: "Test",
-            artist: "Test Artist",
-            previewUrl: null,
-            artworkUrl: "https://art/600x600bb.jpg",
-            appleUrl: "https://music.apple.com/kr/1",
-            spotifySearchUrl: "https://open.spotify.com/search/Test",
-          },
-        ],
-      },
-    },
-  };
-
-  const parsed = ChartFileSchema.parse(legacy);
-
-  expect(parsed.countries.kr.tracks[0].spotifyUrl).toBe(
-    "https://open.spotify.com/search/Test",
-  );
-  expect(parsed.countries.kr.tracks[0]).not.toHaveProperty("spotifySearchUrl");
-});
-
 test("ChartFileSchema accepts null commentary (track skipped or failed generation)", () => {
   const withNullCommentary = {
     lastUpdated: "2026-05-16T00:00:00.000Z",

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -16,7 +16,7 @@ export const CommentarySchema = z.object({
   generatedAt: z.iso.datetime(),
 });
 
-const TrackFields = z.object({
+const TrackSchema = z.object({
   rank: z.number().int().min(1).max(25),
   name: z.string().min(1),
   artist: z.string().min(1),
@@ -26,22 +26,6 @@ const TrackFields = z.object({
   spotifyUrl: z.url(),
   commentary: CommentarySchema.nullable().optional(),
 });
-
-// Accept the legacy `spotifySearchUrl` field so a blob published before the
-// rename still validates; the next crawl rewrites it as `spotifyUrl`. Without
-// this, parsing a pre-rename blob throws and the served chart route fails.
-const TrackSchema = z.preprocess((value) => {
-  if (
-    value &&
-    typeof value === "object" &&
-    !("spotifyUrl" in value) &&
-    "spotifySearchUrl" in value
-  ) {
-    const { spotifySearchUrl, ...rest } = value as Record<string, unknown>;
-    return { ...rest, spotifyUrl: spotifySearchUrl };
-  }
-  return value;
-}, TrackFields);
 
 const CountrySchema = z.object({
   name: z.string().min(1),


### PR DESCRIPTION
## What

Remove the `z.preprocess` shim (and its dedicated test) that mapped a legacy `spotifySearchUrl` field onto `spotifyUrl`.

## Why safe now

The shim was added in #80 (PR #159) so blobs published *before* the field rename still validated through the served chart route. The live published blob is now fully migrated — verified directly against it today: **1575/1575 tracks carry `spotifyUrl`, zero `spotifySearchUrl`**. The crawl only ever writes the new field, and carry-forward copies from the now-clean blob, so no read path can reintroduce the legacy field. The shim is dead weight.

Note: `run.ts`'s `spotifySearchUrl` *function* (the live fallback URL when resolution fails or no creds) is unrelated and stays.

## Test plan

- `pnpm lint` / `pnpm typecheck` — clean
- `pnpm test` — 496 pass (the one removed is the now-obsolete legacy-migration test)

Refs #80.
