### PR TITLE
UI: today's gem hero card (functional)

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -33,14 +33,18 @@ describe("ChartScreen", () => {
 
     render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
 
-    expect(screen.getByText(COUNTRY_US.tracks[0].name)).toBeDefined();
+    expect(
+      screen.getAllByText(COUNTRY_US.tracks[0].name).length,
+    ).toBeGreaterThan(0);
     expect(replaceState).not.toHaveBeenCalled();
   });
 
   test("falls back to defaultCountryCode and writes it to the URL when ?cc= is absent", () => {
     render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
 
-    expect(screen.getByText(COUNTRY_US.tracks[0].name)).toBeDefined();
+    expect(
+      screen.getAllByText(COUNTRY_US.tracks[0].name).length,
+    ).toBeGreaterThan(0);
     expect(replaceState).toHaveBeenCalledWith(null, "", `?cc=${CODE_US}`);
   });
 
@@ -49,7 +53,9 @@ describe("ChartScreen", () => {
 
     render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
 
-    expect(screen.getByText(COUNTRY_US.tracks[0].name)).toBeDefined();
+    expect(
+      screen.getAllByText(COUNTRY_US.tracks[0].name).length,
+    ).toBeGreaterThan(0);
     expect(replaceState).toHaveBeenCalledWith(null, "", `?cc=${CODE_US}`);
   });
 
@@ -58,7 +64,9 @@ describe("ChartScreen", () => {
 
     render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
 
-    expect(screen.getByText(COUNTRY_US.tracks[0].name)).toBeDefined();
+    expect(
+      screen.getAllByText(COUNTRY_US.tracks[0].name).length,
+    ).toBeGreaterThan(0);
     expect(replaceState).toHaveBeenCalledWith(null, "", `?cc=${CODE_US}`);
   });
 });

--- a/src/components/chart-sheet/gem-card.test.tsx
+++ b/src/components/chart-sheet/gem-card.test.tsx
@@ -109,6 +109,41 @@ describe("GemCard", () => {
 
     expect(store.getState().currentTrack).toBeNull();
   });
+
+  test("shows the now-playing badge only while this gem is the current, playing track", () => {
+    const track = makeTrack();
+    const { container } = renderGemCard(track, "entirely their own", {
+      currentTrack: track,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
+
+    expect(container.querySelector(".eq")).not.toBeNull();
+    expect(container.querySelector(".eq[data-paused]")).toBeNull();
+  });
+
+  test("marks the now-playing badge paused when the current gem is paused", () => {
+    const track = makeTrack();
+    const { container } = renderGemCard(track, "entirely their own", {
+      currentTrack: track,
+      isPlaying: false,
+      currentCountryCode: "kr",
+    });
+
+    expect(container.querySelector(".eq[data-paused]")).not.toBeNull();
+  });
+
+  test("shows no now-playing badge when a different track is current", () => {
+    const track = makeTrack();
+    const other = makeTrack({ previewUrl: "https://example.com/other.m4a" });
+    const { container } = renderGemCard(track, "entirely their own", {
+      currentTrack: other,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
+
+    expect(container.querySelector(".eq")).toBeNull();
+  });
 });
 
 describe("GemCard commentary", () => {

--- a/src/components/chart-sheet/gem-card.test.tsx
+++ b/src/components/chart-sheet/gem-card.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { AudioEngine } from "@/lib/audio-engine";
+import { type AudioState, createAudioStore } from "@/lib/audio-store";
+import type { Commentary, Track } from "@/lib/chart-schema";
+import type { GemTier } from "@/lib/select-gem";
+import { AudioStoreContext } from "@/providers/audio-store-provider";
+
+import { GemCard } from "./gem-card";
+
+function makeMockAudio(): AudioEngine {
+  return {
+    src: "",
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    setVolume: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+}
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    rank: 3,
+    name: "Test Gem",
+    artist: "Test Artist",
+    previewUrl: "https://example.com/preview.m4a",
+    artworkUrl: "https://example.com/artwork.jpg",
+    appleUrl: "https://music.apple.com/track/1",
+    spotifyUrl: "https://open.spotify.com/search/Test%20Gem",
+    spread: 1,
+    ...overrides,
+  };
+}
+
+function renderGemCard(
+  track: Track,
+  tier: GemTier = "entirely their own",
+  init?: Partial<AudioState>,
+  countryCode = "kr",
+) {
+  const store = createAudioStore(() => makeMockAudio());
+  if (init) {
+    store.setState(init);
+  }
+  const utils = render(
+    <AudioStoreContext.Provider value={store}>
+      <GemCard track={track} tier={tier} countryCode={countryCode} />
+    </AudioStoreContext.Provider>,
+  );
+  return { ...utils, store };
+}
+
+describe("GemCard", () => {
+  test("renders as an accessible region labeled today's gem", () => {
+    renderGemCard(makeTrack());
+
+    expect(screen.getByRole("region", { name: /today's gem/i })).toBeDefined();
+  });
+
+  test("renders the track name, artist, and tier label", () => {
+    const track = makeTrack({ name: "Local Anthem", artist: "Local Band" });
+
+    renderGemCard(track, "a local favorite");
+
+    expect(screen.getByText("Local Anthem")).toBeDefined();
+    expect(screen.getByText("Local Band")).toBeDefined();
+    expect(screen.getByText(/a local favorite/i)).toBeDefined();
+  });
+
+  test("clicking the play control toggles the gem track on the audio store", () => {
+    const track = makeTrack();
+    const { store } = renderGemCard(
+      track,
+      "entirely their own",
+      undefined,
+      "br",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /play/i }));
+
+    expect(store.getState().currentTrack).toBe(track);
+    expect(store.getState().isPlaying).toBe(true);
+    expect(store.getState().currentCountryCode).toBe("br");
+  });
+
+  test("clicking again pauses a gem that's already playing", () => {
+    const track = makeTrack();
+    const { store } = renderGemCard(track, "entirely their own", {
+      currentTrack: track,
+      isPlaying: true,
+      currentCountryCode: "kr",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /pause/i }));
+
+    expect(store.getState().isPlaying).toBe(false);
+  });
+
+  test("play control is disabled with no toggle when there's no preview", () => {
+    const track = makeTrack({ previewUrl: null });
+    const { store } = renderGemCard(track);
+
+    const button = screen.getByRole("button", { name: /play/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(button);
+
+    expect(store.getState().currentTrack).toBeNull();
+  });
+});
+
+describe("GemCard commentary", () => {
+  const COMMENTARY = {
+    lead: "Barely charts anywhere else.",
+    detail: "A homegrown favorite that hasn't spread beyond this market.",
+    tag: "hidden gem",
+    claim: "what-it-is",
+    sources: ["https://www.billboard.com/charts"],
+    generatedAt: "2026-04-25T03:00:00Z",
+  } satisfies Commentary;
+
+  test("reuses the shared commentary panel when the gem has commentary", () => {
+    const track = makeTrack({ commentary: COMMENTARY });
+
+    renderGemCard(track);
+
+    const toggle = screen.getByRole("button", { expanded: false });
+    expect(toggle.textContent).toContain(COMMENTARY.lead);
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByText(COMMENTARY.detail)).toBeDefined();
+  });
+
+  test("renders no commentary affordance when the gem has none", () => {
+    const track = makeTrack();
+
+    renderGemCard(track);
+
+    expect(screen.queryByRole("button", { expanded: false })).toBeNull();
+  });
+});

--- a/src/components/chart-sheet/gem-card.tsx
+++ b/src/components/chart-sheet/gem-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { PauseIcon } from "@/components/icons/pause";
+import { PlayIcon } from "@/components/icons/play";
+import type { Track } from "@/lib/chart-schema";
+import type { GemTier } from "@/lib/select-gem";
+import { useAudioStore } from "@/providers/audio-store-provider";
+
+import { TrackCommentary } from "./track-commentary";
+
+export interface GemCardProps {
+  track: Track;
+  tier: GemTier;
+  countryCode: string;
+}
+
+// The "today's gem" hero card: the play row mirrors TrackRow's (same store
+// reads, same toggle call) so a tap here behaves identically to tapping a
+// ranked row, with the tier label standing in for the rank number.
+export function GemCard({ track, tier, countryCode }: GemCardProps) {
+  const isCurrent = useAudioStore(
+    (s) =>
+      s.currentTrack?.previewUrl === track.previewUrl &&
+      s.currentCountryCode === countryCode,
+  );
+  const isPlaying = useAudioStore(
+    (s) =>
+      s.isPlaying &&
+      s.currentTrack?.previewUrl === track.previewUrl &&
+      s.currentCountryCode === countryCode,
+  );
+  const toggle = useAudioStore((s) => s.toggle);
+
+  const hasPreview = track.previewUrl !== null;
+  const commentary = track.commentary ?? null;
+
+  return (
+    <section
+      aria-label="Today's gem"
+      className="border-fg-1/10 mb-3 flex flex-col rounded-[14px] border px-3 py-2.5"
+    >
+      <button
+        type="button"
+        disabled={!hasPreview}
+        onClick={() => toggle(track, countryCode)}
+        aria-label={`${isPlaying ? "Pause" : "Play"} today's gem, ${track.name} by ${track.artist}`}
+        className="focus-visible:outline-aurora flex min-w-0 items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none"
+      >
+        <span className="text-fg-3 text-body flex w-7 shrink-0 items-center justify-center">
+          {isPlaying ? (
+            <PauseIcon className="text-sunrise h-4 w-4" />
+          ) : (
+            <PlayIcon
+              className={`h-4 w-4 ${isCurrent ? "text-sunrise" : "text-fg-3"}`}
+            />
+          )}
+        </span>
+        <div
+          aria-hidden="true"
+          style={{ backgroundImage: `url(${track.artworkUrl})` }}
+          className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-fg-3 text-micro uppercase">{`Today's gem · ${tier}`}</p>
+          <p
+            className={`text-body truncate font-medium ${
+              isCurrent ? "text-sunrise" : "text-fg-1"
+            }`}
+          >
+            {track.name}
+            {isCurrent && (
+              <span
+                className="eq ml-2 inline-flex align-middle"
+                data-paused={!isPlaying || undefined}
+                aria-hidden
+              >
+                <span />
+                <span />
+                <span />
+              </span>
+            )}
+          </p>
+          <p className="text-fg-2 text-small truncate">
+            {hasPreview ? track.artist : `No preview · ${track.artist}`}
+          </p>
+        </div>
+      </button>
+      {commentary ? <TrackCommentary commentary={commentary} /> : null}
+    </section>
+  );
+}

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { COUNTRY_KR } from "@/lib/__fixtures__";
 import type { AudioEngine } from "@/lib/audio-engine";
 import { createAudioStore } from "@/lib/audio-store";
+import type { Country } from "@/lib/chart-schema";
 import { selectGem } from "@/lib/select-gem";
 import {
   AudioStoreContext,
@@ -139,6 +140,26 @@ describe("ChartSheet", () => {
 
     expect(store.getState().currentTrack).toEqual(gem);
     expect(store.getState().isPlaying).toBe(true);
+  });
+
+  test("renders no gem card, and doesn't throw, for a country with no tracks", () => {
+    const emptyCountry: Country = { ...COUNTRY_KR, tracks: [] };
+    const store = createAudioStore(() => makeMockAudio());
+
+    expect(() =>
+      render(
+        <AudioStoreContext.Provider value={store}>
+          <ChartSheet
+            country={emptyCountry}
+            countryCode="kr"
+            snap="peek"
+            onSnapChange={vi.fn()}
+          />
+        </AudioStoreContext.Provider>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.queryByRole("region", { name: /today's gem/i })).toBeNull();
   });
 
   test("exposes data-snap='peek' when snap prop is peek", () => {

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -1,10 +1,27 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { COUNTRY_KR } from "@/lib/__fixtures__";
-import { AudioStoreProvider } from "@/providers/audio-store-provider";
+import type { AudioEngine } from "@/lib/audio-engine";
+import { createAudioStore } from "@/lib/audio-store";
+import { selectGem } from "@/lib/select-gem";
+import {
+  AudioStoreContext,
+  AudioStoreProvider,
+} from "@/providers/audio-store-provider";
 
 import { ChartSheet, type SnapState } from "./sheet";
+
+function makeMockAudio(): AudioEngine {
+  return {
+    src: "",
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    setVolume: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+}
 
 function setScrollTop(el: Element, value: number) {
   Object.defineProperty(el, "scrollTop", { value, configurable: true });
@@ -45,17 +62,18 @@ function stubRects(viewport: DOMRect, row: DOMRect) {
 
 function renderSheet(snap: SnapState) {
   const onSnapChange = vi.fn();
+  const store = createAudioStore(() => makeMockAudio());
   const utils = render(
-    <AudioStoreProvider>
+    <AudioStoreContext.Provider value={store}>
       <ChartSheet
         country={COUNTRY_KR}
         countryCode="kr"
         snap={snap}
         onSnapChange={onSnapChange}
       />
-    </AudioStoreProvider>,
+    </AudioStoreContext.Provider>,
   );
-  return { ...utils, onSnapChange };
+  return { ...utils, onSnapChange, store };
 }
 
 // Drag the body with a mouse pointer: press, cross the threshold, drag, release.
@@ -86,9 +104,11 @@ describe("ChartSheet", () => {
   test("renders each track in the country", () => {
     renderSheet("peek");
 
+    // getAllByText, not getByText: the gem card duplicates one track's name
+    // and artist above the ranked list, so that track's text renders twice.
     for (const track of COUNTRY_KR.tracks) {
-      expect(screen.getByText(track.name)).toBeDefined();
-      expect(screen.getByText(track.artist)).toBeDefined();
+      expect(screen.getAllByText(track.name).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(track.artist).length).toBeGreaterThan(0);
     }
   });
 
@@ -96,6 +116,29 @@ describe("ChartSheet", () => {
     renderSheet("peek");
 
     expect(screen.getByText(COUNTRY_KR.name)).toBeDefined();
+  });
+
+  test("renders the country's gem, matching what selectGem picks", () => {
+    const { gem, tier } = selectGem(COUNTRY_KR.tracks);
+
+    renderSheet("peek");
+
+    const region = screen.getByRole("region", { name: /today's gem/i });
+    expect(region.textContent).toContain(gem.name);
+    expect(region.textContent).toContain(tier);
+  });
+
+  test("one-tap play from the gem card plays it on the audio store", () => {
+    const { gem } = selectGem(COUNTRY_KR.tracks);
+    const { store } = renderSheet("peek");
+
+    // Scoped to the region: the gem also renders as an ordinary row further
+    // down the list, which has its own same-named play button.
+    const region = screen.getByRole("region", { name: /today's gem/i });
+    fireEvent.click(within(region).getByRole("button", { name: /play/i }));
+
+    expect(store.getState().currentTrack).toEqual(gem);
+    expect(store.getState().isPlaying).toBe(true);
   });
 
   test("exposes data-snap='peek' when snap prop is peek", () => {

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -11,8 +11,10 @@ import {
 import * as Dialog from "@radix-ui/react-dialog";
 
 import type { Country } from "@/lib/chart-schema";
+import { selectGem } from "@/lib/select-gem";
 
 import { firstCommentaryRank } from "./first-commentary-rank";
+import { GemCard } from "./gem-card";
 import { TrackRow } from "./track-row";
 
 export type SnapState = "hidden" | "closed" | "peek" | "full";
@@ -132,6 +134,13 @@ export function ChartSheet({
   // country (the <ol> remounts on country change, resetting the hint).
   const hintRank = useMemo(
     () => firstCommentaryRank(country.tracks),
+    [country.tracks],
+  );
+
+  // selectGem always returns a gem, so the card renders on every landing
+  // regardless of how the country was reached (spin, tap, or shuffle).
+  const gemSelection = useMemo(
+    () => selectGem(country.tracks),
     [country.tracks],
   );
 
@@ -539,6 +548,13 @@ export function ChartSheet({
             data-peek={(snap === "peek" && !isDragging) || undefined}
             className="min-h-0 flex-1 touch-none overflow-y-auto overscroll-y-contain px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] group-data-[snap=full]:touch-pan-y data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
           >
+            <li>
+              <GemCard
+                track={gemSelection.gem}
+                tier={gemSelection.tier}
+                countryCode={countryCode}
+              />
+            </li>
             {country.tracks.map((track) => (
               <TrackRow
                 key={track.rank}

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -137,10 +137,15 @@ export function ChartSheet({
     [country.tracks],
   );
 
-  // selectGem always returns a gem, so the card renders on every landing
-  // regardless of how the country was reached (spin, tap, or shuffle).
+  // selectGem assumes a non-empty track list; a failed crawl with no
+  // carried-forward snapshot can leave a country with none (crawlCountry
+  // writes { valid: false, tracks: [] }), and that country is reachable via
+  // both a random landing and a direct ?cc= — guard here rather than inside
+  // selectGem, which keeps its non-empty precondition simple to reason about.
+  // Otherwise selectGem always returns a gem, so the card renders on every
+  // landing with real tracks, regardless of how it was reached.
   const gemSelection = useMemo(
-    () => selectGem(country.tracks),
+    () => (country.tracks.length > 0 ? selectGem(country.tracks) : null),
     [country.tracks],
   );
 
@@ -548,13 +553,15 @@ export function ChartSheet({
             data-peek={(snap === "peek" && !isDragging) || undefined}
             className="min-h-0 flex-1 touch-none overflow-y-auto overscroll-y-contain px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] group-data-[snap=full]:touch-pan-y data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
           >
-            <li>
-              <GemCard
-                track={gemSelection.gem}
-                tier={gemSelection.tier}
-                countryCode={countryCode}
-              />
-            </li>
+            {gemSelection ? (
+              <li>
+                <GemCard
+                  track={gemSelection.gem}
+                  tier={gemSelection.tier}
+                  countryCode={countryCode}
+                />
+              </li>
+            ) : null}
             {country.tracks.map((track) => (
               <TrackRow
                 key={track.rank}

--- a/src/components/chart-sheet/track-commentary.tsx
+++ b/src/components/chart-sheet/track-commentary.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Fragment, useId, useState } from "react";
+
+import { ChevronDownIcon } from "@/components/icons/chevron-down";
+import type { Commentary } from "@/lib/chart-schema";
+
+import { useCommentaryHintPulse } from "./use-commentary-hint-pulse";
+
+// Cited sources show as bare hostnames; drop a leading www. for scannability.
+const WWW_PREFIX = /^www\./;
+function sourceLabel(url: string): string {
+  try {
+    return new URL(url).hostname.replace(WWW_PREFIX, "");
+  } catch {
+    return url;
+  }
+}
+
+function ChevronGlyph({ expanded }: { expanded: boolean }) {
+  return (
+    <ChevronDownIcon
+      data-expanded={expanded || undefined}
+      className="text-fg-3 h-4 w-4 transition-transform duration-200 ease-[var(--ease-out)] data-[expanded]:rotate-180 motion-reduce:transition-none"
+    />
+  );
+}
+
+// Only mounted on the single hint-target row, so its store reads and observer
+// are paid once. The pulse animates this wrapper, not the SVG inside it.
+function HintedChevron({ expanded }: { expanded: boolean }) {
+  const { chevronRef, pulsing } = useCommentaryHintPulse();
+  return (
+    <span
+      ref={chevronRef}
+      data-commentary-hint={pulsing || undefined}
+      className="inline-flex shrink-0 items-center justify-center"
+    >
+      <ChevronGlyph expanded={expanded} />
+    </span>
+  );
+}
+
+export interface TrackCommentaryProps {
+  commentary: Commentary;
+  // True on the single row eligible for the one-time discovery pulse (see
+  // first-commentary-rank.ts). Callers outside the ranked list, like the gem
+  // card, never pass this.
+  isHintTarget?: boolean;
+}
+
+// The expandable tag/lead/detail/sources panel, shared by TrackRow and the gem
+// card so both surfaces reuse identical commentary markup rather than each
+// carrying its own copy.
+export function TrackCommentary({
+  commentary,
+  isHintTarget,
+}: TrackCommentaryProps) {
+  const [expanded, setExpanded] = useState(false);
+  const panelId = useId();
+
+  return (
+    <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((open) => !open)}
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
+      >
+        <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
+          {commentary.tag}
+        </span>
+        <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
+          {commentary.lead}
+        </span>
+        {isHintTarget ? (
+          <HintedChevron expanded={expanded} />
+        ) : (
+          <span className="inline-flex shrink-0 items-center justify-center">
+            <ChevronGlyph expanded={expanded} />
+          </span>
+        )}
+      </button>
+      <div
+        id={panelId}
+        inert={!expanded}
+        data-expanded={expanded || undefined}
+        className="max-h-0 overflow-hidden transition-[max-height] duration-300 ease-[var(--ease-out)] data-[expanded]:max-h-96 motion-reduce:transition-none"
+      >
+        <div className="flex flex-col gap-2 pt-2">
+          {commentary.detail ? (
+            <p className="text-fg-2 text-small leading-relaxed">
+              {commentary.detail}
+            </p>
+          ) : null}
+          <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
+            {commentary.sources.map((url, i) => (
+              <Fragment key={`${url}-${i}`}>
+                {i > 0 ? (
+                  <span aria-hidden className="text-fg-4 mx-2">
+                    ·
+                  </span>
+                ) : null}
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
+                >
+                  {sourceLabel(url)}
+                </a>
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Fragment, useId, useState } from "react";
+import { useState } from "react";
 
 import { AppleMusicIcon } from "@/components/icons/apple-music";
-import { ChevronDownIcon } from "@/components/icons/chevron-down";
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
 import { SpotifyIcon } from "@/components/icons/spotify";
@@ -11,41 +10,7 @@ import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import type { Track } from "@/lib/chart-schema";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
-import { useCommentaryHintPulse } from "./use-commentary-hint-pulse";
-
-// Cited sources show as bare hostnames; drop a leading www. for scannability.
-const WWW_PREFIX = /^www\./;
-function sourceLabel(url: string): string {
-  try {
-    return new URL(url).hostname.replace(WWW_PREFIX, "");
-  } catch {
-    return url;
-  }
-}
-
-function ChevronGlyph({ expanded }: { expanded: boolean }) {
-  return (
-    <ChevronDownIcon
-      data-expanded={expanded || undefined}
-      className="text-fg-3 h-4 w-4 transition-transform duration-200 ease-[var(--ease-out)] data-[expanded]:rotate-180 motion-reduce:transition-none"
-    />
-  );
-}
-
-// Only mounted on the single hint-target row, so its store reads and observer
-// are paid once. The pulse animates this wrapper, not the SVG inside it.
-function HintedChevron({ expanded }: { expanded: boolean }) {
-  const { chevronRef, pulsing } = useCommentaryHintPulse();
-  return (
-    <span
-      ref={chevronRef}
-      data-commentary-hint={pulsing || undefined}
-      className="inline-flex shrink-0 items-center justify-center"
-    >
-      <ChevronGlyph expanded={expanded} />
-    </span>
-  );
-}
+import { TrackCommentary } from "./track-commentary";
 
 export interface TrackRowProps {
   track: Track;
@@ -87,11 +52,7 @@ export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
     text: track.name,
   });
 
-  // Expand is per-row presentational state, so it stays local rather than in
-  // the audio store.
   const commentary = track.commentary ?? null;
-  const [expanded, setExpanded] = useState(false);
-  const panelId = useId();
 
   return (
     <li
@@ -188,62 +149,7 @@ export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
         </div>
       </div>
       {commentary ? (
-        <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
-          <button
-            type="button"
-            onClick={() => setExpanded((open) => !open)}
-            aria-expanded={expanded}
-            aria-controls={panelId}
-            className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
-          >
-            <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
-              {commentary.tag}
-            </span>
-            <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
-              {commentary.lead}
-            </span>
-            {isHintTarget ? (
-              <HintedChevron expanded={expanded} />
-            ) : (
-              <span className="inline-flex shrink-0 items-center justify-center">
-                <ChevronGlyph expanded={expanded} />
-              </span>
-            )}
-          </button>
-          <div
-            id={panelId}
-            inert={!expanded}
-            data-expanded={expanded || undefined}
-            className="max-h-0 overflow-hidden transition-[max-height] duration-300 ease-[var(--ease-out)] data-[expanded]:max-h-96 motion-reduce:transition-none"
-          >
-            <div className="flex flex-col gap-2 pt-2">
-              {commentary.detail ? (
-                <p className="text-fg-2 text-small leading-relaxed">
-                  {commentary.detail}
-                </p>
-              ) : null}
-              <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
-                {commentary.sources.map((url, i) => (
-                  <Fragment key={`${url}-${i}`}>
-                    {i > 0 ? (
-                      <span aria-hidden className="text-fg-4 mx-2">
-                        ·
-                      </span>
-                    ) : null}
-                    <a
-                      href={url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
-                    >
-                      {sourceLabel(url)}
-                    </a>
-                  </Fragment>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
+        <TrackCommentary commentary={commentary} isHintTarget={isHintTarget} />
       ) : null}
     </li>
   );


### PR DESCRIPTION
Every country landing now shows a "today's gem" hero card inline in the sheet, ahead of the ranked list — the one track that's actually distinctive to that country, one-tap playable, with the existing commentary reused.

Wires `selectGem` (#184) into `ChartSheet` via `useMemo`. The card sits as the first item inside the sheet's existing scrollable list rather than in its fixed header, since the header's peek-mode height is a tuned clamp a new element would've silently broken. Along the way, `TrackCommentary` was extracted out of `TrackRow` into its own component so both it and the new `GemCard` render identical commentary markup instead of forking it. Accessible as a `region` landmark, reduced-motion-safe, screen-reader labeled.

Closes #181.

## Test plan
- [x] `mise exec -- pnpm typecheck / lint / test / build` all pass
- [x] Component tests: render, tier label, commentary reuse, one-tap play/pause
- [x] Integration tests in `sheet.test.tsx` assert the rendered gem matches `selectGem`'s actual pick
- [ ] On-device check of the reduced-motion and screen-reader behavior (not run by this agent)

**Stacked on #184** (180-select-gem) — merge in order: 183 → 184 → this.
