### PR TITLE
feat(globe): shuffle button to fling to a random country

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from "next/font/local";
 
 import { CountrySelector } from "@/components/country-selector";
 import { GlobeMount } from "@/components/globe/globe-mount";
+import { ShuffleButton } from "@/components/shuffle-button";
 import { SITE_URL } from "@/lib/site-url";
 
 import "./globals.css";
@@ -87,6 +88,7 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <CountrySelector />
         </Suspense>
+        <ShuffleButton />
         {children}
       </body>
     </html>

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -93,18 +93,19 @@ function SceneContent() {
   }, []);
 
   // "Surprise me": on a bumped shuffle signal, draw a fair random country and
-  // publish it like the a11y list does. The globe's targetCode effect then
-  // settles to it, and handleSettle owns the ?cc= write, visited, and haptic —
-  // so this only picks and publishes. Ref-gated so only a real bump acts, never
-  // the mount value or a visited/selection re-render. Excluding the settled code
-  // (selectedCode, or the initial centre before the first selection) guarantees
-  // a different country, so the settle always fires.
+  // publish it via shuffleTo — sets selectedCountry (the globe's targetCode
+  // effect then settles to it, handleSettle owns the ?cc= write, visited, and
+  // haptic) and records the landing so the button announces this shuffle's own
+  // pick, not whatever selection changes next. Ref-gated so only a real bump
+  // acts, never the mount value or a visited/selection re-render. Excluding the
+  // settled code (selectedCode, or the initial centre before the first
+  // selection) guarantees a different country, so the settle always fires.
   const prevShuffleRef = useRef(shuffleSignal);
   useEffect(() => {
     if (shuffleSignal === prevShuffleRef.current) return;
     prevShuffleRef.current = shuffleSignal;
     const code = pickShuffleCountry(visited, selectedCode ?? initialCode);
-    globeChartStore.getState().setSelectedCountry(code);
+    globeChartStore.getState().shuffleTo(code);
   }, [shuffleSignal, visited, selectedCode, initialCode]);
 
   return (

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, use, useCallback, useEffect, useState } from "react";
+import { Suspense, use, useCallback, useEffect, useRef, useState } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { PerspectiveCamera } from "three";
 
@@ -16,7 +16,7 @@ import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
 import { triggerLandingHaptic } from "./landing-haptic";
-import { addVisited } from "./spin-select";
+import { addVisited, pickShuffleCountry } from "./spin-select";
 import { SpinSnapControls } from "./spin-snap-controls";
 import { StarBackdrop } from "./star-backdrop";
 
@@ -61,6 +61,7 @@ function SceneContent() {
   const selectedCode = useGlobeChart((s) => s.selectedCountry);
   const reducedMotion = usePrefersReducedMotion();
   const readMode = useGlobeChart((s) => s.readMode);
+  const shuffleSignal = useGlobeChart((s) => s.shuffleSignal);
 
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const hoveredIsoNum =
@@ -90,6 +91,21 @@ function SceneContent() {
     window.history.replaceState(null, "", `?cc=${code}`);
     setVisited((prev) => addVisited(prev, code));
   }, []);
+
+  // "Surprise me": on a bumped shuffle signal, draw a fair random country and
+  // publish it like the a11y list does. The globe's targetCode effect then
+  // settles to it, and handleSettle owns the ?cc= write, visited, and haptic —
+  // so this only picks and publishes. Ref-gated so only a real bump acts, never
+  // the mount value or a visited/selection re-render. Excluding the settled code
+  // (selectedCode, or the initial centre before the first selection) guarantees
+  // a different country, so the settle always fires.
+  const prevShuffleRef = useRef(shuffleSignal);
+  useEffect(() => {
+    if (shuffleSignal === prevShuffleRef.current) return;
+    prevShuffleRef.current = shuffleSignal;
+    const code = pickShuffleCountry(visited, selectedCode ?? initialCode);
+    globeChartStore.getState().setSelectedCountry(code);
+  }, [shuffleSignal, visited, selectedCode, initialCode]);
 
   return (
     <>

--- a/src/components/globe/spin-select.test.ts
+++ b/src/components/globe/spin-select.test.ts
@@ -7,6 +7,7 @@ import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
 import {
   addVisited,
   pickNearestToPoint,
+  pickShuffleCountry,
   pickSnapCountry,
   projectFrontCountries,
   rankNearest,
@@ -188,6 +189,57 @@ test("every country appears in some nearest pool over the reachable sphere", () 
     (c) => c.code,
   );
   expect(unreachable).toEqual([]);
+});
+
+test("pickShuffleCountry never returns the country already shown", () => {
+  const current = COUNTRIES[0].code;
+
+  // Sweep the whole draw range: none of it may land back on the current country.
+  for (let r = 0; r < 1; r += 0.02) {
+    expect(pickShuffleCountry(new Set(), current, () => r)).not.toBe(current);
+  }
+});
+
+test("pickShuffleCountry draws from the whole globe, not a rest-direction cluster", () => {
+  // r=0 takes the first pool member. With the current country excluded that is
+  // the first COUNTRIES entry that isn't current, so the pool spans every
+  // country rather than a geographic neighbourhood.
+  const current = COUNTRIES[1].code;
+  const firstOther = COUNTRIES.find((c) => c.code !== current)!.code;
+
+  expect(pickShuffleCountry(new Set(), current, () => 0)).toBe(firstOther);
+});
+
+test("pickShuffleCountry allows any country when nothing is shown yet", () => {
+  expect(pickShuffleCountry(new Set(), null, () => 0)).toBe(COUNTRIES[0].code);
+});
+
+test("pickShuffleCountry favours an unvisited country over any single visited one", () => {
+  // Visit every country but one; the current (also visited) is excluded from the
+  // pool. Across a uniform draw sweep the unvisited country wins far more often
+  // than any single visited one, and the current country never appears.
+  const current = COUNTRIES[0].code;
+  const unseen = COUNTRIES[COUNTRIES.length - 1].code;
+  const visited = new Set(
+    COUNTRIES.filter((c) => c.code !== current && c.code !== unseen).map(
+      (c) => c.code,
+    ),
+  );
+
+  const counts = new Map<string, number>();
+  for (let r = 0; r < 1; r += 0.001) {
+    const code = pickShuffleCountry(visited, current, () => r);
+    counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+
+  const unseenCount = counts.get(unseen) ?? 0;
+  const maxVisited = Math.max(
+    ...[...counts]
+      .filter(([code]) => code !== unseen)
+      .map(([, count]) => count),
+  );
+  expect(counts.has(current)).toBe(false);
+  expect(unseenCount).toBeGreaterThan(maxVisited);
 });
 
 test("addVisited records a newly settled country in the visited set", () => {

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -160,3 +160,23 @@ export function pickSnapCountry(
     rng(),
   );
 }
+
+const ALL_CODES = COUNTRIES.map((c) => c.code);
+
+// Shuffle target: a fair random country from anywhere on the globe, never the
+// one already shown so "surprise me" always lands somewhere new. Unlike
+// pickSnapCountry there is no rest direction — geography doesn't narrow the pool,
+// every country is a candidate — but the draw reuses the same visited-weighting,
+// so a run of shuffles spreads across the map instead of repeating. Randomness
+// enters via `rng` (defaults to Math.random), injected so the draw stays
+// testable.
+export function pickShuffleCountry(
+  visited: ReadonlySet<string>,
+  current: string | null,
+  rng: () => number = Math.random,
+): string {
+  const pool = current
+    ? ALL_CODES.filter((code) => code !== current)
+    : ALL_CODES;
+  return weightedDraw(pool, visited, rng());
+}

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -20,6 +20,11 @@ const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slid
 const EL_LIMIT = 75 * DEG; // stop short of the poles so the view never flips
 const SETTLE_VEL = 2; // rad/s under which a fling hands off to the snap spring
 const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
+// rad/s ceiling on a settle. A far external pick (shuffle / a11y list) would
+// otherwise ride the spring's amplitude-scaled peak velocity and strobe across
+// the globe; the cap turns that into a steady glide. Small post-fling snaps
+// stay under it, so their feel is untouched.
+const MAX_SETTLE_VEL = 7;
 const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
 const TAP_HIT_PX = 44; // a tap beyond this from every country pin selects nothing
 const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips
@@ -411,6 +416,12 @@ export function SpinSnapControls({
         (SNAP_OMEGA * SNAP_OMEGA * dAz - 2 * zeta * SNAP_OMEGA * s.vAz) * dtc;
       s.vEl +=
         (SNAP_OMEGA * SNAP_OMEGA * dEl - 2 * zeta * SNAP_OMEGA * s.vEl) * dtc;
+      const speed = Math.hypot(s.vAz, s.vEl);
+      if (speed > MAX_SETTLE_VEL) {
+        const k = MAX_SETTLE_VEL / speed;
+        s.vAz *= k;
+        s.vEl *= k;
+      }
       s.az += s.vAz * dtc;
       s.el += s.vEl * dtc;
       if (

--- a/src/components/shuffle-button.tsx
+++ b/src/components/shuffle-button.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { countryByCode } from "@/lib/country-code";
+import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
+
+// "Surprise me": flings the globe to a fair random country and lands it, the
+// same end-state as a manual fling (no autoplay — selection alone, like every
+// other pick). The globe owns the draw because the anti-repeat memory lives
+// there, so this only signals across the globe-chart store.
+export function ShuffleButton() {
+  // Recede under the rising sheet on the same rule as the country badge: at full
+  // the sheet covers this corner, so inert + pointer-events follow read mode.
+  const readMode = useGlobeChart((s) => s.readMode);
+
+  // Announce the landed country to screen readers, since the change is otherwise
+  // only visual. Only a shuffle this button started should speak, not a fling or
+  // list pick, so a pending flag arms the next selection change. Announcing from
+  // the store subscription (not a selector + effect) keeps setState in an
+  // external-update callback and off the button's render path.
+  const [announcement, setAnnouncement] = useState("");
+  const pendingAnnounce = useRef(false);
+  useEffect(() => {
+    return globeChartStore.subscribe((state, prev) => {
+      if (state.selectedCountry === prev.selectedCountry) return;
+      if (!pendingAnnounce.current) return;
+      pendingAnnounce.current = false;
+      const country = state.selectedCountry
+        ? countryByCode(state.selectedCountry)
+        : null;
+      if (country) setAnnouncement(`Now showing ${country.name}`);
+    });
+  }, []);
+
+  const onShuffle = () => {
+    pendingAnnounce.current = true;
+    globeChartStore.getState().requestShuffle();
+  };
+
+  return (
+    <>
+      <div
+        inert={readMode}
+        style={{
+          transform:
+            "translateY(calc(var(--sheet-cover, 0) * var(--badge-recede-rise, -64px)))",
+          opacity: "calc(1 - var(--sheet-cover, 0))",
+        }}
+        className={`fixed top-[max(env(safe-area-inset-top),16px)] right-4 z-40 ${
+          readMode ? "pointer-events-none" : ""
+        }`}
+      >
+        <button
+          type="button"
+          onClick={onShuffle}
+          aria-label="Surprise me with a random country"
+          className="bg-aurora text-void focus-visible:outline-aurora flex items-center justify-center rounded-full p-3 shadow-lg transition-transform hover:scale-[1.03] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-5 w-5"
+          >
+            <path d="M16 3h5v5" />
+            <path d="M4 20 21 3" />
+            <path d="M21 16v5h-5" />
+            <path d="m15 15 6 6" />
+            <path d="M4 4l5 5" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="sr-only" role="status" aria-live="polite">
+        {announcement}
+      </div>
+    </>
+  );
+}

--- a/src/components/shuffle-button.tsx
+++ b/src/components/shuffle-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { countryByCode } from "@/lib/country-code";
 import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
@@ -15,26 +15,22 @@ export function ShuffleButton() {
   const readMode = useGlobeChart((s) => s.readMode);
 
   // Announce the landed country to screen readers, since the change is otherwise
-  // only visual. Only a shuffle this button started should speak, not a fling or
-  // list pick, so a pending flag arms the next selection change. Announcing from
-  // the store subscription (not a selector + effect) keeps setState in an
-  // external-update callback and off the button's render path.
+  // only visual. Keyed on the globe's shuffleLanded signal (the shuffle's own
+  // pick), so a selection from another source — a fling settling, a list pick —
+  // can't be mistaken for this shuffle's result. Announcing from the store
+  // subscription (not a selector + effect) keeps setState in an external-update
+  // callback and off the button's render path.
   const [announcement, setAnnouncement] = useState("");
-  const pendingAnnounce = useRef(false);
   useEffect(() => {
     return globeChartStore.subscribe((state, prev) => {
-      if (state.selectedCountry === prev.selectedCountry) return;
-      if (!pendingAnnounce.current) return;
-      pendingAnnounce.current = false;
-      const country = state.selectedCountry
-        ? countryByCode(state.selectedCountry)
-        : null;
+      if (state.shuffleLanded === prev.shuffleLanded) return;
+      if (!state.shuffleLanded) return;
+      const country = countryByCode(state.shuffleLanded.code);
       if (country) setAnnouncement(`Now showing ${country.name}`);
     });
   }, []);
 
   const onShuffle = () => {
-    pendingAnnounce.current = true;
     globeChartStore.getState().requestShuffle();
   };
 
@@ -55,7 +51,7 @@ export function ShuffleButton() {
           type="button"
           onClick={onShuffle}
           aria-label="Surprise me with a random country"
-          className="bg-aurora text-void focus-visible:outline-aurora flex items-center justify-center rounded-full p-3 shadow-lg transition-transform hover:scale-[1.03] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
+          className="bg-aurora/90 text-void focus-visible:outline-aurora flex items-center justify-center rounded-full p-3 shadow-lg transition-transform hover:scale-[1.03] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
         >
           <svg
             aria-hidden="true"

--- a/src/lib/globe-chart-store.test.ts
+++ b/src/lib/globe-chart-store.test.ts
@@ -9,6 +9,8 @@ describe("globeChartStore", () => {
       settleSignal: 0,
       skipSignal: { dir: 1, nonce: 0 },
       shuffleSignal: 0,
+      shuffleLanded: null,
+      selectedCountry: null,
       listening: false,
       skip: () => false,
     });
@@ -54,5 +56,25 @@ describe("globeChartStore", () => {
     globeChartStore.getState().requestShuffle();
 
     expect(globeChartStore.getState().shuffleSignal).toBe(2);
+  });
+
+  test("shuffleTo lands the country and records it for the screen-reader announce", () => {
+    globeChartStore.getState().shuffleTo("kr");
+
+    expect(globeChartStore.getState().selectedCountry).toBe("kr");
+    expect(globeChartStore.getState().shuffleLanded).toEqual({
+      code: "kr",
+      nonce: 1,
+    });
+  });
+
+  test("shuffleTo bumps the nonce so re-landing the same country still announces", () => {
+    globeChartStore.getState().shuffleTo("kr");
+    globeChartStore.getState().shuffleTo("kr");
+
+    expect(globeChartStore.getState().shuffleLanded).toEqual({
+      code: "kr",
+      nonce: 2,
+    });
   });
 });

--- a/src/lib/globe-chart-store.test.ts
+++ b/src/lib/globe-chart-store.test.ts
@@ -8,6 +8,7 @@ describe("globeChartStore", () => {
       readMode: false,
       settleSignal: 0,
       skipSignal: { dir: 1, nonce: 0 },
+      shuffleSignal: 0,
       listening: false,
       skip: () => false,
     });
@@ -46,5 +47,12 @@ describe("globeChartStore", () => {
     globeChartStore.getState().signalSkip(1);
 
     expect(globeChartStore.getState().skipSignal).toEqual({ dir: 1, nonce: 2 });
+  });
+
+  test("requestShuffle increments so each press is a distinct landing signal", () => {
+    globeChartStore.getState().requestShuffle();
+    globeChartStore.getState().requestShuffle();
+
+    expect(globeChartStore.getState().shuffleSignal).toBe(2);
   });
 });

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -36,12 +36,18 @@ export interface GlobeChartState {
   // (a plain `dir` diff would miss next-after-next). The globe edge-tap is the
   // only producer, so the flash lands on the tapped edge, not on a button skip.
   skipSignal: { dir: 1 | -1; nonce: number };
+  // Monotonic counter a "surprise me" button bumps to fling the globe to a
+  // random country. The pick lives in the globe (where the anti-repeat `visited`
+  // set does), so the button can't run it directly; it signals across this seam
+  // and the globe draws and settles like any other landing.
+  shuffleSignal: number;
   setSelectedCountry: (code: string | null) => void;
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
   setListening: (listening: boolean) => void;
   setSkip: (skip: (dir: 1 | -1) => boolean) => void;
   signalSkip: (dir: 1 | -1) => void;
+  requestShuffle: () => void;
 }
 
 export const globeChartStore = createStore<GlobeChartState>()((set) => ({
@@ -51,6 +57,7 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   listening: false,
   skip: () => false,
   skipSignal: { dir: 1, nonce: 0 },
+  shuffleSignal: 0,
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),
   signalSettle: () =>
@@ -61,6 +68,8 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
     set((state) => ({
       skipSignal: { dir, nonce: state.skipSignal.nonce + 1 },
     })),
+  requestShuffle: () =>
+    set((state) => ({ shuffleSignal: state.shuffleSignal + 1 })),
 }));
 
 export function useGlobeChart<T>(selector: (state: GlobeChartState) => T): T {

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -41,6 +41,12 @@ export interface GlobeChartState {
   // set does), so the button can't run it directly; it signals across this seam
   // and the globe draws and settles like any other landing.
   shuffleSignal: number;
+  // The country a shuffle just drew, set by the globe when it lands one. The
+  // screen-reader announcement keys on this rather than the next selectedCountry
+  // change, so a selection from another source (a fling settling, a list pick)
+  // can't be mistaken for this shuffle's result. `nonce` re-fires the announce
+  // even if a later shuffle repeats the country.
+  shuffleLanded: { code: string; nonce: number } | null;
   setSelectedCountry: (code: string | null) => void;
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
@@ -48,6 +54,8 @@ export interface GlobeChartState {
   setSkip: (skip: (dir: 1 | -1) => boolean) => void;
   signalSkip: (dir: 1 | -1) => void;
   requestShuffle: () => void;
+  // Land a shuffle draw: move the globe and record the landing to announce.
+  shuffleTo: (code: string) => void;
 }
 
 export const globeChartStore = createStore<GlobeChartState>()((set) => ({
@@ -58,6 +66,7 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   skip: () => false,
   skipSignal: { dir: 1, nonce: 0 },
   shuffleSignal: 0,
+  shuffleLanded: null,
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),
   signalSettle: () =>
@@ -70,6 +79,11 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
     })),
   requestShuffle: () =>
     set((state) => ({ shuffleSignal: state.shuffleSignal + 1 })),
+  shuffleTo: (code) =>
+    set((state) => ({
+      selectedCountry: code,
+      shuffleLanded: { code, nonce: (state.shuffleLanded?.nonce ?? 0) + 1 },
+    })),
 }));
 
 export function useGlobeChart<T>(selector: (state: GlobeChartState) => T): T {


### PR DESCRIPTION
An icon-only "Surprise me" control that draws a fairness-weighted random country and lands it on the globe like a manual fling — no autoplay, selection only. Bundles a globe spring fix the feature surfaced.

## Commits
- **fix(globe): cap settle velocity** — external selections (shuffle, the a11y list) settled with a spring whose peak velocity scales with the angle, so a far country whipped across in a few frames and read as flicker. Capping the settle speed turns that into a steady glide; small post-fling snaps stay under the cap and feel unchanged.
- **feat(globe): shuffle button** — top-right icon pill, reuses the fling's fairness-weighted draw (excludes current + visited so a run spreads across the map), announces the landing to screen readers.

## Test plan
- Unit: fair-draw and store-signal tests added; full suite 533 pass. Typecheck, lint, build green.
- Manual (localhost): pressed repeatedly — lands a different country each time, spins smoothly (no strobe), no autoplay; recedes under the rising sheet like the country badge.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new shuffle button to quickly jump to a different country on the globe.
  * Shuffle results now announce the new country for better screen-reader support.

* **Bug Fixes**
  * Improved shuffle behavior so it avoids repeating the currently shown country and spreads picks more evenly.
  * Smoothed globe settling by capping excessive spin speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->