### PR TITLE
fix(audio): keep rapid skips from wedging the player

### DIFF
--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -372,6 +372,28 @@ describe("createAudioStore", () => {
     expect(store.getState().lastError).toBeNull();
   });
 
+  test("a stale rejection sharing the live track's previewUrl does not clobber it", async () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const trackA = makeTrack({ previewUrl: "https://example.com/a.m4a" });
+    const trackB = makeTrack({ previewUrl: "https://example.com/b.m4a" });
+    // Only the first attempt rejects; re-selecting trackA succeeds. The stale
+    // rejection shares trackA's previewUrl, so a value-keyed guard would let it
+    // through and mark the live re-attempt as errored.
+    vi.mocked(audio.play).mockRejectedValueOnce(
+      new DOMException("autoplay blocked", "NotAllowedError"),
+    );
+
+    store.getState().toggle(trackA); // attempt 1 (rejects)
+    store.getState().toggle(trackB); // attempt 2
+    store.getState().toggle(trackA); // attempt 3 (live)
+    await Promise.resolve();
+
+    expect(store.getState().currentTrack).toBe(trackA);
+    expect(store.getState().isPlaying).toBe(true);
+    expect(store.getState().lastError).toBeNull();
+  });
+
   test("browser pause event syncs store (Layer 1)", () => {
     const audio = makeMockAudio();
     const store = createAudioStore(() => audio);

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -322,6 +322,56 @@ describe("createAudioStore", () => {
     expect(store.getState().lastError).toBeNull();
   });
 
+  test("play rejection clears isPlaying and records lastError", async () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack({ previewUrl: "https://example.com/blocked.m4a" });
+    vi.mocked(audio.play).mockRejectedValueOnce(
+      new DOMException("autoplay blocked", "NotAllowedError"),
+    );
+
+    store.getState().toggle(track);
+    await Promise.resolve();
+
+    expect(store.getState().isPlaying).toBe(false);
+    expect(store.getState().lastError).toEqual({
+      previewUrl: track.previewUrl,
+    });
+  });
+
+  test("play rejection with AbortError leaves state untouched (benign interrupt)", async () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const track = makeTrack();
+    vi.mocked(audio.play).mockRejectedValueOnce(
+      new DOMException("interrupted", "AbortError"),
+    );
+
+    store.getState().toggle(track);
+    await Promise.resolve();
+
+    expect(store.getState().isPlaying).toBe(true);
+    expect(store.getState().lastError).toBeNull();
+  });
+
+  test("a stale play rejection does not clobber a newer track's state", async () => {
+    const audio = makeMockAudio();
+    const store = createAudioStore(() => audio);
+    const trackA = makeTrack({ previewUrl: "https://example.com/a.m4a" });
+    const trackB = makeTrack({ previewUrl: "https://example.com/b.m4a" });
+    vi.mocked(audio.play).mockRejectedValueOnce(
+      new DOMException("autoplay blocked", "NotAllowedError"),
+    );
+
+    store.getState().toggle(trackA);
+    store.getState().toggle(trackB);
+    await Promise.resolve();
+
+    expect(store.getState().currentTrack).toBe(trackB);
+    expect(store.getState().isPlaying).toBe(true);
+    expect(store.getState().lastError).toBeNull();
+  });
+
   test("browser pause event syncs store (Layer 1)", () => {
     const audio = makeMockAudio();
     const store = createAudioStore(() => audio);

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -37,6 +37,10 @@ export function createAudioStore(
   factory: AudioEngineFactory = createBrowserAudioEngine,
 ) {
   let engine: AudioEngine | null = null;
+  // Monotonic id per play() attempt. A rejection only owns the state if its
+  // token still matches; a newer attempt (even one on a track that shares this
+  // previewUrl, e.g. two preview-less tracks) supersedes it.
+  let playToken = 0;
 
   return createStore<AudioState>()((set, get) => {
     function getEngine(): AudioEngine {
@@ -89,11 +93,11 @@ export function createAudioStore(
     // rejection (the track was already switched) must not clobber the live
     // track either. Otherwise mirror the engine's error listener: clear
     // isPlaying, record lastError, breadcrumb, and tell the OS it's paused.
-    function handlePlayRejection(track: Track) {
+    function handlePlayRejection(track: Track, token: number) {
       return (error: unknown) => {
         if (error instanceof DOMException && error.name === "AbortError")
           return;
-        if (get().currentTrack?.previewUrl !== track.previewUrl) return;
+        if (token !== playToken) return;
         const previewUrl = track.previewUrl ?? null;
         set({ isPlaying: false, lastError: { previewUrl } });
         setPlaybackState("paused");
@@ -125,12 +129,12 @@ export function createAudioStore(
         if (isCurrent) {
           // Resume in place: reassigning src restarts at 0, so leave it and
           // just play. Keeps the preview position and the stored countryCode.
-          void a.play().catch(handlePlayRejection(track));
+          void a.play().catch(handlePlayRejection(track, ++playToken));
           set({ currentTrack: track, isPlaying: true, lastError: null });
           return;
         }
         a.src = track.previewUrl ?? "";
-        void a.play().catch(handlePlayRejection(track));
+        void a.play().catch(handlePlayRejection(track, ++playToken));
         setNowPlaying(track);
         set({
           currentTrack: track,

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -83,6 +83,29 @@ export function createAudioStore(
       return engine;
     }
 
+    // play() rejects when playback can't start. AbortError means a newer action
+    // interrupted this play (rapid track-switch); it's benign, and the newer
+    // action owns the resulting state, so leave state untouched. A stale
+    // rejection (the track was already switched) must not clobber the live
+    // track either. Otherwise mirror the engine's error listener: clear
+    // isPlaying, record lastError, breadcrumb, and tell the OS it's paused.
+    function handlePlayRejection(track: Track) {
+      return (error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+        if (get().currentTrack?.previewUrl !== track.previewUrl) return;
+        const previewUrl = track.previewUrl ?? null;
+        set({ isPlaying: false, lastError: { previewUrl } });
+        setPlaybackState("paused");
+        Sentry.addBreadcrumb({
+          category: "audio",
+          level: "warning",
+          message: "preview audio play rejected",
+          data: { previewUrl },
+        });
+      };
+    }
+
     return {
       currentTrack: null,
       currentCountryCode: null,
@@ -102,12 +125,12 @@ export function createAudioStore(
         if (isCurrent) {
           // Resume in place: reassigning src restarts at 0, so leave it and
           // just play. Keeps the preview position and the stored countryCode.
-          void a.play();
+          void a.play().catch(handlePlayRejection(track));
           set({ currentTrack: track, isPlaying: true, lastError: null });
           return;
         }
         a.src = track.previewUrl ?? "";
-        void a.play();
+        void a.play().catch(handlePlayRejection(track));
         setNowPlaying(track);
         set({
           currentTrack: track,


### PR DESCRIPTION
## What
Both `toggle()` play() calls route through one shared handler: an `AbortError` (a pending play interrupted by a rapid track switch) is swallowed, a stale rejection (the track already switched) is ignored, and only a genuine failure clears `isPlaying` + records `lastError`, mirroring the engine's existing `error` listener.

## Why
Rapid track-switching — mini-player prev/next (#162) and globe edge-tap skip (#163) — interrupts an in-flight `play()`, which rejects with `AbortError`. Unhandled, it produced console/Sentry noise and could leave `isPlaying` stale (set true synchronously right after `void a.play()`). These rejections do not fire the media `error` event the engine already handles.

## Test plan
- New unit tests drive a rejecting engine `play()`: genuine failure -> `isPlaying:false` + `lastError`; `AbortError` -> state untouched; a stale rejection after switching tracks -> the newer track's state is not clobbered.
- typecheck / lint / test (531 pass) / build all green locally.

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback reliability by preventing outdated “play failed” results from overwriting the currently selected track during rapid switching.
  * Autoplay-blocked playback now reliably pauses the player, clears the playing flag, and records the correct track error.
  * Quick-interrupt cases are handled quietly (no error surfaced), avoiding unnecessary error states.
  * Added expanded test coverage for play-rejection edge cases, including stale rejections after multiple toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->