### PR TITLE
feat(sheet): auto-scroll the open sheet to the now-playing track

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -221,6 +221,7 @@ function ChartScreenInner({
         snap={snap}
         onSnapChange={setSnap}
         currentTrackRank={currentTrackRank}
+        currentCountryCode={currentCountryCode}
         hasMiniPlayer={hasCurrentTrack}
         scrollSignal={scrollSignal}
       />

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -11,10 +11,37 @@ function setScrollTop(el: Element, value: number) {
 }
 
 const originalScrollIntoView = Element.prototype.scrollIntoView;
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
 afterEach(() => {
   Element.prototype.scrollIntoView = originalScrollIntoView;
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
 });
+
+// jsdom has no layout, so reveal-only's visibility check reads all-zero rects.
+// Stub the vertical bounds the check compares: the <ol> is the viewport, and any
+// row is placed relative to it to force the fully-visible / clipped branch.
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    top,
+    bottom,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: bottom - top,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function stubRects(viewport: DOMRect, row: DOMRect) {
+  Element.prototype.getBoundingClientRect = function () {
+    if (this.tagName === "OL") return viewport;
+    if (this.hasAttribute("data-rank")) return row;
+    return rect(0, 0);
+  };
+}
 
 function renderSheet(snap: SnapState) {
   const onSnapChange = vi.fn();
@@ -279,6 +306,80 @@ describe("ChartSheet", () => {
       </AudioStoreProvider>,
     );
 
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  test("scrolls the now-playing row into view when the track changes while open and the row is off-screen", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // Row sits below the peek viewport, so reveal-only must pull it in.
+    stubRects(rect(0, 100), rect(200, 240));
+    const first = COUNTRY_KR.tracks[0].rank;
+    const next = COUNTRY_KR.tracks[2].rank;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={first}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={next}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not scroll when the track changes while open but the row is already fully visible", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // Row sits inside the peek viewport, so reveal-only leaves the list put.
+    stubRects(rect(0, 100), rect(10, 50));
+    const first = COUNTRY_KR.tracks[0].rank;
+    const next = COUNTRY_KR.tracks[2].rank;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={first}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={next}
+        />
+      </AudioStoreProvider>,
+    );
     await new Promise<void>((r) => requestAnimationFrame(() => r()));
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -348,6 +348,46 @@ describe("ChartSheet", () => {
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });
 
+  test("does not scroll when the playing country differs from the displayed country", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // Row would be off-screen, but the now-playing track belongs to another
+    // country, so its rank must not scroll the browsed country's list.
+    stubRects(rect(0, 100), rect(200, 240));
+    const first = COUNTRY_KR.tracks[0].rank;
+    const next = COUNTRY_KR.tracks[2].rank;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={first}
+          currentCountryCode="us"
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={next}
+          currentCountryCode="us"
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
   test("does not scroll when the track changes while open but the row is already fully visible", async () => {
     const scrollIntoViewMock = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoViewMock;

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -44,6 +44,21 @@ const SNAP_Y: Record<SnapState, string> = {
   hidden: `${SNAP_Y_PCT.hidden}%`,
 };
 
+// True when the whole row sits inside the list's scroll viewport. Reveal-only
+// auto-scroll uses this to leave an already-visible now-playing row untouched;
+// only a partially- or fully-clipped row is scrolled into view.
+function isRowFullyVisible(row: HTMLElement, viewport: HTMLElement): boolean {
+  if (row.getBoundingClientRect().top < viewport.getBoundingClientRect().top) {
+    return false;
+  }
+  if (
+    row.getBoundingClientRect().bottom > viewport.getBoundingClientRect().bottom
+  ) {
+    return false;
+  }
+  return true;
+}
+
 const SNAP_ORDER: SnapState[] = ["full", "peek", "closed", "hidden"];
 
 // Pointer travel (px) before a press becomes a drag, so a tap on the handle
@@ -441,22 +456,34 @@ export function ChartSheet({
 
   const prevSnapRef = useRef(snap);
   const prevSignalRef = useRef(scrollSignal);
+  const prevRankRef = useRef(currentTrackRank);
 
   useEffect(() => {
     const wasMin =
       prevSnapRef.current === "closed" || prevSnapRef.current === "hidden";
     const signalChanged = prevSignalRef.current !== scrollSignal;
+    const rankChanged = prevRankRef.current !== currentTrackRank;
     prevSnapRef.current = snap;
     prevSignalRef.current = scrollSignal;
+    prevRankRef.current = currentTrackRank;
     if (snap === "closed" || snap === "hidden") return;
     if (currentTrackRank === null) return;
-    if (!wasMin && !signalChanged) return;
+    // A reopen (raised from minimized, or a mini-player tap that bumped the
+    // signal) always reveals the row. An in-place track change while the sheet
+    // is already open only follows it when the row would otherwise be hidden,
+    // so a row that's already visible (an adjacent step, or one the user tapped)
+    // never yanks the list.
+    const isReopen = wasMin || signalChanged;
+    if (!isReopen && !rankChanged) return;
     // Defer one frame so the new snap/country is in the DOM before query.
     const id = requestAnimationFrame(() => {
-      const el = olRef.current?.querySelector<HTMLElement>(
+      const ol = olRef.current;
+      const el = ol?.querySelector<HTMLElement>(
         `[data-rank="${currentTrackRank}"]`,
       );
-      el?.scrollIntoView({
+      if (!ol || !el) return;
+      if (!isReopen && isRowFullyVisible(el, ol)) return;
+      el.scrollIntoView({
         block: snap === "peek" ? "start" : "center",
         behavior: "smooth",
       });

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -23,6 +23,7 @@ export interface ChartSheetProps {
   snap: SnapState;
   onSnapChange: (snap: SnapState) => void;
   currentTrackRank?: number | null;
+  currentCountryCode?: string | null;
   hasMiniPlayer?: boolean;
   scrollSignal?: number;
 }
@@ -46,17 +47,13 @@ const SNAP_Y: Record<SnapState, string> = {
 
 // True when the whole row sits inside the list's scroll viewport. Reveal-only
 // auto-scroll uses this to leave an already-visible now-playing row untouched;
-// only a partially- or fully-clipped row is scrolled into view.
+// only a partially- or fully-clipped row is scrolled into view. The 1px
+// tolerance absorbs sub-pixel layout rounding so a hair's clip doesn't read as
+// hidden and trigger a needless scroll.
 function isRowFullyVisible(row: HTMLElement, viewport: HTMLElement): boolean {
-  if (row.getBoundingClientRect().top < viewport.getBoundingClientRect().top) {
-    return false;
-  }
-  if (
-    row.getBoundingClientRect().bottom > viewport.getBoundingClientRect().bottom
-  ) {
-    return false;
-  }
-  return true;
+  const r = row.getBoundingClientRect();
+  const v = viewport.getBoundingClientRect();
+  return r.top >= v.top - 1 && r.bottom <= v.bottom + 1;
 }
 
 const SNAP_ORDER: SnapState[] = ["full", "peek", "closed", "hidden"];
@@ -124,6 +121,7 @@ export function ChartSheet({
   snap,
   onSnapChange,
   currentTrackRank = null,
+  currentCountryCode = null,
   hasMiniPlayer = false,
   scrollSignal = 0,
 }: ChartSheetProps) {
@@ -468,6 +466,12 @@ export function ChartSheet({
     prevRankRef.current = currentTrackRank;
     if (snap === "closed" || snap === "hidden") return;
     if (currentTrackRank === null) return;
+    // The now-playing row only exists in the displayed list when the playing
+    // country is the one on screen. Ranks repeat across countries, so a
+    // mismatch would scroll to an unrelated row of the browsed country; skip
+    // until they align (null = nothing playing, already handled above).
+    if (currentCountryCode !== null && currentCountryCode !== countryCode)
+      return;
     // A reopen (raised from minimized, or a mini-player tap that bumped the
     // signal) always reveals the row. An in-place track change while the sheet
     // is already open only follows it when the row would otherwise be hidden,
@@ -489,7 +493,7 @@ export function ChartSheet({
       });
     });
     return () => cancelAnimationFrame(id);
-  }, [snap, currentTrackRank, scrollSignal]);
+  }, [snap, currentTrackRank, scrollSignal, countryCode, currentCountryCode]);
 
   return (
     // Not wrapped in Dialog.Portal: the sheet must be in the server-rendered


### PR DESCRIPTION
## What

The chart sheet, while open at peek, didn't follow the now-playing track when it changed in place. Stepping prev/next or auto-advancing pushed the playing row off-screen with no visual feedback. The open sheet now scrolls the now-playing row into view on any in-place track change.

**Reveal-only:** a row that's already fully visible (an adjacent step, or one the user just tapped) is left untouched, so the list never yanks. Only a partially- or fully-clipped row is scrolled in (`block: start` at peek, `center` at full).

## Why

The sheet already had auto-scroll, but the guard only fired on reopen (raised from minimized, or a mini-player tap that bumped `scrollSignal`). An in-place track change re-ran the effect on the rank change, then dropped it. Surfaced by the mini-player prev/next navigation (#162); the same gap covers the now-playing swipe, media-session skip keys, auto-advance on end, and the trialed globe edge-tap (#163).

## How

- Extend the auto-scroll effect guard with a `prevRankRef`: a reopen still always reveals; an in-place rank change follows the track only when the row isn't already fully visible.
- `isRowFullyVisible` compares the row's and the viewport `<ol>`'s `getBoundingClientRect` bounds, read one deferred frame after the state settles (robust to the sheet's `translateY` and the peek `max-height` clamp).

## Test plan

- `pnpm typecheck` / `pnpm lint` / `pnpm test` (513 pass, +2 new) / `pnpm build` — all green.
- New tests lock the reveal-only branch (jsdom has no layout, so row/viewport rects are stubbed): off-screen row on rank change scrolls; already-visible row on rank change does not; existing reopen/signal/null paths unchanged.
- On-device (iOS Safari): manual prev/next and auto-advance both scroll the now-playing row into view at peek; an adjacent already-visible row stays put; no scroll thrash on rapid stepping.

Closes #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scrolling in the chart sheet so the currently playing row is brought into view when needed.
  * Avoided unnecessary scrolling when the target row is already fully visible.
  * Stabilized test behavior by restoring browser layout helpers between tests.

* **Tests**
  * Added coverage for scrolling behavior when the current track changes while the sheet is open.
  * Expanded test support for consistent viewport and row visibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->