### PR TITLE
feat(globe): frost the shuffle button into glass

### DIFF
--- a/src/components/shuffle-button.tsx
+++ b/src/components/shuffle-button.tsx
@@ -51,7 +51,7 @@ export function ShuffleButton() {
           type="button"
           onClick={onShuffle}
           aria-label="Surprise me with a random country"
-          className="bg-aurora/90 text-void focus-visible:outline-aurora flex items-center justify-center rounded-full p-3 shadow-lg transition-transform hover:scale-[1.03] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
+          className="bg-void/55 text-aurora ring-aurora/40 focus-visible:outline-aurora flex items-center justify-center rounded-full p-3 shadow-lg ring-1 backdrop-blur transition-transform hover:scale-[1.03] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
Polishes the shuffle FAB from #177. A solid `bg-aurora` fill read as a heavy CTA over the globe, and simply lowering its opacity only muddied the mint: a bright color composites toward the near-black `void` as alpha drops, so it dims rather than turning glassy.

Switches to the app's floating-control glass pattern (`edge-tap-hint`, `country-selector`): a translucent `bg-void/55` fill plus `backdrop-blur` so the globe frosts through, with the aurora moved onto the icon (`text-aurora`) and a `ring-aurora/40` rim.

**Change**
- `bg-aurora/90 text-void` → `bg-void/55 text-aurora ring-1 ring-aurora/40 backdrop-blur`

**Test plan**
- typecheck, eslint, prettier all clean (pre-commit hook + CI `format:check`)
- Checked over the globe backdrop in dark at 375 and full width, against solid / opacity-only / aurora-dim alternatives; the glass reads as intentional frost and the icon stays crisp.

**Note**
- The character shift is intentional: the button now recedes into the globe like the other floating chips instead of asserting itself as an accent CTA. If it reads too quiet, `ring-aurora/40 → /60` or fill `/55 → /45` re-asserts it without returning to the muddy look.
