### PR TITLE
feat(globe): edge-tap to skip tracks while listening

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
+import { EdgeTapHint } from "@/components/globe/edge-tap-hint";
 import { MiniPlayer } from "@/components/mini-player";
 import { TourHost } from "@/components/tour/tour-host";
 import { findAdjacentPlayable } from "@/lib/adjacent-playable";
@@ -213,6 +214,19 @@ function ChartScreenInner({
     setSkipHandlers({ previoustrack: goPrev, nexttrack: goNext });
   }, [goPrev, goNext]);
 
+  // Mirror the listening gate and the shared step to the globe so an edge-tap on
+  // the layout-backdrop globe routes through the same prev/next. The globe sits
+  // outside the audio provider, so it can't read currentTrack or call step
+  // directly; this crosses the same seam selectedCountry already does.
+  useEffect(() => {
+    globeChartStore.getState().setListening(hasCurrentTrack);
+    return () => globeChartStore.getState().setListening(false);
+  }, [hasCurrentTrack]);
+  useEffect(() => {
+    globeChartStore.getState().setSkip(step);
+    return () => globeChartStore.getState().setSkip(() => {});
+  }, [step]);
+
   return (
     <>
       <ChartSheet
@@ -231,6 +245,7 @@ function ChartScreenInner({
         canPrev={canPrev}
         canNext={canNext}
       />
+      <EdgeTapHint active={hasCurrentTrack} />
       <TourHost
         snap={snap}
         hasCurrentTrack={hasCurrentTrack}

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -175,18 +175,20 @@ function ChartScreenInner({
   // Step within the source country, not the visible one. Reads live store state
   // so the callbacks stay stable across track changes.
   const step = useCallback(
-    (dir: 1 | -1) => {
+    (dir: 1 | -1): boolean => {
       const { currentTrack, currentCountryCode, toggle } =
         audioStore.getState();
-      if (currentTrack === null || currentCountryCode === null) return;
+      if (currentTrack === null || currentCountryCode === null) return false;
       const source = charts.countries[currentCountryCode];
-      if (!source) return;
+      if (!source) return false;
       const adj = findAdjacentPlayable(
         source.tracks,
         currentTrack.previewUrl,
         dir,
       );
-      if (adj) toggle(adj, currentCountryCode);
+      if (!adj) return false;
+      toggle(adj, currentCountryCode);
+      return true;
     },
     [audioStore, charts.countries],
   );
@@ -225,7 +227,7 @@ function ChartScreenInner({
   }, [hasCurrentTrack]);
   useEffect(() => {
     globeChartStore.getState().setSkip(step);
-    return () => globeChartStore.getState().setSkip(() => {});
+    return () => globeChartStore.getState().setSkip(() => false);
   }, [step]);
 
   return (

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -247,7 +247,7 @@ function ChartScreenInner({
         canNext={canNext}
       />
       <EdgeTapHint active={hasCurrentTrack} />
-      <SkipFlash />
+      <SkipFlash sheetSnap={snap} />
       <TourHost
         snap={snap}
         hasCurrentTrack={hasCurrentTrack}

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
 import { EdgeTapHint } from "@/components/globe/edge-tap-hint";
+import { SkipFlash } from "@/components/globe/skip-flash";
 import { MiniPlayer } from "@/components/mini-player";
 import { TourHost } from "@/components/tour/tour-host";
 import { findAdjacentPlayable } from "@/lib/adjacent-playable";
@@ -246,6 +247,7 @@ function ChartScreenInner({
         canNext={canNext}
       />
       <EdgeTapHint active={hasCurrentTrack} />
+      <SkipFlash />
       <TourHost
         snap={snap}
         hasCurrentTrack={hasCurrentTrack}

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -248,7 +248,9 @@ function ChartScreenInner({
         canPrev={canPrev}
         canNext={canNext}
       />
-      <EdgeTapHint active={hasCurrentTrack} />
+      {/* Only while the globe is visible: at full the sheet covers it, so
+          showing the hint there would burn its one-time display unseen. */}
+      <EdgeTapHint active={hasCurrentTrack && snap !== "full"} />
       <SkipFlash sheetSnap={snap} />
       <TourHost
         snap={snap}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -709,60 +709,40 @@
    out, never rotating the globe so "skip a song" stays distinct from rotating
    to a country. Duration and travel come from JS (--skip-flash-*) so they tune
    in one place. */
-@keyframes skip-flash-next {
+@keyframes skip-fade {
   0% {
     opacity: 0;
-    transform: translateX(0) scale(0.86);
   }
-  22% {
+  18% {
     opacity: 1;
-    transform: translateX(calc(var(--skip-flash-travel, 24px) * 0.25)) scale(1);
   }
-  55% {
+  62% {
     opacity: 1;
-    transform: translateX(calc(var(--skip-flash-travel, 24px) * 0.6)) scale(1);
   }
   100% {
     opacity: 0;
+  }
+}
+
+@keyframes skip-slide-next {
+  0% {
+    transform: translateX(0) scale(0.9);
+  }
+  100% {
     transform: translateX(var(--skip-flash-travel, 24px)) scale(1);
   }
 }
 
-@keyframes skip-flash-prev {
+@keyframes skip-slide-prev {
   0% {
-    opacity: 0;
-    transform: translateX(0) scale(0.86);
-  }
-  22% {
-    opacity: 1;
-    transform: translateX(calc(var(--skip-flash-travel, 24px) * -0.25)) scale(1);
-  }
-  55% {
-    opacity: 1;
-    transform: translateX(calc(var(--skip-flash-travel, 24px) * -0.6)) scale(1);
+    transform: translateX(0) scale(0.9);
   }
   100% {
-    opacity: 0;
-    transform: translateX(calc(var(--skip-flash-travel, 24px) * -1)) scale(1);
-  }
-}
-
-/* Reduced motion keeps the cue but drops the slide: a brief opacity flash. */
-@keyframes skip-flash-static {
-  0% {
-    opacity: 0;
-  }
-  28% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
+    transform: translateX(calc(-1 * var(--skip-flash-travel, 24px))) scale(1);
   }
 }
 
 .skip-flash {
-  animation-duration: var(--skip-flash-dur, 340ms);
-  animation-timing-function: var(--ease-out);
   animation-fill-mode: forwards;
   /* aurora glow (transient-feedback color); doubled so the chevron reads over
      the globe's warm glow, which a same-hue sunrise cue washed out on device. */
@@ -770,12 +750,19 @@
     drop-shadow(0 0 8px rgba(107, 229, 197, 0.6));
 }
 
+/* Opacity (linear) and the slide (single-segment ease-out) run as two concurrent
+   animations. A single multi-stop keyframe re-eases at every stop, which read as
+   a two-stage stutter on device; splitting them keeps the slide one smooth ease. */
 .skip-flash[data-dir="next"] {
-  animation-name: skip-flash-next;
+  animation:
+    skip-fade var(--skip-flash-dur, 460ms) linear forwards,
+    skip-slide-next var(--skip-flash-dur, 460ms) var(--ease-out) forwards;
 }
 
 .skip-flash[data-dir="prev"] {
-  animation-name: skip-flash-prev;
+  animation:
+    skip-fade var(--skip-flash-dur, 460ms) linear forwards,
+    skip-slide-prev var(--skip-flash-dur, 460ms) var(--ease-out) forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -788,10 +775,10 @@
     animation: none;
     box-shadow: 0 0 0 2px rgba(255, 107, 71, 0.45);
   }
-  /* Skip cue keeps a brief opacity flash but drops the directional slide. */
+  /* Skip cue keeps the opacity flash but drops the directional slide. */
   .skip-flash[data-dir="next"],
   .skip-flash[data-dir="prev"] {
-    animation-name: skip-flash-static;
+    animation: skip-fade var(--skip-flash-dur, 460ms) linear forwards;
   }
   .eq span {
     transform: scaleY(0.7);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -704,6 +704,67 @@
     commentary-hint-pop 1150ms var(--ease-out);
 }
 
+/* Skip cue: a directional chevron on the tapped edge confirms a track skip
+   (next = right, prev = left). It fades in, slides toward that edge, and fades
+   out, never rotating the globe so "skip a song" stays distinct from rotating
+   to a country. Duration and travel come from JS (--skip-flash-*) so they tune
+   in one place. */
+@keyframes skip-flash-next {
+  0% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+  28% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(var(--skip-flash-travel, 20px));
+  }
+}
+
+@keyframes skip-flash-prev {
+  0% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+  28% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--skip-flash-travel, 20px)));
+  }
+}
+
+/* Reduced motion keeps the cue but drops the slide: a brief opacity flash. */
+@keyframes skip-flash-static {
+  0% {
+    opacity: 0;
+  }
+  28% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.skip-flash {
+  animation-duration: var(--skip-flash-dur, 340ms);
+  animation-timing-function: var(--ease-out);
+  animation-fill-mode: forwards;
+  filter: drop-shadow(0 0 16px rgba(255, 107, 71, 0.45));
+}
+
+.skip-flash[data-dir="next"] {
+  animation-name: skip-flash-next;
+}
+
+.skip-flash[data-dir="prev"] {
+  animation-name: skip-flash-prev;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .eq,
   .eq span {
@@ -713,6 +774,11 @@
   [data-commentary-hint] {
     animation: none;
     box-shadow: 0 0 0 2px rgba(255, 107, 71, 0.45);
+  }
+  /* Skip cue keeps a brief opacity flash but drops the directional slide. */
+  .skip-flash[data-dir="next"],
+  .skip-flash[data-dir="prev"] {
+    animation-name: skip-flash-static;
   }
   .eq span {
     transform: scaleY(0.7);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -724,45 +724,27 @@
   }
 }
 
-@keyframes skip-slide-next {
+@keyframes skip-slide {
   0% {
     transform: translateX(0) scale(0.9);
   }
   100% {
-    transform: translateX(var(--skip-flash-travel, 24px)) scale(1);
-  }
-}
-
-@keyframes skip-slide-prev {
-  0% {
-    transform: translateX(0) scale(0.9);
-  }
-  100% {
-    transform: translateX(calc(-1 * var(--skip-flash-travel, 24px))) scale(1);
+    transform: translateX(var(--skip-flash-travel)) scale(1);
   }
 }
 
 .skip-flash {
-  animation-fill-mode: forwards;
   /* aurora glow (transient-feedback color); doubled so the chevron reads over
      the globe's warm glow, which a same-hue sunrise cue washed out on device. */
   filter: drop-shadow(0 0 16px rgba(107, 229, 197, 0.6))
     drop-shadow(0 0 8px rgba(107, 229, 197, 0.6));
-}
-
-/* Opacity (linear) and the slide (single-segment ease-out) run as two concurrent
-   animations. A single multi-stop keyframe re-eases at every stop, which read as
-   a two-stage stutter on device; splitting them keeps the slide one smooth ease. */
-.skip-flash[data-dir="next"] {
+  /* Opacity (linear) and the slide (single-segment ease-out) run as two
+     concurrent animations. A single multi-stop keyframe re-eases at every stop,
+     a two-stage stutter on device; splitting them keeps the slide one smooth
+     ease. Direction is the sign of --skip-flash-travel, set in JS. */
   animation:
-    skip-fade var(--skip-flash-dur, 460ms) linear forwards,
-    skip-slide-next var(--skip-flash-dur, 460ms) var(--ease-out) forwards;
-}
-
-.skip-flash[data-dir="prev"] {
-  animation:
-    skip-fade var(--skip-flash-dur, 460ms) linear forwards,
-    skip-slide-prev var(--skip-flash-dur, 460ms) var(--ease-out) forwards;
+    skip-fade var(--skip-flash-dur) linear forwards,
+    skip-slide var(--skip-flash-dur) var(--ease-out) forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -776,9 +758,8 @@
     box-shadow: 0 0 0 2px rgba(255, 107, 71, 0.45);
   }
   /* Skip cue keeps the opacity flash but drops the directional slide. */
-  .skip-flash[data-dir="next"],
-  .skip-flash[data-dir="prev"] {
-    animation: skip-fade var(--skip-flash-dur, 460ms) linear forwards;
+  .skip-flash {
+    animation: skip-fade var(--skip-flash-dur) linear forwards;
   }
   .eq span {
     transform: scaleY(0.7);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -712,28 +712,38 @@
 @keyframes skip-flash-next {
   0% {
     opacity: 0;
-    transform: translateX(0);
+    transform: translateX(0) scale(0.86);
   }
-  28% {
+  22% {
     opacity: 1;
+    transform: translateX(calc(var(--skip-flash-travel, 24px) * 0.25)) scale(1);
+  }
+  55% {
+    opacity: 1;
+    transform: translateX(calc(var(--skip-flash-travel, 24px) * 0.6)) scale(1);
   }
   100% {
     opacity: 0;
-    transform: translateX(var(--skip-flash-travel, 20px));
+    transform: translateX(var(--skip-flash-travel, 24px)) scale(1);
   }
 }
 
 @keyframes skip-flash-prev {
   0% {
     opacity: 0;
-    transform: translateX(0);
+    transform: translateX(0) scale(0.86);
   }
-  28% {
+  22% {
     opacity: 1;
+    transform: translateX(calc(var(--skip-flash-travel, 24px) * -0.25)) scale(1);
+  }
+  55% {
+    opacity: 1;
+    transform: translateX(calc(var(--skip-flash-travel, 24px) * -0.6)) scale(1);
   }
   100% {
     opacity: 0;
-    transform: translateX(calc(-1 * var(--skip-flash-travel, 20px)));
+    transform: translateX(calc(var(--skip-flash-travel, 24px) * -1)) scale(1);
   }
 }
 
@@ -754,7 +764,10 @@
   animation-duration: var(--skip-flash-dur, 340ms);
   animation-timing-function: var(--ease-out);
   animation-fill-mode: forwards;
-  filter: drop-shadow(0 0 16px rgba(255, 107, 71, 0.45));
+  /* aurora glow (transient-feedback color); doubled so the chevron reads over
+     the globe's warm glow, which a same-hue sunrise cue washed out on device. */
+  filter: drop-shadow(0 0 16px rgba(107, 229, 197, 0.6))
+    drop-shadow(0 0 8px rgba(107, 229, 197, 0.6));
 }
 
 .skip-flash[data-dir="next"] {

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -30,7 +30,7 @@ export interface ChartSheetProps {
 // translateY as a fraction of the sheet's own height at each snap: full shows
 // all of it, hidden pushes it fully below the viewport, peek leaves ~35% (the
 // height the <ol> max-height clamp is tuned to).
-const SNAP_Y_PCT: Record<SnapState, number> = {
+export const SNAP_Y_PCT: Record<SnapState, number> = {
   full: 0,
   peek: 65,
   closed: 90,

--- a/src/components/globe/edge-tap-hint.tsx
+++ b/src/components/globe/edge-tap-hint.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { SkipBackIcon } from "@/components/icons/skip-back";
+import { SkipForwardIcon } from "@/components/icons/skip-forward";
+
+import { hasSeenEdgeTapHint, markEdgeTapHintSeen } from "./seen-edge-tap-hint";
+
+const VISIBLE_MS = 2600;
+
+const CHIP_CLASS =
+  "bg-void/70 text-fg-1 ring-fg-1/10 shadow-sheet flex h-11 w-11 items-center justify-center rounded-full opacity-80 ring-1 backdrop-blur-sm";
+
+// One-time cue that the globe's left/right edges skip tracks while a preview
+// plays. Pointer-transparent so it never intercepts the taps it teaches; shown
+// once per device, then the seen flag persists. Entrance uses the shared
+// tour-fade, which globals.css already drops under prefers-reduced-motion.
+export function EdgeTapHint({ active }: { active: boolean }) {
+  // Read the persisted flag once at mount, before any track plays, so it holds
+  // the true prior-session value. Visibility is then derived from `active`, not
+  // toggled on synchronously in an effect; only the auto-dismiss flips state,
+  // from the timer callback.
+  const [seenAtMount] = useState(() => hasSeenEdgeTapHint());
+  const [dismissed, setDismissed] = useState(false);
+  const armedRef = useRef(false);
+
+  const visible = active && !seenAtMount && !dismissed;
+
+  useEffect(() => {
+    if (!visible || armedRef.current) return;
+    armedRef.current = true;
+    markEdgeTapHintSeen();
+    const id = window.setTimeout(() => setDismissed(true), VISIBLE_MS);
+    return () => window.clearTimeout(id);
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      aria-hidden
+      className="tour-fade pointer-events-none fixed inset-y-0 right-0 left-0 z-40 flex items-center justify-between px-3"
+    >
+      <span className={CHIP_CLASS}>
+        <SkipBackIcon className="h-5 w-5" />
+      </span>
+      <span className={CHIP_CLASS}>
+        <SkipForwardIcon className="h-5 w-5" />
+      </span>
+    </div>
+  );
+}

--- a/src/components/globe/edge-tap-hint.tsx
+++ b/src/components/globe/edge-tap-hint.tsx
@@ -12,10 +12,14 @@ const VISIBLE_MS = 2600;
 const CHIP_CLASS =
   "bg-void/70 text-fg-1 ring-fg-1/10 shadow-sheet flex h-11 w-11 items-center justify-center rounded-full opacity-80 ring-1 backdrop-blur-sm";
 
-// One-time cue that the globe's left/right edges skip tracks while a preview
-// plays. Pointer-transparent so it never intercepts the taps it teaches; shown
-// once per device, then the seen flag persists. Entrance uses the shared
-// tour-fade, which globals.css already drops under prefers-reduced-motion.
+const CAPTION_CLASS =
+  "bg-void/70 text-fg-1 ring-fg-1/10 shadow-sheet rounded-full px-3 py-1.5 text-sm font-medium opacity-80 ring-1 backdrop-blur-sm";
+
+// One-time cue that a double-tap on the globe's left/right edge skips tracks
+// while a preview plays (a single tap still selects a country). Pointer-
+// transparent so it never intercepts the taps it teaches; shown once per device,
+// then the seen flag persists. Entrance uses the shared tour-fade, which
+// globals.css already drops under prefers-reduced-motion.
 export function EdgeTapHint({ active }: { active: boolean }) {
   // Read the persisted flag once at mount, before any track plays, so it holds
   // the true prior-session value. Visibility is then derived from `active`, not
@@ -45,6 +49,7 @@ export function EdgeTapHint({ active }: { active: boolean }) {
       <span className={CHIP_CLASS}>
         <SkipBackIcon className="h-5 w-5" />
       </span>
+      <span className={CAPTION_CLASS}>Double-tap to skip</span>
       <span className={CHIP_CLASS}>
         <SkipForwardIcon className="h-5 w-5" />
       </span>

--- a/src/components/globe/edge-tap-hint.tsx
+++ b/src/components/globe/edge-tap-hint.tsx
@@ -32,7 +32,13 @@ export function EdgeTapHint({ active }: { active: boolean }) {
   const visible = active && !seenAtMount && !dismissed;
 
   useEffect(() => {
-    if (!visible || armedRef.current) return;
+    // Reset the gate when the hint hides so a later show re-arms the timer; the
+    // gate keeps a single continuous show from re-arming.
+    if (!visible) {
+      armedRef.current = false;
+      return;
+    }
+    if (armedRef.current) return;
     armedRef.current = true;
     markEdgeTapHintSeen();
     const id = window.setTimeout(() => setDismissed(true), VISIBLE_MS);

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -61,6 +61,8 @@ function SceneContent() {
   const selectedCode = useGlobeChart((s) => s.selectedCountry);
   const reducedMotion = usePrefersReducedMotion();
   const readMode = useGlobeChart((s) => s.readMode);
+  const listening = useGlobeChart((s) => s.listening);
+  const skip = useGlobeChart((s) => s.skip);
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
@@ -127,6 +129,8 @@ function SceneContent() {
         fair={SPIN_FAIR}
         visited={visited}
         readMode={readMode}
+        listening={listening}
+        onSkip={skip}
         onSettle={handleSettle}
       />
     </>

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -65,11 +65,14 @@ function SceneContent() {
   const skip = useGlobeChart((s) => s.skip);
 
   // Route the edge-tap skip and signal the directional cue from one place: the
-  // decision still lives in the controls, this only forwards and flashes.
+  // decision still lives in the controls; this forwards, then flashes only when
+  // a track actually changed.
   const handleSkip = useCallback(
     (dir: 1 | -1) => {
-      skip(dir);
-      globeChartStore.getState().signalSkip(dir);
+      // step clamps (returns false) at the first/last playable track, mirroring
+      // the mini-player's disabled prev/next, so the cue never claims a skip
+      // that didn't happen.
+      if (skip(dir)) globeChartStore.getState().signalSkip(dir);
     },
     [skip],
   );

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -61,21 +61,6 @@ function SceneContent() {
   const selectedCode = useGlobeChart((s) => s.selectedCountry);
   const reducedMotion = usePrefersReducedMotion();
   const readMode = useGlobeChart((s) => s.readMode);
-  const listening = useGlobeChart((s) => s.listening);
-  const skip = useGlobeChart((s) => s.skip);
-
-  // Route the edge-tap skip and signal the directional cue from one place: the
-  // decision still lives in the controls; this forwards, then flashes only when
-  // a track actually changed.
-  const handleSkip = useCallback(
-    (dir: 1 | -1) => {
-      // step clamps (returns false) at the first/last playable track, mirroring
-      // the mini-player's disabled prev/next, so the cue never claims a skip
-      // that didn't happen.
-      if (skip(dir)) globeChartStore.getState().signalSkip(dir);
-    },
-    [skip],
-  );
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
@@ -142,8 +127,6 @@ function SceneContent() {
         fair={SPIN_FAIR}
         visited={visited}
         readMode={readMode}
-        listening={listening}
-        onSkip={handleSkip}
         onSettle={handleSettle}
       />
     </>

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -64,6 +64,16 @@ function SceneContent() {
   const listening = useGlobeChart((s) => s.listening);
   const skip = useGlobeChart((s) => s.skip);
 
+  // Route the edge-tap skip and signal the directional cue from one place: the
+  // decision still lives in the controls, this only forwards and flashes.
+  const handleSkip = useCallback(
+    (dir: 1 | -1) => {
+      skip(dir);
+      globeChartStore.getState().signalSkip(dir);
+    },
+    [skip],
+  );
+
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
     hoveredCode !== null && hoveredCode !== selectedCode
@@ -130,7 +140,7 @@ function SceneContent() {
         visited={visited}
         readMode={readMode}
         listening={listening}
-        onSkip={skip}
+        onSkip={handleSkip}
         onSettle={handleSettle}
       />
     </>

--- a/src/components/globe/seen-edge-tap-hint.ts
+++ b/src/components/globe/seen-edge-tap-hint.ts
@@ -1,0 +1,39 @@
+// One-time gate for the edge-tap-to-skip cue, persisted across sessions and kept
+// separate from the other hint flags so each surfaces on its own schedule. The
+// :v1 suffix lets a redesigned hint re-trigger everyone by bumping the key, with
+// no migration code, mirroring the tour and commentary flags.
+const SEEN_KEY = "sounds-abroad:edge-tap-hint-seen:v1";
+
+type HintStorage = Pick<Storage, "getItem" | "setItem">;
+
+function defaultStorage(): HintStorage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    // Touching localStorage can throw outright (sandboxed iframe, hard-blocked
+    // cookies), not just on read. Treat that as "no storage".
+    return null;
+  }
+}
+
+// Reads tolerantly: any failure means "not seen", so a storage hiccup lets the
+// hint run rather than silently suppressing it.
+export function hasSeenEdgeTapHint(storage = defaultStorage()): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(SEEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+// Best-effort write: if persisting fails (quota, private mode), the worst case
+// is the hint shows again next visit, which is harmless.
+export function markEdgeTapHintSeen(storage = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(SEEN_KEY, "1");
+  } catch {
+    return;
+  }
+}

--- a/src/components/globe/skip-flash.tsx
+++ b/src/components/globe/skip-flash.tsx
@@ -8,8 +8,8 @@ import { useGlobeChart } from "@/lib/globe-chart-store";
 // Tune the skip cue here: how long the chevron stays on screen and how far it
 // slides toward the tapped edge. Kept brief so it confirms the skip without
 // pulling the eye off the globe.
-const FLASH_MS = 340;
-const TRAVEL_PX = 20;
+const FLASH_MS = 460;
+const TRAVEL_PX = 24;
 
 // A transient directional chevron on the tapped globe edge confirms a track
 // skip (next = right, prev = left): it fades in, slides toward that edge, and
@@ -43,16 +43,18 @@ export function SkipFlash() {
 
   const isNext = flash.dir === 1;
   return (
+    // The box spans the globe area above the peek sheet (~top 65%), so the cue
+    // centers on visible globe rather than the viewport middle the sheet crowds.
     <div
       aria-hidden
-      className={`pointer-events-none fixed inset-y-0 right-0 left-0 z-40 flex items-center px-5 ${
+      className={`pointer-events-none fixed top-0 right-0 bottom-[35%] left-0 z-40 flex items-center px-5 ${
         isNext ? "justify-end" : "justify-start"
       }`}
     >
       <span
         key={flash.nonce}
         data-dir={isNext ? "next" : "prev"}
-        className="skip-flash text-sunrise"
+        className="skip-flash text-aurora"
         style={
           {
             "--skip-flash-dur": `${FLASH_MS}ms`,
@@ -61,7 +63,8 @@ export function SkipFlash() {
         }
       >
         <ChevronsRightIcon
-          className={`h-10 w-10 ${isNext ? "" : "-scale-x-100"}`}
+          strokeWidth={2.5}
+          className={`h-16 w-16 ${isNext ? "" : "-scale-x-100"}`}
         />
       </span>
     </div>

--- a/src/components/globe/skip-flash.tsx
+++ b/src/components/globe/skip-flash.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { type CSSProperties, useEffect, useRef, useState } from "react";
+
+import { ChevronsRightIcon } from "@/components/icons/chevrons-right";
+import { useGlobeChart } from "@/lib/globe-chart-store";
+
+// Tune the skip cue here: how long the chevron stays on screen and how far it
+// slides toward the tapped edge. Kept brief so it confirms the skip without
+// pulling the eye off the globe.
+const FLASH_MS = 340;
+const TRAVEL_PX = 20;
+
+// A transient directional chevron on the tapped globe edge confirms a track
+// skip (next = right, prev = left): it fades in, slides toward that edge, and
+// fades out. It stays an overlay, never a globe rotation, so "skip a song" reads
+// distinct from rotating to a country. Pointer-transparent so it never blocks
+// the taps below it; reduced motion drops the slide for a plain opacity flash
+// (handled in globals.css, matching the tour/hint idiom).
+export function SkipFlash() {
+  const skipSignal = useGlobeChart((s) => s.skipSignal);
+  const prevNonceRef = useRef(skipSignal.nonce);
+  const [flash, setFlash] = useState<{ dir: 1 | -1; nonce: number } | null>(
+    null,
+  );
+
+  // Ref-gated so only an actual skip (a bumped nonce) plays the cue, never a
+  // dep-only re-run or the mount baseline.
+  useEffect(() => {
+    if (skipSignal.nonce === prevNonceRef.current) return;
+    prevNonceRef.current = skipSignal.nonce;
+    setFlash({ dir: skipSignal.dir, nonce: skipSignal.nonce });
+  }, [skipSignal]);
+
+  // Clear after the animation; keyed on the flash so a fresh skip resets it.
+  useEffect(() => {
+    if (!flash) return;
+    const id = window.setTimeout(() => setFlash(null), FLASH_MS);
+    return () => window.clearTimeout(id);
+  }, [flash]);
+
+  if (!flash) return null;
+
+  const isNext = flash.dir === 1;
+  return (
+    <div
+      aria-hidden
+      className={`pointer-events-none fixed inset-y-0 right-0 left-0 z-40 flex items-center px-5 ${
+        isNext ? "justify-end" : "justify-start"
+      }`}
+    >
+      <span
+        key={flash.nonce}
+        data-dir={isNext ? "next" : "prev"}
+        className="skip-flash text-sunrise"
+        style={
+          {
+            "--skip-flash-dur": `${FLASH_MS}ms`,
+            "--skip-flash-travel": `${TRAVEL_PX}px`,
+          } as CSSProperties
+        }
+      >
+        <ChevronsRightIcon
+          className={`h-10 w-10 ${isNext ? "" : "-scale-x-100"}`}
+        />
+      </span>
+    </div>
+  );
+}

--- a/src/components/globe/skip-flash.tsx
+++ b/src/components/globe/skip-flash.tsx
@@ -2,6 +2,7 @@
 
 import { type CSSProperties, useEffect, useRef, useState } from "react";
 
+import { type SnapState } from "@/components/chart-sheet/sheet";
 import { ChevronsRightIcon } from "@/components/icons/chevrons-right";
 import { useGlobeChart } from "@/lib/globe-chart-store";
 
@@ -11,13 +12,23 @@ import { useGlobeChart } from "@/lib/globe-chart-store";
 const FLASH_MS = 460;
 const TRAVEL_PX = 24;
 
+// Vertical center of the cue = middle of the globe visible above the sheet. The
+// sheet's top edge sits near SNAP_Y% of the viewport, so the box bottom is the
+// covered fraction (100% - SNAP_Y%): peek leaves 35%, closed 10%, hidden 0%.
+const COVER_BOTTOM: Record<SnapState, string> = {
+  full: "0%",
+  peek: "35%",
+  closed: "10%",
+  hidden: "0%",
+};
+
 // A transient directional chevron on the tapped globe edge confirms a track
 // skip (next = right, prev = left): it fades in, slides toward that edge, and
 // fades out. It stays an overlay, never a globe rotation, so "skip a song" reads
 // distinct from rotating to a country. Pointer-transparent so it never blocks
 // the taps below it; reduced motion drops the slide for a plain opacity flash
 // (handled in globals.css, matching the tour/hint idiom).
-export function SkipFlash() {
+export function SkipFlash({ sheetSnap }: { sheetSnap: SnapState }) {
   const skipSignal = useGlobeChart((s) => s.skipSignal);
   const prevNonceRef = useRef(skipSignal.nonce);
   const [flash, setFlash] = useState<{ dir: 1 | -1; nonce: number } | null>(
@@ -43,11 +54,13 @@ export function SkipFlash() {
 
   const isNext = flash.dir === 1;
   return (
-    // The box spans the globe area above the peek sheet (~top 65%), so the cue
-    // centers on visible globe rather than the viewport middle the sheet crowds.
+    // The box spans the globe visible above the sheet (bottom tracks the snap),
+    // so the cue centers on visible globe, not the viewport middle the sheet
+    // crowds at peek.
     <div
       aria-hidden
-      className={`pointer-events-none fixed top-0 right-0 bottom-[35%] left-0 z-40 flex items-center px-5 ${
+      style={{ bottom: COVER_BOTTOM[sheetSnap] }}
+      className={`pointer-events-none fixed top-0 right-0 left-0 z-40 flex items-center px-5 ${
         isNext ? "justify-end" : "justify-start"
       }`}
     >

--- a/src/components/globe/skip-flash.tsx
+++ b/src/components/globe/skip-flash.tsx
@@ -2,7 +2,7 @@
 
 import { type CSSProperties, useEffect, useRef, useState } from "react";
 
-import { type SnapState } from "@/components/chart-sheet/sheet";
+import { SNAP_Y_PCT, type SnapState } from "@/components/chart-sheet/sheet";
 import { ChevronsRightIcon } from "@/components/icons/chevrons-right";
 import { useGlobeChart } from "@/lib/globe-chart-store";
 
@@ -11,16 +11,6 @@ import { useGlobeChart } from "@/lib/globe-chart-store";
 // pulling the eye off the globe.
 const FLASH_MS = 460;
 const TRAVEL_PX = 24;
-
-// Vertical center of the cue = middle of the globe visible above the sheet. The
-// sheet's top edge sits near SNAP_Y% of the viewport, so the box bottom is the
-// covered fraction (100% - SNAP_Y%): peek leaves 35%, closed 10%, hidden 0%.
-const COVER_BOTTOM: Record<SnapState, string> = {
-  full: "0%",
-  peek: "35%",
-  closed: "10%",
-  hidden: "0%",
-};
 
 // A transient directional chevron on the tapped globe edge confirms a track
 // skip (next = right, prev = left): it fades in, slides toward that edge, and
@@ -54,24 +44,26 @@ export function SkipFlash({ sheetSnap }: { sheetSnap: SnapState }) {
 
   const isNext = flash.dir === 1;
   return (
-    // The box spans the globe visible above the sheet (bottom tracks the snap),
-    // so the cue centers on visible globe, not the viewport middle the sheet
-    // crowds at peek.
     <div
       aria-hidden
-      style={{ bottom: COVER_BOTTOM[sheetSnap] }}
+      style={{
+        // Bottom tracks the sheet: its top edge sits near SNAP_Y% of the
+        // viewport, so the covered fraction below is 100 - SNAP_Y% (full covers
+        // all, so bottom 0). Centers the cue on visible globe, not the viewport
+        // middle the sheet crowds at peek.
+        bottom: sheetSnap === "full" ? "0%" : `${100 - SNAP_Y_PCT[sheetSnap]}%`,
+      }}
       className={`pointer-events-none fixed top-0 right-0 left-0 z-40 flex items-center px-5 ${
         isNext ? "justify-end" : "justify-start"
       }`}
     >
       <span
         key={flash.nonce}
-        data-dir={isNext ? "next" : "prev"}
         className="skip-flash text-aurora"
         style={
           {
             "--skip-flash-dur": `${FLASH_MS}ms`,
-            "--skip-flash-travel": `${TRAVEL_PX}px`,
+            "--skip-flash-travel": `${isNext ? TRAVEL_PX : -TRAVEL_PX}px`,
           } as CSSProperties
         }
       >

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -11,7 +11,7 @@ import {
   pickSnapCountry,
   projectFrontCountries,
 } from "./spin-select";
-import { isTap } from "./tap-detect";
+import { horizontalThird, isTap } from "./tap-detect";
 
 const DEG = Math.PI / 180;
 const RADIUS = 3.5;
@@ -46,6 +46,10 @@ interface SpinSnapControlsProps {
   fair: boolean;
   visited: ReadonlySet<string>;
   readMode: boolean;
+  // A track is playing: a no-movement tap on the left/right third skips instead
+  // of selecting. Off (no track) keeps every tap selecting a country.
+  listening: boolean;
+  onSkip: (dir: 1 | -1) => void;
   // `changed` is false when the settle re-lands the country already shown, so
   // the caller can fire on every settle but gate country-change side effects.
   onSettle: (code: string, changed: boolean) => void;
@@ -66,6 +70,8 @@ export function SpinSnapControls({
   fair,
   visited,
   readMode,
+  listening,
+  onSkip,
   onSettle,
 }: SpinSnapControlsProps) {
   const camera = useThree((s) => s.camera);
@@ -80,6 +86,8 @@ export function SpinSnapControls({
     visited,
     reducedMotion,
     readMode,
+    listening,
+    onSkip,
   });
   const onSettleRef = useRef(onSettle);
 
@@ -95,6 +103,8 @@ export function SpinSnapControls({
       visited,
       reducedMotion,
       readMode,
+      listening,
+      onSkip,
     };
     onSettleRef.current = onSettle;
   });
@@ -237,6 +247,22 @@ export function SpinSnapControls({
         )
       ) {
         const rect = el.getBoundingClientRect();
+
+        // While listening, an edge tap skips: left third -> prev, right third ->
+        // next. The center third falls through to the usual select-nearest. A
+        // drag never reaches here (isTap above gates it), so spinning is intact.
+        if (cfg.current.listening) {
+          const third = horizontalThird(e.clientX - rect.left, rect.width);
+          if (third === "left") {
+            cfg.current.onSkip(-1);
+            return;
+          }
+          if (third === "right") {
+            cfg.current.onSkip(1);
+            return;
+          }
+        }
+
         const candidates = projectFrontCountries(
           camera,
           rect.width,

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -11,7 +11,7 @@ import {
   pickSnapCountry,
   projectFrontCountries,
 } from "./spin-select";
-import { horizontalThird, isTap } from "./tap-detect";
+import { classifyTap, horizontalThird, isTap } from "./tap-detect";
 
 const DEG = Math.PI / 180;
 const RADIUS = 3.5;
@@ -21,6 +21,7 @@ const SETTLE_VEL = 2; // rad/s under which a fling hands off to the snap spring
 const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
 const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
 const TAP_HIT_PX = 44; // a tap beyond this from every country pin selects nothing
+const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips; the only added tap latency
 
 const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
 
@@ -90,6 +91,12 @@ export function SpinSnapControls({
     onSkip,
   });
   const onSettleRef = useRef(onSettle);
+
+  // A side-third tap while listening defers its select by one double-tap window
+  // so a second tap can cancel it into a skip. These hold that pending timer and
+  // the time of the tap that armed it; cleared on a new press and on unmount.
+  const pendingSelect = useRef<number | null>(null);
+  const lastEdgeTapAt = useRef<number | null>(null);
 
   // Keep the long-lived pointer handlers and per-frame loop reading the latest
   // props without re-subscribing. Written in an effect, never during render.
@@ -196,9 +203,19 @@ export function SpinSnapControls({
       dragging: false,
     };
 
+    const clearPendingSelect = () => {
+      if (pendingSelect.current !== null) {
+        window.clearTimeout(pendingSelect.current);
+        pendingSelect.current = null;
+      }
+    };
+
     const onDown = (e: PointerEvent) => {
       // Read mode covers the globe; ignore presses so reading never grabs it.
       if (cfg.current.readMode) return;
+      // Cancel a deferred edge-tap select so it can't fire mid-gesture; the
+      // armed window survives this press so a second tap can still skip.
+      clearPendingSelect();
       const s = sim.current;
       s.mode = "drag";
       s.vAz = 0;
@@ -247,39 +264,63 @@ export function SpinSnapControls({
         )
       ) {
         const rect = el.getBoundingClientRect();
+        const cx = e.clientX;
+        const cy = e.clientY;
+        const region = horizontalThird(cx - rect.left, rect.width);
 
-        // While listening, an edge tap skips: left third -> prev, right third ->
-        // next. The center third falls through to the usual select-nearest. A
-        // drag never reaches here (isTap above gates it), so spinning is intact.
-        if (cfg.current.listening) {
-          const third = horizontalThird(e.clientX - rect.left, rect.width);
-          if (third === "left") {
-            cfg.current.onSkip(-1);
-            return;
-          }
-          if (third === "right") {
-            cfg.current.onSkip(1);
-            return;
-          }
+        // Select the nearest country, re-centring the current one on a miss so a
+        // tap on open ocean never jumps away. Coordinates are captured now, not
+        // read in the timer, so a deferred run still aims at the tap point.
+        const runSelect = () => {
+          lastEdgeTapAt.current = null;
+          const candidates = projectFrontCountries(
+            camera,
+            rect.width,
+            rect.height,
+          );
+          const hit = pickNearestToPoint(
+            candidates,
+            cx - rect.left,
+            cy - rect.top,
+            TAP_HIT_PX,
+          );
+          settleTo(hit ?? sim.current.settledCode);
+        };
+
+        const action = classifyTap({
+          listening: cfg.current.listening,
+          region,
+          now: e.timeStamp,
+          lastEdgeTapAt: lastEdgeTapAt.current,
+          windowMs: DOUBLE_TAP_MS,
+        });
+
+        if (action.kind === "skip") {
+          // A second side-third tap within the window: drop the first tap's
+          // pending select and skip instead.
+          clearPendingSelect();
+          lastEdgeTapAt.current = null;
+          cfg.current.onSkip(action.dir);
+          return;
         }
 
-        const candidates = projectFrontCountries(
-          camera,
-          rect.width,
-          rect.height,
-        );
-        const hit = pickNearestToPoint(
-          candidates,
-          e.clientX - rect.left,
-          e.clientY - rect.top,
-          TAP_HIT_PX,
-        );
-        // A tap that lands on no country re-centres the current one, so a
-        // mis-aim on open ocean does nothing rather than jumping away.
-        settleTo(hit ?? s.settledCode);
+        if (action.kind === "deferSelect") {
+          // First side-third tap while listening: hold one window for a second
+          // tap to make it a skip; select if none comes. The only added latency.
+          clearPendingSelect();
+          lastEdgeTapAt.current = e.timeStamp;
+          pendingSelect.current = window.setTimeout(runSelect, DOUBLE_TAP_MS);
+          return;
+        }
+
+        // Center third or no preview: a double-tap has no skip meaning, so
+        // select with no delay and arm no window.
+        runSelect();
         return;
       }
 
+      // A fling is a fresh intent: drop any armed double-tap window.
+      lastEdgeTapAt.current = null;
       const sens = cfg.current.sensitivity;
       s.vAz = -flickToSpin(g.vx) * sens;
       s.vEl = cfg.current.horizontalLock ? 0 : flickToSpin(g.vy) * sens;
@@ -293,6 +334,9 @@ export function SpinSnapControls({
       if (!g.dragging) return;
       g.dragging = false;
       el.releasePointerCapture?.(e.pointerId);
+      // An abandoned gesture ends any armed double-tap window too.
+      clearPendingSelect();
+      lastEdgeTapAt.current = null;
       const s = sim.current;
       settleTo(
         pickSnapCountry(s.el, s.az, cfg.current.visited, cfg.current.fair),
@@ -304,6 +348,7 @@ export function SpinSnapControls({
     el.addEventListener("pointerup", onUp);
     el.addEventListener("pointercancel", onCancel);
     return () => {
+      clearPendingSelect();
       el.removeEventListener("pointerdown", onDown);
       el.removeEventListener("pointermove", onMove);
       el.removeEventListener("pointerup", onUp);

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 
 import { COUNTRIES } from "@/lib/countries";
+import { globeChartStore } from "@/lib/globe-chart-store";
 
 import { flickToSpin } from "./spin-feel";
 import {
@@ -21,7 +22,11 @@ const SETTLE_VEL = 2; // rad/s under which a fling hands off to the snap spring
 const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
 const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
 const TAP_HIT_PX = 44; // a tap beyond this from every country pin selects nothing
-const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips; the only added tap latency
+const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips
+// Deferred-select delay: waits past the double-tap window (longer than
+// DOUBLE_TAP_MS) so main-thread jank can't fire the select before a second
+// tap's pointerup and misclassify a skip as a select.
+const SELECT_DEFER_MS = 360;
 
 const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
 
@@ -47,10 +52,6 @@ interface SpinSnapControlsProps {
   fair: boolean;
   visited: ReadonlySet<string>;
   readMode: boolean;
-  // A track is playing: a no-movement tap on the left/right third skips instead
-  // of selecting. Off (no track) keeps every tap selecting a country.
-  listening: boolean;
-  onSkip: (dir: 1 | -1) => void;
   // `changed` is false when the settle re-lands the country already shown, so
   // the caller can fire on every settle but gate country-change side effects.
   onSettle: (code: string, changed: boolean) => void;
@@ -71,8 +72,6 @@ export function SpinSnapControls({
   fair,
   visited,
   readMode,
-  listening,
-  onSkip,
   onSettle,
 }: SpinSnapControlsProps) {
   const camera = useThree((s) => s.camera);
@@ -87,8 +86,6 @@ export function SpinSnapControls({
     visited,
     reducedMotion,
     readMode,
-    listening,
-    onSkip,
   });
   const onSettleRef = useRef(onSettle);
 
@@ -97,6 +94,15 @@ export function SpinSnapControls({
   // the time of the tap that armed it; cleared on a new press and on unmount.
   const pendingSelect = useRef<number | null>(null);
   const lastEdgeTapAt = useRef<number | null>(null);
+
+  // Cancel a pending deferred edge-tap select. Shared by the pointer handlers
+  // and the external-selection effect.
+  const clearPendingSelect = useCallback(() => {
+    if (pendingSelect.current !== null) {
+      window.clearTimeout(pendingSelect.current);
+      pendingSelect.current = null;
+    }
+  }, []);
 
   // Keep the long-lived pointer handlers and per-frame loop reading the latest
   // props without re-subscribing. Written in an effect, never during render.
@@ -110,8 +116,6 @@ export function SpinSnapControls({
       visited,
       reducedMotion,
       readMode,
-      listening,
-      onSkip,
     };
     onSettleRef.current = onSettle;
   });
@@ -181,9 +185,11 @@ export function SpinSnapControls({
   // the time this runs — it no-ops, no feedback loop.
   useEffect(() => {
     if (targetCode && targetCode !== sim.current.settledCode) {
+      // An external ?cc= selection cancels any armed edge-tap select.
+      clearPendingSelect();
       settleTo(targetCode);
     }
-  }, [targetCode]);
+  }, [targetCode, clearPendingSelect]);
 
   useEffect(() => {
     const el = gl.domElement;
@@ -201,13 +207,6 @@ export function SpinSnapControls({
       vx: 0,
       vy: 0,
       dragging: false,
-    };
-
-    const clearPendingSelect = () => {
-      if (pendingSelect.current !== null) {
-        window.clearTimeout(pendingSelect.current);
-        pendingSelect.current = null;
-      }
     };
 
     const onDown = (e: PointerEvent) => {
@@ -272,6 +271,10 @@ export function SpinSnapControls({
         // tap on open ocean never jumps away. Coordinates are captured now, not
         // read in the timer, so a deferred run still aims at the tap point.
         const runSelect = () => {
+          // Bail if the situation changed while armed: read mode forbids moving
+          // the globe under the reader, and mode "settle" means an external ?cc=
+          // already landed the globe during the window.
+          if (cfg.current.readMode || sim.current.mode === "settle") return;
           lastEdgeTapAt.current = null;
           const candidates = projectFrontCountries(
             camera,
@@ -288,7 +291,7 @@ export function SpinSnapControls({
         };
 
         const action = classifyTap({
-          listening: cfg.current.listening,
+          listening: globeChartStore.getState().listening,
           region,
           now: e.timeStamp,
           lastEdgeTapAt: lastEdgeTapAt.current,
@@ -300,16 +303,22 @@ export function SpinSnapControls({
           // pending select and skip instead.
           clearPendingSelect();
           lastEdgeTapAt.current = null;
-          cfg.current.onSkip(action.dir);
+          // A skip moves no globe, so return the machine to rest instead of
+          // leaving it at "drag" from the press.
+          s.mode = "idle";
+          // Skip via the chart's adjacency owner; flash only on a real change.
+          if (globeChartStore.getState().skip(action.dir))
+            globeChartStore.getState().signalSkip(action.dir);
           return;
         }
 
         if (action.kind === "deferSelect") {
-          // First side-third tap while listening: hold one window for a second
-          // tap to make it a skip; select if none comes. The only added latency.
+          // First side-third tap while listening: defer the select past the
+          // double-tap window so a second tap can turn it into a skip; select if
+          // none comes.
           clearPendingSelect();
           lastEdgeTapAt.current = e.timeStamp;
-          pendingSelect.current = window.setTimeout(runSelect, DOUBLE_TAP_MS);
+          pendingSelect.current = window.setTimeout(runSelect, SELECT_DEFER_MS);
           return;
         }
 
@@ -349,12 +358,13 @@ export function SpinSnapControls({
     el.addEventListener("pointercancel", onCancel);
     return () => {
       clearPendingSelect();
+      lastEdgeTapAt.current = null;
       el.removeEventListener("pointerdown", onDown);
       el.removeEventListener("pointermove", onMove);
       el.removeEventListener("pointerup", onUp);
       el.removeEventListener("pointercancel", onCancel);
     };
-  }, [gl, camera]);
+  }, [gl, camera, clearPendingSelect]);
 
   useFrame((_, dt) => {
     const s = sim.current;

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -185,8 +185,11 @@ export function SpinSnapControls({
   // the time this runs — it no-ops, no feedback loop.
   useEffect(() => {
     if (targetCode && targetCode !== sim.current.settledCode) {
-      // An external ?cc= selection cancels any armed edge-tap select.
+      // An external ?cc= selection cancels any armed edge-tap select, clearing
+      // both the timer and the arm window (matching onCancel / the skip branch)
+      // so a following tap isn't misread as a double-tap's second tap.
       clearPendingSelect();
+      lastEdgeTapAt.current = null;
       settleTo(targetCode);
     }
   }, [targetCode, clearPendingSelect]);

--- a/src/components/globe/tap-detect.test.ts
+++ b/src/components/globe/tap-detect.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 
-import { isTap } from "./tap-detect";
+import { horizontalThird, isTap } from "./tap-detect";
 
 const MAX = 8;
 
@@ -18,4 +18,26 @@ test("isTap treats a release beyond the tolerance as a spin", () => {
 
 test("isTap measures straight-line distance, not per-axis", () => {
   expect(isTap({ x: 100, y: 100 }, { x: 106, y: 106 }, MAX)).toBe(false);
+});
+
+const WIDTH = 300;
+
+test("horizontalThird reads a point in the first third as left", () => {
+  expect(horizontalThird(50, WIDTH)).toBe("left");
+});
+
+test("horizontalThird reads a point in the middle third as center", () => {
+  expect(horizontalThird(150, WIDTH)).toBe("center");
+});
+
+test("horizontalThird reads a point in the last third as right", () => {
+  expect(horizontalThird(250, WIDTH)).toBe("right");
+});
+
+test("horizontalThird leans the left boundary into the center", () => {
+  expect(horizontalThird(WIDTH / 3, WIDTH)).toBe("center");
+});
+
+test("horizontalThird leans the right boundary into the right zone", () => {
+  expect(horizontalThird((WIDTH * 2) / 3, WIDTH)).toBe("right");
 });

--- a/src/components/globe/tap-detect.test.ts
+++ b/src/components/globe/tap-detect.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 
-import { horizontalThird, isTap } from "./tap-detect";
+import { classifyTap, horizontalThird, isTap } from "./tap-detect";
 
 const MAX = 8;
 
@@ -40,4 +40,94 @@ test("horizontalThird leans the left boundary into the center", () => {
 
 test("horizontalThird leans the right boundary into the right zone", () => {
   expect(horizontalThird((WIDTH * 2) / 3, WIDTH)).toBe("right");
+});
+
+const WINDOW = 280;
+
+test("classifyTap selects immediately for a center tap while listening", () => {
+  const action = classifyTap({
+    listening: true,
+    region: "center",
+    now: 1000,
+    lastEdgeTapAt: null,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "select" });
+});
+
+test("classifyTap selects immediately for a side tap when not listening", () => {
+  const action = classifyTap({
+    listening: false,
+    region: "left",
+    now: 1000,
+    lastEdgeTapAt: 900,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "select" });
+});
+
+test("classifyTap defers a first side tap while listening", () => {
+  const action = classifyTap({
+    listening: true,
+    region: "right",
+    now: 1000,
+    lastEdgeTapAt: null,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "deferSelect" });
+});
+
+test("classifyTap skips back on a second left tap within the window", () => {
+  const first = 1000;
+  const action = classifyTap({
+    listening: true,
+    region: "left",
+    now: first + WINDOW - 1,
+    lastEdgeTapAt: first,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "skip", dir: -1 });
+});
+
+test("classifyTap skips forward on a second right tap within the window", () => {
+  const first = 1000;
+  const action = classifyTap({
+    listening: true,
+    region: "right",
+    now: first + WINDOW - 1,
+    lastEdgeTapAt: first,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "skip", dir: 1 });
+});
+
+test("classifyTap counts a second tap exactly at the window edge as a skip", () => {
+  const first = 1000;
+  const action = classifyTap({
+    listening: true,
+    region: "right",
+    now: first + WINDOW,
+    lastEdgeTapAt: first,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "skip", dir: 1 });
+});
+
+test("classifyTap defers again once the window has elapsed", () => {
+  const first = 1000;
+  const action = classifyTap({
+    listening: true,
+    region: "left",
+    now: first + WINDOW + 1,
+    lastEdgeTapAt: first,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "deferSelect" });
 });

--- a/src/components/globe/tap-detect.ts
+++ b/src/components/globe/tap-detect.ts
@@ -17,12 +17,43 @@ export function isTap(start: Point, end: Point, maxPx: number): boolean {
 
 export type HorizontalThird = "left" | "center" | "right";
 
-// Which horizontal third of a `width`-wide viewport the point `x` falls in. In
-// listening mode the caller maps left->prev and right->next, leaving the center
-// third to the default select-country tap. Boundaries lean toward the center so
-// the side zones never overrun the middle.
+// Which horizontal third of a `width`-wide viewport the point `x` falls in. The
+// caller treats the side thirds as skip zones (left->prev, right->next) and the
+// center as plain select. Boundaries lean toward the center so the side zones
+// never overrun the middle.
 export function horizontalThird(x: number, width: number): HorizontalThird {
   if (x < width / 3) return "left";
   if (x >= (width * 2) / 3) return "right";
   return "center";
+}
+
+// What a settled tap should do: skip a track, select immediately, or hold the
+// select for one double-tap window. A skip needs a preview playing and two taps
+// in a side third within `windowMs`; the second tap's side picks the direction.
+export type TapAction =
+  | { kind: "skip"; dir: 1 | -1 }
+  | { kind: "select" }
+  | { kind: "deferSelect" };
+
+// Single-tap selects everywhere, so the side thirds keep no dead zone. The skip
+// gesture is a layer on top: a side-third tap while listening defers, and a
+// second side-third tap within the window turns the pair into a skip. A center
+// tap or a tap with no preview has no skip meaning, so it selects with no delay.
+// `lastEdgeTapAt` is the time of the prior deferred side tap, or null.
+export function classifyTap(args: {
+  listening: boolean;
+  region: HorizontalThird;
+  now: number;
+  lastEdgeTapAt: number | null;
+  windowMs: number;
+}): TapAction {
+  const { listening, region, now, lastEdgeTapAt, windowMs } = args;
+
+  if (!listening || region === "center") return { kind: "select" };
+
+  if (lastEdgeTapAt !== null && now - lastEdgeTapAt <= windowMs) {
+    return { kind: "skip", dir: region === "left" ? -1 : 1 };
+  }
+
+  return { kind: "deferSelect" };
 }

--- a/src/components/globe/tap-detect.ts
+++ b/src/components/globe/tap-detect.ts
@@ -14,3 +14,15 @@ export function isTap(start: Point, end: Point, maxPx: number): boolean {
 
   return Math.hypot(dx, dy) <= maxPx;
 }
+
+export type HorizontalThird = "left" | "center" | "right";
+
+// Which horizontal third of a `width`-wide viewport the point `x` falls in. In
+// listening mode the caller maps left->prev and right->next, leaving the center
+// third to the default select-country tap. Boundaries lean toward the center so
+// the side zones never overrun the middle.
+export function horizontalThird(x: number, width: number): HorizontalThird {
+  if (x < width / 3) return "left";
+  if (x >= (width * 2) / 3) return "right";
+  return "center";
+}

--- a/src/components/icons/chevrons-right.tsx
+++ b/src/components/icons/chevrons-right.tsx
@@ -1,0 +1,20 @@
+import type { SVGProps } from "react";
+
+export function ChevronsRightIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="m6 17 5-5-5-5" />
+      <path d="m13 17 5-5-5-5" />
+    </svg>
+  );
+}

--- a/src/lib/globe-chart-store.test.ts
+++ b/src/lib/globe-chart-store.test.ts
@@ -8,6 +8,8 @@ describe("globeChartStore", () => {
       readMode: false,
       settleSignal: 0,
       skipSignal: { dir: 1, nonce: 0 },
+      listening: false,
+      skip: () => false,
     });
   });
 

--- a/src/lib/globe-chart-store.test.ts
+++ b/src/lib/globe-chart-store.test.ts
@@ -4,7 +4,11 @@ import { globeChartStore } from "./globe-chart-store";
 
 describe("globeChartStore", () => {
   beforeEach(() => {
-    globeChartStore.setState({ readMode: false, settleSignal: 0 });
+    globeChartStore.setState({
+      readMode: false,
+      settleSignal: 0,
+      skipSignal: { dir: 1, nonce: 0 },
+    });
   });
 
   test("starts out of read mode with no settle yet", () => {
@@ -24,5 +28,21 @@ describe("globeChartStore", () => {
     globeChartStore.getState().signalSettle();
     globeChartStore.getState().signalSettle();
     expect(globeChartStore.getState().settleSignal).toBe(2);
+  });
+
+  test("signalSkip records the direction and bumps the nonce", () => {
+    globeChartStore.getState().signalSkip(-1);
+
+    expect(globeChartStore.getState().skipSignal).toEqual({
+      dir: -1,
+      nonce: 1,
+    });
+  });
+
+  test("signalSkip bumps the nonce on a repeated direction so the cue replays", () => {
+    globeChartStore.getState().signalSkip(1);
+    globeChartStore.getState().signalSkip(1);
+
+    expect(globeChartStore.getState().skipSignal).toEqual({ dir: 1, nonce: 2 });
   });
 });

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -21,19 +21,34 @@ export interface GlobeChartState {
   // raise a dismissed sheet, so re-landing on the same country still raises
   // (a plain ?cc= diff would miss that).
   settleSignal: number;
+  // A track is loaded (the "listening" state), so a no-movement tap on the globe
+  // edge skips a track instead of selecting a country. The audio store lives in
+  // the page's provider, which the layout-backdrop globe can't read, so the
+  // chart mirrors the gate here alongside selectedCountry.
+  listening: boolean;
+  // Routes a globe edge-tap to the chart's shared prev/next (dir -1/+1), the one
+  // place that owns the adjacency logic. Default no-op until the chart publishes
+  // it, so calling before a track plays is safe.
+  skip: (dir: 1 | -1) => void;
   setSelectedCountry: (code: string | null) => void;
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
+  setListening: (listening: boolean) => void;
+  setSkip: (skip: (dir: 1 | -1) => void) => void;
 }
 
 export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   selectedCountry: null,
   readMode: false,
   settleSignal: 0,
+  listening: false,
+  skip: () => {},
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),
   signalSettle: () =>
     set((state) => ({ settleSignal: state.settleSignal + 1 })),
+  setListening: (listening) => set({ listening }),
+  setSkip: (skip) => set({ skip }),
 }));
 
 export function useGlobeChart<T>(selector: (state: GlobeChartState) => T): T {

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -27,9 +27,10 @@ export interface GlobeChartState {
   // chart mirrors the gate here alongside selectedCountry.
   listening: boolean;
   // Routes a globe edge-tap to the chart's shared prev/next (dir -1/+1), the one
-  // place that owns the adjacency logic. Default no-op until the chart publishes
-  // it, so calling before a track plays is safe.
-  skip: (dir: 1 | -1) => void;
+  // place that owns the adjacency logic. Returns whether a track actually
+  // changed (false when it clamps at the first/last playable track) so the cue
+  // only flashes on a real skip. Default no-op until the chart publishes it.
+  skip: (dir: 1 | -1) => boolean;
   // One-shot cue for the directional skip flash: `dir` is the skip direction and
   // `nonce` bumps on each skip so the overlay replays even on a repeat direction
   // (a plain `dir` diff would miss next-after-next). The globe edge-tap is the
@@ -39,7 +40,7 @@ export interface GlobeChartState {
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
   setListening: (listening: boolean) => void;
-  setSkip: (skip: (dir: 1 | -1) => void) => void;
+  setSkip: (skip: (dir: 1 | -1) => boolean) => void;
   signalSkip: (dir: 1 | -1) => void;
 }
 
@@ -48,7 +49,7 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   readMode: false,
   settleSignal: 0,
   listening: false,
-  skip: () => {},
+  skip: () => false,
   skipSignal: { dir: 1, nonce: 0 },
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -30,11 +30,17 @@ export interface GlobeChartState {
   // place that owns the adjacency logic. Default no-op until the chart publishes
   // it, so calling before a track plays is safe.
   skip: (dir: 1 | -1) => void;
+  // One-shot cue for the directional skip flash: `dir` is the skip direction and
+  // `nonce` bumps on each skip so the overlay replays even on a repeat direction
+  // (a plain `dir` diff would miss next-after-next). The globe edge-tap is the
+  // only producer, so the flash lands on the tapped edge, not on a button skip.
+  skipSignal: { dir: 1 | -1; nonce: number };
   setSelectedCountry: (code: string | null) => void;
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
   setListening: (listening: boolean) => void;
   setSkip: (skip: (dir: 1 | -1) => void) => void;
+  signalSkip: (dir: 1 | -1) => void;
 }
 
 export const globeChartStore = createStore<GlobeChartState>()((set) => ({
@@ -43,12 +49,17 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   settleSignal: 0,
   listening: false,
   skip: () => {},
+  skipSignal: { dir: 1, nonce: 0 },
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),
   signalSettle: () =>
     set((state) => ({ settleSignal: state.settleSignal + 1 })),
   setListening: (listening) => set({ listening }),
   setSkip: (skip) => set({ skip }),
+  signalSkip: (dir) =>
+    set((state) => ({
+      skipSignal: { dir, nonce: state.skipSignal.nonce + 1 },
+    })),
 }));
 
 export function useGlobeChart<T>(selector: (state: GlobeChartState) => T): T {


### PR DESCRIPTION
## What

Experimental: tapping the globe's left/right edge skips tracks while a song is
playing. Stacks on #162 (reuses the shared `step()` / `findAdjacentPlayable` via a
globe-chart-store seam, so no adjacency logic is duplicated). Opened as a **draft
for on-device validation** before deciding whether to merge.

## Behavior

- Listening (a track is playing): a no-movement tap on the left or right third
  steps prev/next; the center third still selects the nearest country; a drag
  still spins.
- Not listening: every tap selects a country (edge-skip is off).
- A one-time edge hint, reduced-motion-aware.

## Device-test focus (what decides merge)

- 8px tap-vs-spin threshold (`TAP_MAX_PX`): does an edge skip trigger too easily
  while spinning, or a short flick skip unintentionally?
- 33/33/33 thirds: does the center (select) zone feel too narrow on a phone?
- iOS: left-edge skip vs Safari's system back-swipe.

## Verify

- `format` / `lint` / `typecheck` / `test` (516) all green.

> Base is `feat/mini-player-prev-next` so the diff shows only the edge-tap delta;
> it retargets to `main` once #162 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a double-tap skip hint and a skip confirmation animation on the globe.
  * Improved globe tap behavior so edge taps can skip between tracks, while center taps still select normally.
  * Added a new icon used in the skip hint UI.

* **Bug Fixes**
  * Made skip actions reliably trigger the next visual cue, even when repeated in the same direction.
  * Respected reduced-motion settings by simplifying the skip animation for users who prefer less motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->