### PR TITLE
feat(player): prev/next track navigation in the mini-player

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
 import { MiniPlayer } from "@/components/mini-player";
 import { TourHost } from "@/components/tour/tour-host";
+import { findAdjacentPlayable } from "@/lib/adjacent-playable";
 import type { ChartFile, Country } from "@/lib/chart-schema";
 import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
+import { setSkipHandlers } from "@/lib/media-session";
 import {
   AudioStoreProvider,
   useAudioStore,
@@ -76,8 +78,10 @@ function ChartScreenInner({
   // prop: that resolves from useSearchParams, which a replaceState-only globe
   // landing never re-triggers, so it wouldn't move on a fling.
   const selectedCountry = useGlobeChart((s) => s.selectedCountry);
-  const hasCurrentTrack = useAudioStore((s) => s.currentTrack !== null);
-  const currentTrackRank = useAudioStore((s) => s.currentTrack?.rank ?? null);
+  const currentTrack = useAudioStore((s) => s.currentTrack);
+  const currentCountryCode = useAudioStore((s) => s.currentCountryCode);
+  const hasCurrentTrack = currentTrack !== null;
+  const currentTrackRank = currentTrack?.rank ?? null;
   const endedSignal = useAudioStore((s) => s.endedSignal);
   const audioStore = useAudioStoreApi();
 
@@ -118,16 +122,12 @@ function ChartScreenInner({
     if (currentTrack === null || currentCountryCode === null) return;
     const source = charts.countries[currentCountryCode];
     if (!source) return;
-    const startIdx = source.tracks.findIndex(
-      (t) => t.previewUrl === currentTrack.previewUrl,
+    const next = findAdjacentPlayable(
+      source.tracks,
+      currentTrack.previewUrl,
+      1,
     );
-    if (startIdx === -1) return;
-    for (let i = startIdx + 1; i < source.tracks.length; i++) {
-      if (source.tracks[i].previewUrl !== null) {
-        toggle(source.tracks[i], currentCountryCode);
-        return;
-      }
-    }
+    if (next) toggle(next, currentCountryCode);
   }, [endedSignal, audioStore, charts.countries]);
 
   // Hidden sheet has no on-screen affordance; the next pointerdown anywhere
@@ -170,6 +170,49 @@ function ChartScreenInner({
     setScrollSignal((n) => n + 1);
   }, [audioStore, countryCode]);
 
+  // Step within the source country, not the visible one. Reads live store state
+  // so the callbacks stay stable across track changes.
+  const step = useCallback(
+    (dir: 1 | -1) => {
+      const { currentTrack, currentCountryCode, toggle } =
+        audioStore.getState();
+      if (currentTrack === null || currentCountryCode === null) return;
+      const source = charts.countries[currentCountryCode];
+      if (!source) return;
+      const adj = findAdjacentPlayable(
+        source.tracks,
+        currentTrack.previewUrl,
+        dir,
+      );
+      if (adj) toggle(adj, currentCountryCode);
+    },
+    [audioStore, charts.countries],
+  );
+  const goPrev = useCallback(() => step(-1), [step]);
+  const goNext = useCallback(() => step(1), [step]);
+
+  const canPrev = useMemo(() => {
+    if (currentTrack === null || currentCountryCode === null) return false;
+    const source = charts.countries[currentCountryCode];
+    return source
+      ? findAdjacentPlayable(source.tracks, currentTrack.previewUrl, -1) !==
+          null
+      : false;
+  }, [currentTrack, currentCountryCode, charts.countries]);
+  const canNext = useMemo(() => {
+    if (currentTrack === null || currentCountryCode === null) return false;
+    const source = charts.countries[currentCountryCode];
+    return source
+      ? findAdjacentPlayable(source.tracks, currentTrack.previewUrl, 1) !== null
+      : false;
+  }, [currentTrack, currentCountryCode, charts.countries]);
+
+  // Skip lives here, not in the audio store: routing prev/next needs the chart
+  // data to find the adjacent playable track, which the store doesn't hold.
+  useEffect(() => {
+    setSkipHandlers({ previoustrack: goPrev, nexttrack: goNext });
+  }, [goPrev, goNext]);
+
   return (
     <>
       <ChartSheet
@@ -181,7 +224,13 @@ function ChartScreenInner({
         hasMiniPlayer={hasCurrentTrack}
         scrollSignal={scrollSignal}
       />
-      <MiniPlayer onTap={handleMiniTap} />
+      <MiniPlayer
+        onTap={handleMiniTap}
+        onPrev={goPrev}
+        onNext={goNext}
+        canPrev={canPrev}
+        canNext={canNext}
+      />
       <TourHost
         snap={snap}
         hasCurrentTrack={hasCurrentTrack}

--- a/src/components/icons/skip-back.tsx
+++ b/src/components/icons/skip-back.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from "react";
+
+export function SkipBackIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      {...props}
+    >
+      <path d="M6 6h2v12H6V6zm3.5 6 8.5 6V6l-8.5 6z" />
+    </svg>
+  );
+}

--- a/src/components/icons/skip-forward.tsx
+++ b/src/components/icons/skip-forward.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from "react";
+
+export function SkipForwardIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      {...props}
+    >
+      <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+    </svg>
+  );
+}

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -6,7 +6,7 @@ import { type AudioState, createAudioStore } from "@/lib/audio-store";
 import type { Track } from "@/lib/chart-schema";
 import { AudioStoreContext } from "@/providers/audio-store-provider";
 
-import { MiniPlayer } from "./mini-player";
+import { MiniPlayer, type MiniPlayerProps } from "./mini-player";
 
 function makeMockAudio(): AudioEngine {
   return {
@@ -33,19 +33,27 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 }
 
 function renderMiniPlayer(
-  props: { onTap: () => void },
+  props: Partial<MiniPlayerProps> = {},
   init?: Partial<AudioState>,
 ) {
   const store = createAudioStore(() => makeMockAudio());
   if (init) {
     store.setState(init);
   }
+  const fullProps: MiniPlayerProps = {
+    onTap: vi.fn(),
+    onPrev: vi.fn(),
+    onNext: vi.fn(),
+    canPrev: true,
+    canNext: true,
+    ...props,
+  };
   const utils = render(
     <AudioStoreContext.Provider value={store}>
-      <MiniPlayer {...props} />
+      <MiniPlayer {...fullProps} />
     </AudioStoreContext.Provider>,
   );
-  return { ...utils, store };
+  return { ...utils, store, props: fullProps };
 }
 
 describe("MiniPlayer", () => {
@@ -120,5 +128,86 @@ describe("MiniPlayer", () => {
     renderMiniPlayer({ onTap: vi.fn() }, { currentTrack: makeTrack() });
 
     expect(screen.getByRole("button", { name: /volume/i })).toBeDefined();
+  });
+
+  test("next button fires onNext", () => {
+    const onNext = vi.fn();
+
+    renderMiniPlayer({ onNext }, { currentTrack: makeTrack() });
+
+    fireEvent.click(screen.getByRole("button", { name: /next track/i }));
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  test("prev button fires onPrev", () => {
+    const onPrev = vi.fn();
+
+    renderMiniPlayer({ onPrev }, { currentTrack: makeTrack() });
+
+    fireEvent.click(screen.getByRole("button", { name: /previous track/i }));
+
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  test("next button is disabled when canNext is false", () => {
+    renderMiniPlayer({ canNext: false }, { currentTrack: makeTrack() });
+
+    const nextButton = screen.getByRole("button", { name: /next track/i });
+    expect((nextButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("prev button is disabled when canPrev is false", () => {
+    renderMiniPlayer({ canPrev: false }, { currentTrack: makeTrack() });
+
+    const prevButton = screen.getByRole("button", { name: /previous track/i });
+    expect((prevButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("swipe left fires onNext and suppresses the tap", () => {
+    const onNext = vi.fn();
+    const onTap = vi.fn();
+
+    renderMiniPlayer({ onNext, onTap }, { currentTrack: makeTrack() });
+
+    const area = screen.getByRole("button", { name: /reopen chart/i });
+    fireEvent.pointerDown(area, { clientX: 200, clientY: 10 });
+    fireEvent.pointerUp(area, { clientX: 40, clientY: 10 });
+    fireEvent.click(area);
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  test("swipe right fires onPrev and suppresses the tap", () => {
+    const onPrev = vi.fn();
+    const onTap = vi.fn();
+
+    renderMiniPlayer({ onPrev, onTap }, { currentTrack: makeTrack() });
+
+    const area = screen.getByRole("button", { name: /reopen chart/i });
+    fireEvent.pointerDown(area, { clientX: 40, clientY: 10 });
+    fireEvent.pointerUp(area, { clientX: 200, clientY: 10 });
+    fireEvent.click(area);
+
+    expect(onPrev).toHaveBeenCalledTimes(1);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  test("a short press below the swipe threshold still taps", () => {
+    const onNext = vi.fn();
+    const onPrev = vi.fn();
+    const onTap = vi.fn();
+
+    renderMiniPlayer({ onNext, onPrev, onTap }, { currentTrack: makeTrack() });
+
+    const area = screen.getByRole("button", { name: /reopen chart/i });
+    fireEvent.pointerDown(area, { clientX: 100, clientY: 10 });
+    fireEvent.pointerUp(area, { clientX: 110, clientY: 10 });
+    fireEvent.click(area);
+
+    expect(onTap).toHaveBeenCalledTimes(1);
+    expect(onNext).not.toHaveBeenCalled();
+    expect(onPrev).not.toHaveBeenCalled();
   });
 });

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -60,6 +60,13 @@ export function MiniPlayer({
     startYRef.current = e.clientY;
     trackingRef.current = true;
     swipedRef.current = false;
+    // Capture so a swipe that drifts off the button still delivers its pointerup
+    // here; the browser releases the capture on pointerup/cancel.
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      /* setPointerCapture is unsupported under jsdom; capture is best-effort */
+    }
   };
 
   const handlePointerUp = (e: ReactPointerEvent<HTMLButtonElement>) => {

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -1,16 +1,37 @@
 "use client";
 
+import { type PointerEvent as ReactPointerEvent, useRef } from "react";
+
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
+import { SkipBackIcon } from "@/components/icons/skip-back";
+import { SkipForwardIcon } from "@/components/icons/skip-forward";
 import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import { VolumeControl } from "@/components/volume-control";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface MiniPlayerProps {
   onTap: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  canPrev: boolean;
+  canNext: boolean;
 }
 
-export function MiniPlayer({ onTap }: MiniPlayerProps) {
+// Horizontal pointer travel (px) that turns a press on the now-playing area into
+// a skip swipe instead of a tap that reopens the chart.
+const SWIPE_THRESHOLD_PX = 40;
+
+const SKIP_BUTTON_CLASS =
+  "text-fg-2 hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-30";
+
+export function MiniPlayer({
+  onTap,
+  onPrev,
+  onNext,
+  canPrev,
+  canNext,
+}: MiniPlayerProps) {
   const currentTrack = useAudioStore((s) => s.currentTrack);
   const isPlaying = useAudioStore((s) => s.isPlaying);
   const toggle = useAudioStore((s) => s.toggle);
@@ -25,6 +46,48 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
     text: currentTrack?.name,
   });
 
+  // Transient swipe state in refs so tracking the pointer never re-renders.
+  // touch-pan-y (below) hands horizontal drags to JS but can't cancel Safari's
+  // system edge-swipe, so a prev-swipe begun at the very screen edge may still
+  // navigate back.
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const trackingRef = useRef(false);
+  const swipedRef = useRef(false);
+
+  const handlePointerDown = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    startXRef.current = e.clientX;
+    startYRef.current = e.clientY;
+    trackingRef.current = true;
+    swipedRef.current = false;
+  };
+
+  const handlePointerUp = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!trackingRef.current) return;
+    trackingRef.current = false;
+    const dx = e.clientX - startXRef.current;
+    const dy = e.clientY - startYRef.current;
+    if (Math.abs(dx) <= SWIPE_THRESHOLD_PX || Math.abs(dx) <= Math.abs(dy)) {
+      return;
+    }
+    // A swipe fired: flag it so the click that follows doesn't also reopen.
+    swipedRef.current = true;
+    if (dx < 0) onNext();
+    else onPrev();
+  };
+
+  const handlePointerCancel = () => {
+    trackingRef.current = false;
+  };
+
+  const handleTap = () => {
+    if (swipedRef.current) {
+      swipedRef.current = false;
+      return;
+    }
+    onTap();
+  };
+
   if (currentTrack === null) return null;
 
   return (
@@ -32,9 +95,12 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
       <div className="flex items-center gap-[14px] px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]">
         <button
           type="button"
-          onClick={onTap}
+          onClick={handleTap}
+          onPointerDown={handlePointerDown}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
           aria-label="Reopen chart"
-          className="focus-visible:outline-aurora flex min-w-0 flex-1 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
+          className="focus-visible:outline-aurora flex min-w-0 flex-1 touch-pan-y items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
         >
           <div
             aria-hidden="true"
@@ -71,6 +137,15 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
         <VolumeControl />
         <button
           type="button"
+          onClick={onPrev}
+          disabled={!canPrev}
+          aria-label="Previous track"
+          className={SKIP_BUTTON_CLASS}
+        >
+          <SkipBackIcon className="h-[18px] w-[18px]" />
+        </button>
+        <button
+          type="button"
           onClick={() => toggle(currentTrack)}
           aria-label={
             isPlaying
@@ -84,6 +159,15 @@ export function MiniPlayer({ onTap }: MiniPlayerProps) {
           ) : (
             <PlayIcon className="h-4 w-4" />
           )}
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={!canNext}
+          aria-label="Next track"
+          className={SKIP_BUTTON_CLASS}
+        >
+          <SkipForwardIcon className="h-[18px] w-[18px]" />
         </button>
       </div>
     </div>

--- a/src/lib/adjacent-playable.test.ts
+++ b/src/lib/adjacent-playable.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+
+import { findAdjacentPlayable } from "./adjacent-playable";
+import type { Track } from "./chart-schema";
+
+function makeTrack(rank: number, previewUrl: string | null): Track {
+  return {
+    rank,
+    name: `Track ${rank}`,
+    artist: `Artist ${rank}`,
+    previewUrl,
+    artworkUrl: "https://example.com/art.jpg",
+    appleUrl: "https://music.apple.com/x",
+    spotifyUrl: "https://open.spotify.com/search/x",
+  };
+}
+
+describe("findAdjacentPlayable", () => {
+  test("next skips a track with no preview", () => {
+    const current = makeTrack(1, "https://example.com/1.m4a");
+    const gap = makeTrack(2, null);
+    const target = makeTrack(3, "https://example.com/3.m4a");
+    const tracks = [current, gap, target];
+
+    expect(findAdjacentPlayable(tracks, current.previewUrl, 1)).toBe(target);
+  });
+
+  test("prev skips a track with no preview", () => {
+    const target = makeTrack(1, "https://example.com/1.m4a");
+    const gap = makeTrack(2, null);
+    const current = makeTrack(3, "https://example.com/3.m4a");
+    const tracks = [target, gap, current];
+
+    expect(findAdjacentPlayable(tracks, current.previewUrl, -1)).toBe(target);
+  });
+
+  test("next at the last playable returns null", () => {
+    const first = makeTrack(1, "https://example.com/1.m4a");
+    const last = makeTrack(2, "https://example.com/2.m4a");
+    const trailingGap = makeTrack(3, null);
+    const tracks = [first, last, trailingGap];
+
+    expect(findAdjacentPlayable(tracks, last.previewUrl, 1)).toBeNull();
+  });
+
+  test("prev at the first playable returns null", () => {
+    const leadingGap = makeTrack(1, null);
+    const first = makeTrack(2, "https://example.com/2.m4a");
+    const second = makeTrack(3, "https://example.com/3.m4a");
+    const tracks = [leadingGap, first, second];
+
+    expect(findAdjacentPlayable(tracks, first.previewUrl, -1)).toBeNull();
+  });
+
+  test("returns null when the current preview is not in the list", () => {
+    const tracks = [
+      makeTrack(1, "https://example.com/1.m4a"),
+      makeTrack(2, "https://example.com/2.m4a"),
+    ];
+
+    expect(
+      findAdjacentPlayable(tracks, "https://example.com/absent.m4a", 1),
+    ).toBeNull();
+  });
+
+  test("a list with one playable returns null in both directions", () => {
+    const leadingGap = makeTrack(1, null);
+    const only = makeTrack(2, "https://example.com/2.m4a");
+    const trailingGap = makeTrack(3, null);
+    const tracks = [leadingGap, only, trailingGap];
+
+    expect(findAdjacentPlayable(tracks, only.previewUrl, 1)).toBeNull();
+    expect(findAdjacentPlayable(tracks, only.previewUrl, -1)).toBeNull();
+  });
+});

--- a/src/lib/adjacent-playable.ts
+++ b/src/lib/adjacent-playable.ts
@@ -1,0 +1,21 @@
+import type { Track } from "./chart-schema";
+
+/**
+ * The next or previous playable track relative to the current one, or null.
+ * Clamps at the ends (no #1<->#last wrap) and skips tracks with no preview, so
+ * stepping never lands on a track that can't play.
+ */
+export function findAdjacentPlayable(
+  tracks: Track[],
+  currentPreviewUrl: string | null,
+  dir: 1 | -1,
+): Track | null {
+  const currentIdx = tracks.findIndex(
+    (t) => t.previewUrl === currentPreviewUrl,
+  );
+  if (currentIdx === -1) return null;
+  for (let i = currentIdx + dir; i >= 0 && i < tracks.length; i += dir) {
+    if (tracks[i].previewUrl !== null) return tracks[i];
+  }
+  return null;
+}

--- a/src/lib/media-session.test.ts
+++ b/src/lib/media-session.test.ts
@@ -7,6 +7,7 @@ import {
   setActionHandlers,
   setNowPlaying,
   setPlaybackState,
+  setSkipHandlers,
   type MediaSessionDeps,
 } from "./media-session";
 
@@ -102,6 +103,30 @@ test("setActionHandlers registers play and pause", () => {
 
 test("setActionHandlers no-ops when mediaSession is unavailable", () => {
   setActionHandlers({ play: vi.fn(), pause: vi.fn() }, { mediaSession: null });
+});
+
+test("setSkipHandlers registers nexttrack and previoustrack", () => {
+  const deps = makeDeps();
+  const nexttrack = vi.fn();
+  const previoustrack = vi.fn();
+
+  setSkipHandlers({ nexttrack, previoustrack }, deps);
+
+  expect(deps.mediaSession!.setActionHandler).toHaveBeenCalledWith(
+    "nexttrack",
+    nexttrack,
+  );
+  expect(deps.mediaSession!.setActionHandler).toHaveBeenCalledWith(
+    "previoustrack",
+    previoustrack,
+  );
+});
+
+test("setSkipHandlers no-ops when mediaSession is unavailable", () => {
+  setSkipHandlers(
+    { nexttrack: vi.fn(), previoustrack: vi.fn() },
+    { mediaSession: null },
+  );
 });
 
 test("setNowPlaying no-ops when mediaSession is unavailable", () => {

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -10,6 +10,11 @@ export interface MediaSessionHandlers {
   pause: () => void;
 }
 
+export interface MediaSessionSkipHandlers {
+  nexttrack: () => void;
+  previoustrack: () => void;
+}
+
 function defaultDeps(): MediaSessionDeps {
   const nav = typeof navigator !== "undefined" ? navigator : undefined;
   return {
@@ -54,7 +59,7 @@ export function setPlaybackState(
 /**
  * Registers play/pause transport handlers. iOS requires at least these for a
  * reliable now-playing presentation; without them it falls back to a minimal,
- * art-only card. Next/previous and seek are out of scope.
+ * art-only card. Seek is out of scope.
  */
 export function setActionHandlers(
   handlers: MediaSessionHandlers,
@@ -64,6 +69,21 @@ export function setActionHandlers(
   if (!mediaSession) return;
   mediaSession.setActionHandler("play", handlers.play);
   mediaSession.setActionHandler("pause", handlers.pause);
+}
+
+/**
+ * Registers the OS skip controls. Separate from play/pause because routing them
+ * needs the chart data to find the adjacent track, which lives in the chart UI,
+ * not the audio store that wires play/pause.
+ */
+export function setSkipHandlers(
+  handlers: MediaSessionSkipHandlers,
+  deps: MediaSessionDeps = defaultDeps(),
+): void {
+  const { mediaSession } = deps;
+  if (!mediaSession) return;
+  mediaSession.setActionHandler("nexttrack", handlers.nexttrack);
+  mediaSession.setActionHandler("previoustrack", handlers.previoustrack);
 }
 
 export function clearNowPlaying(deps: MediaSessionDeps = defaultDeps()): void {


### PR DESCRIPTION
## What

Step through the current country's chart from the mini-player: prev/next buttons
flanking play/pause, plus a horizontal swipe on the now-playing strip. Skips
preview-less tracks and clamps at the ends (no wrap). The OS media-session
next/previous keys (lock screen, earbuds) route through the same path.

## Why

The mini-player could only play/pause; moving between tracks meant reopening the
chart. Stepping in place matches the listening flow.

## How

- `findAdjacentPlayable(tracks, currentPreviewUrl, dir)` extracts the next-playable
  scan the on-ended auto-advance already ran, so manual and automatic navigation
  share one rule (clamp, skip null-preview).
- `chart-screen` owns `goPrev` / `goNext` and `canPrev` / `canNext` (it holds the
  chart data the audio store lacks) and registers the media-session skip handlers.
- `mini-player` gets the buttons (disabled at the first/last playable track) and
  the swipe (40px, horizontal-dominant, suppresses the reopen tap).

## Test plan

- `pnpm format / lint / typecheck / test / build` all green (511 tests; +6 helper,
  +7 mini-player, +2 media-session).
- Manual: buttons disable at the first/last playable track; swipe steps tracks; a
  tap still reopens the chart; preview-less tracks are skipped.

## Notes

- iOS: an edge-origin horizontal swipe can still trigger Safari's system back
  gesture; `touch-pan-y` mitigates and the strip starts inset, but worth a device
  check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added previous/next track controls in the mini player and on-screen skip actions.
  * Improved swipe gestures on the now-playing area to move between tracks.

* **Bug Fixes**
  * Playback now advances more reliably to the next available preview track.
  * Skip controls are disabled when no adjacent track is available.

* **Tests**
  * Expanded coverage for skip buttons, swipe gestures, track selection, and media session skip handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->