### PR TITLE
Crawl: bake per-track spread count

### DIFF
--- a/docs/adr/0013-bake-track-spread-at-crawl-time.md
+++ b/docs/adr/0013-bake-track-spread-at-crawl-time.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-#175 wants to surface "gems": tracks that are charting widely across countries but easy to miss on any single country's list. The input signal is spread — how many of the 40 countries' charts contain a given track — and the open questions are where spread gets computed and how a track's identity is compared across countries that each ran their own independent crawl.
+#175 wants to surface "gems": tracks that are charting widely across countries but easy to miss on any single country's list. The input signal is spread — how many of the 63 countries' charts contain a given track — and the open questions are where spread gets computed and how a track's identity is compared across countries that each ran their own independent crawl.
 
 Cross-country identity needs a key that's stable regardless of which country's RSS feed produced the track. The raw Apple RSS response carries the song id as a plain field (`AppleRssTrack.id`), but `crawlCountry` currently drops it when building the public `Track` object; the same id is also recoverable by parsing the `i=` query param off `appleUrl`, which every observed RSS response carries.
 

--- a/docs/adr/0013-bake-track-spread-at-crawl-time.md
+++ b/docs/adr/0013-bake-track-spread-at-crawl-time.md
@@ -1,0 +1,33 @@
+# ADR-0013: Bake per-track spread at crawl time, derive gem selection at read time
+
+**Status:** Accepted (2026-07-03).
+
+## Context
+
+#175 wants to surface "gems": tracks that are charting widely across countries but easy to miss on any single country's list. The input signal is spread — how many of the 40 countries' charts contain a given track — and the open questions are where spread gets computed and how a track's identity is compared across countries that each ran their own independent crawl.
+
+Cross-country identity needs a key that's stable regardless of which country's RSS feed produced the track. The raw Apple RSS response carries the song id as a plain field (`AppleRssTrack.id`), but `crawlCountry` currently drops it when building the public `Track` object; the same id is also recoverable by parsing the `i=` query param off `appleUrl`, which every observed RSS response carries.
+
+## Decision
+
+A post-loop pass, `bakeSpread`, runs once over the fully-built `countries` map after the per-country crawl loop and before the blob upload, mirroring `bakeCommentary` ([ADR-0007](0007-out-of-band-human-curated-commentary.md)). It counts, per cross-country key, how many countries' charts contain a track with that key, then writes that count onto every track sharing it as `spread`. The field is additive-optional on `TrackSchema`, so a blob predating this change still validates.
+
+- **Cross-country key:** the Apple song id parsed from `appleUrl`'s `i=` param, falling back to normalized `artist|name` (mirroring `commentaryKey`) when no id is present. Chosen over carrying `AppleRssTrack.id` forward as a new `Track` field: the id is already recoverable from `appleUrl`, which is already public on every track, so parsing it needs no schema change and no edit to the already-tested `crawlCountry` build path. It also avoids adding a raw Apple-internal id as a permanent field on the public chart contract for a value that's redundant with data already there. The tradeoff is a soft dependency on Apple's RSS URLs continuing to carry `i=`; the artist+name fallback keeps that a degradation, not a failure.
+- **Gem selection stays read-time.** This ADR bakes only the raw count. A future slice will derive "is this a gem" from the baked `spread` plus a track's rank, computed where the chart is rendered, not in the crawl. Spread is a stable per-track fact; what counts as a gem is a display judgment (a threshold, a comparison across the current spread distribution) that should be tunable without waiting for the next crawl to see the effect. Baking gem status would also mean re-deriving it from scratch every run regardless, since it depends on that run's own spread values, so there is no accuracy or cost argument for baking it too.
+
+## Consequences
+
+**Positive**
+
+- `bakeSpread` is a pure, in-memory pass over data already assembled this run: no external calls, no new rate-limit surface, no addition to the crawl's runtime budget.
+- The blob stays backward-compatible; old blobs without `spread` still parse.
+- Gem selection can be redefined or tuned without a re-crawl, since it reads the already-baked `spread` at render time.
+
+**Negative**
+
+- The fallback key (normalized artist+name) can undercount a track whose metadata differs across countries' RSS feeds beyond what normalization folds away, or, rarely, overcount two distinct songs that happen to share an exact normalized artist+title.
+- Spread reflects only the current run's charts; a track that dropped off every chart after resolving spread once won't retroactively update older cached reads until the next crawl.
+
+**Neutral**
+
+- Spread is recomputed from scratch every run, the same no-persisted-intermediate-state pattern the crawl already uses for the charts themselves.

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -500,6 +500,44 @@ test("summarizeValidity reports total, valid count, and the invalid codes", asyn
   expect(summary).toEqual({ total: 3, validCount: 2, invalidCodes: ["ng"] });
 });
 
+test("crawlAll bakes spread as the count of countries whose chart contains a matching track", async () => {
+  const US: CountryEntry = {
+    code: "us",
+    name: "United States",
+    region: "Americas",
+    lat: 38.9015,
+    lon: -77.0114,
+    isoNum: 840,
+  };
+  const sharedTrack = (cc: string): AppleRssTrack => ({
+    rank: 1,
+    id: `${cc}-shared`,
+    name: "Shared Song",
+    artist: "Shared Artist",
+    appleUrl: `https://music.apple.com/${cc}/album/1?i=999999`,
+    artworkUrl: `https://art/${cc}/1/600x600bb.jpg`,
+  });
+  const onlyKrTrack: AppleRssTrack = {
+    rank: 2,
+    id: "kr-only",
+    name: "KR Only Song",
+    artist: "KR Only Artist",
+    appleUrl: "https://music.apple.com/kr/album/2?i=111111",
+    artworkUrl: "https://art/kr/2/600x600bb.jpg",
+  };
+  const fetchRss = vi.fn(async (cc: string) =>
+    cc === "kr" ? [sharedTrack(cc), onlyKrTrack] : [sharedTrack(cc)],
+  );
+  const deps = makeCrawlAllDeps({ countries: [KR, NG, US], fetchRss });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.kr.tracks[0].spread).toBe(3);
+  expect(result.chartFile.countries.ng.tracks[0].spread).toBe(3);
+  expect(result.chartFile.countries.us.tracks[0].spread).toBe(3);
+  expect(result.chartFile.countries.kr.tracks[1].spread).toBe(1);
+});
+
 test("crawlAll bakes a matching blurb and sets null on tracks without one", async () => {
   const krEntry = commentaryEntry("KR blurb.");
   const store: CommentaryStore = {

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -5,6 +5,7 @@ import {
   type CommentaryStore,
 } from "../../src/lib/commentary-store";
 import type { CountryEntry } from "../../src/lib/countries";
+import { trackSpreadKey } from "../../src/lib/track-spread";
 
 import { AppleRssError, type AppleRssTrack } from "./apple-rss";
 import { ItunesLookupError, type LookupResult } from "./itunes-lookup";
@@ -183,6 +184,28 @@ export function bakeCommentary(
   }
 }
 
+/**
+ * Back-fills each track's spread: how many countries' charts contain a track
+ * with the same cross-country key (ADR-0013). Recomputed from scratch every
+ * crawl, so a track's spread always reflects this run's charts, including
+ * any carried-forward country.
+ */
+export function bakeSpread(countries: ChartFile["countries"]): void {
+  const countryCountByKey = new Map<string, number>();
+  for (const country of Object.values(countries)) {
+    const keysInCountry = new Set(country.tracks.map(trackSpreadKey));
+    for (const key of keysInCountry) {
+      countryCountByKey.set(key, (countryCountByKey.get(key) ?? 0) + 1);
+    }
+  }
+
+  for (const country of Object.values(countries)) {
+    for (const track of country.tracks) {
+      track.spread = countryCountByKey.get(trackSpreadKey(track));
+    }
+  }
+}
+
 export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
   const {
     countries,
@@ -227,6 +250,8 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
       `[crawl ${cc}] ${country.tracks.length} tracks (valid=${country.valid})`,
     );
   }
+
+  bakeSpread(countriesMap);
 
   const commentary = deps.fetchCommentary ? await deps.fetchCommentary() : null;
   if (commentary) {

--- a/src/lib/chart-schema.test.ts
+++ b/src/lib/chart-schema.test.ts
@@ -264,6 +264,32 @@ test("ChartFileSchema accepts both allowed claim values", () => {
   expect(() => ChartFileSchema.parse(withBothClaims)).not.toThrow();
 });
 
+test("ChartFileSchema accepts a track with a baked spread", () => {
+  const withSpread = {
+    lastUpdated: "2026-05-16T00:00:00.000Z",
+    countries: {
+      kr: {
+        name: "South Korea",
+        valid: true,
+        tracks: [
+          {
+            rank: 1,
+            name: "Test",
+            artist: "Test Artist",
+            previewUrl: null,
+            artworkUrl: "https://art/600x600bb.jpg",
+            appleUrl: "https://music.apple.com/kr/1",
+            spotifyUrl: "https://open.spotify.com/search/Test",
+            spread: 3,
+          },
+        ],
+      },
+    },
+  };
+
+  expect(() => ChartFileSchema.parse(withSpread)).not.toThrow();
+});
+
 test("ChartFileSchema rejects an empty countries record", () => {
   const empty = {
     lastUpdated: "2026-05-16T00:00:00.000Z",

--- a/src/lib/chart-schema.ts
+++ b/src/lib/chart-schema.ts
@@ -25,6 +25,7 @@ const TrackSchema = z.object({
   appleUrl: z.url(),
   spotifyUrl: z.url(),
   commentary: CommentarySchema.nullable().optional(),
+  spread: z.number().int().min(1).optional(),
 });
 
 const CountrySchema = z.object({

--- a/src/lib/track-spread.test.ts
+++ b/src/lib/track-spread.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vitest";
+
+import { trackSpreadKey } from "./track-spread";
+
+test("trackSpreadKey keys on the Apple song id parsed from appleUrl's i= param", () => {
+  const track = {
+    appleUrl: "https://music.apple.com/kr/album/redred/1887671065?i=1887671067",
+    artist: "Artist",
+    name: "Song",
+  };
+
+  expect(trackSpreadKey(track)).toBe("id:1887671067");
+});
+
+test("trackSpreadKey is stable across countries for the same song id, regardless of locale in the URL", () => {
+  const kr = {
+    appleUrl: "https://music.apple.com/kr/album/redred/1887671065?i=1887671067",
+    artist: "Artist",
+    name: "Song",
+  };
+  const us = {
+    appleUrl: "https://music.apple.com/us/album/redred/1887671065?i=1887671067",
+    artist: "Artist",
+    name: "Song",
+  };
+
+  expect(trackSpreadKey(kr)).toBe(trackSpreadKey(us));
+});
+
+test("trackSpreadKey falls back to normalized artist+name when appleUrl has no i= param", () => {
+  const track = {
+    appleUrl: "https://music.apple.com/kr/album/redred/1887671065",
+    artist: "  The Band ",
+    name: "HIT  song",
+  };
+
+  expect(trackSpreadKey(track)).toBe("name:the band|hit song");
+});
+
+test("trackSpreadKey falls back to normalized artist+name when appleUrl is unparseable", () => {
+  const track = {
+    appleUrl: "not a url",
+    artist: "Artist",
+    name: "Song",
+  };
+
+  expect(trackSpreadKey(track)).toBe("name:artist|song");
+});

--- a/src/lib/track-spread.ts
+++ b/src/lib/track-spread.ts
@@ -1,0 +1,24 @@
+import { normalizeForKey } from "./commentary-store";
+
+/**
+ * Cross-country identity of a charting track: the Apple song id parsed from
+ * the `i=` query param on `appleUrl`, or an artist+name fallback (mirroring
+ * `commentaryKey`) when the id can't be parsed out.
+ */
+export function trackSpreadKey(track: {
+  appleUrl: string;
+  artist: string;
+  name: string;
+}): string {
+  const songId = appleSongId(track.appleUrl);
+  if (songId) return `id:${songId}`;
+  return `name:${normalizeForKey(track.artist)}|${normalizeForKey(track.name)}`;
+}
+
+function appleSongId(appleUrl: string): string | null {
+  try {
+    return new URL(appleUrl).searchParams.get("i");
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Bakes each track's "spread" — how many of the 63 crawled countries chart it — so a later slice can tell a globally-shared hit apart from a country's own sound.

`bakeSpread` runs as a post-loop pass mirroring the existing `bakeCommentary`, keyed by the Apple song id parsed from `appleUrl`'s `i=` param (falling back to normalized artist+name). The field is additive-optional on `TrackSchema`, so old blobs still validate. ADR-0013 records the choice to bake spread at crawl time while leaving gem selection itself to a read-time function (next slice), and the id-parsing-over-carry-forward tradeoff.

Closes #179.

## Test plan
- [x] `mise exec -- pnpm typecheck / lint / test / build` all pass
- [x] Fixture test: a track shared across 3 countries gets `spread: 3`; a unique track gets `spread: 1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart entries now include a baked cross-country “spread” count, improving consistency of cross-region highlights.
  * Shared tracks are matched using a stable identity derived from track links, with a fallback to artist/title when needed.
* **Bug Fixes**
  * Shared-track detection is more reliable across localized chart sources.
* **Documentation**
  * Added an ADR and release documentation describing the spread computation approach and backward compatibility with existing saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->