### PR TITLE
Queue a country's gem for commentary regardless of rank movement

### DIFF
--- a/docs/adr/0014-gem-selection-triggers-commentary.md
+++ b/docs/adr/0014-gem-selection-triggers-commentary.md
@@ -1,0 +1,34 @@
+# ADR-0014: A country's gem triggers commentary regardless of rank movement, and bypasses the confidence penalty
+
+**Status:** Accepted (2026-07-06). Extends [ADR-0007](0007-out-of-band-human-curated-commentary.md)'s significance trigger and its confidence gate; neither is replaced.
+
+## Context
+
+[#175](https://github.com/taewanu/sounds-abroad/issues/175) added a "today's gem" card: on every country landing, `selectGem` (from [#180](https://github.com/taewanu/sounds-abroad/issues/180)) surfaces the one track that's distinctly local — low `spread` ([ADR-0013](0013-bake-track-spread-at-crawl-time.md)), meaning it barely charts anywhere else. The card is built to reuse the existing commentary panel, so the natural expectation is that a gem usually has a "why it's trending here" blurb to show.
+
+In practice it often doesn't. The commentary worklist (`scripts/commentary/worklist.ts`) only queues a track when its rank moves significantly — `new-entry`, `rank-jump`, `top-debut` — against the prior crawl. A track holding a stable rank never re-triggers, no matter how prominent. Separately, `chartConfidence` treats a track's charting footprint as `"low"` (a "thin-market quirk, not a real story") when it's confined to one storefront or a same-region pair, and low-confidence items sort to the back of the queue (or drop entirely, under `suppressLowConfidence`).
+
+These two mechanisms collide with gem selection rather than complementing it. A gem is, by construction, a low-spread track — usually confined to one or two markets, which is exactly the footprint `chartConfidence` calls thin. And a genuinely strong local hit is often stable at the top of its chart rather than freshly moving, which is exactly what the significance trigger ignores. Confirmed live: `REDRED` by 코르티스 was rank 1 in South Korea, selected as Korea's gem, and had no commentary — it never re-entered the worklist (no recent movement), and its single-market footprint would have sorted it toward the back even if it had.
+
+## Decision
+
+A track selected as some country's gem (`WorklistReason: "local-gem"`) queues for commentary even with no rank movement, and is exempt from the confidence-based penalty — it neither gets suppressed by `suppressLowConfidence` nor sorted behind confident items. Being selected as a gem is itself independent evidence of a real local story (a `spread`-based cross-country comparison, not a same-tier proxy like `chartConfidence`'s regional-adjacency heuristic), so the thin-footprint signal that would otherwise read as noise reads as the point instead.
+
+This bypass applies only to gems in the `"entirely their own"` or `"a local favorite"` tier. The `"their most local pick today"` fallback tier — `selectGem`'s answer when a market has no genuinely local track at all — carries the same thin evidence `chartConfidence` already distrusts, so it does not bypass the gate. A weak-evidence gem is still worth showing in the UI (the card must never be empty), but it isn't worth spending generation and human-review effort proving a story that the selection function itself flagged as its last resort.
+
+A real movement reason still takes precedence when both apply — it's the more specific, tellable story; `"local-gem"` is a fallback for when no movement reason exists, not an override of one.
+
+## Consequences
+
+**Positive**
+
+- A country's most emblematic track is much more likely to have an explanation on the card that's built specifically to invite the question "why is this trending here?"
+- The bypass is scoped to gems with real spread evidence, so it doesn't undo `chartConfidence`'s original purpose — filtering out actually-thin, uninteresting chart positions — for tracks that merely happen to sit in a data-thin market with no compelling gem candidate.
+
+**Negative**
+
+- Adds up to one new worklist candidate per country per crawl (bounded by 63, less in practice since most countries' gems stabilize and already have commentary), a modest addition to the out-of-band generation and human-review load ([ADR-0008](0008-risk-tiered-commentary-gate.md)).
+
+**Neutral**
+
+- The significance trigger and `chartConfidence` are unchanged for every non-gem track; this is an additional trigger and a narrow, evidenced exemption, not a redesign of either mechanism.

--- a/scripts/commentary/draft.test.ts
+++ b/scripts/commentary/draft.test.ts
@@ -17,6 +17,7 @@ function item(overrides: Partial<WorklistItem> = {}): WorklistItem {
     bestRank: 3,
     reason: "new-entry",
     confidence: "ok",
+    isGem: false,
     countries: [
       { cc: "us", rank: 3 },
       { cc: "ca", rank: 5 },

--- a/scripts/commentary/draft.ts
+++ b/scripts/commentary/draft.ts
@@ -99,6 +99,8 @@ const SIGNIFICANCE: Record<WorklistReason, (bestRank: number) => string> = {
   "new-entry": (r) => `a new chart entry, peaking at #${r}`,
   "rank-jump": (r) => `a sharp climb up the chart, now peaking at #${r}`,
   "top-debut": (r) => `a strong move into the upper chart, peaking at #${r}`,
+  "local-gem": (r) =>
+    `a track distinctly local to where it charts, holding at #${r} there while barely charting anywhere else`,
 };
 
 /**

--- a/scripts/commentary/worklist.test.ts
+++ b/scripts/commentary/worklist.test.ts
@@ -9,7 +9,12 @@ import {
 import type { DropsStore } from "./drops";
 import { chartConfidence, computeWorklist } from "./worklist";
 
-function track(rank: number, artist: string, name: string): Track {
+function track(
+  rank: number,
+  artist: string,
+  name: string,
+  spread?: number,
+): Track {
   return {
     rank,
     name,
@@ -18,6 +23,7 @@ function track(rank: number, artist: string, name: string): Track {
     artworkUrl: "https://art/x/600x600bb.jpg",
     appleUrl: "https://music.apple.com/x/1",
     spotifyUrl: "https://open.spotify.com/search/x",
+    spread,
   };
 }
 
@@ -336,4 +342,81 @@ test("suppresses low-confidence items entirely when asked", () => {
   });
 
   expect(items.map((i) => i.name)).toEqual(["Broad Mover"]);
+});
+
+test("queues a country's stable gem for commentary even with no rank movement", () => {
+  const previous = chart({
+    kr: country("South Korea", [
+      track(1, "Artist A", "Local Hit", 1),
+      track(2, "Artist B", "Global Hit", 40),
+    ]),
+  });
+  const current = chart({
+    kr: country("South Korea", [
+      track(1, "Artist A", "Local Hit", 1),
+      track(2, "Artist B", "Global Hit", 40),
+    ]),
+  });
+
+  const items = computeWorklist({ current, previous, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual(["Local Hit"]);
+  expect(items[0].reason).toBe("local-gem");
+  expect(items[0].isGem).toBe(true);
+});
+
+test("does not queue a fallback-tier gem picked from a market with no real local track", () => {
+  const previous = chart({
+    kr: country("South Korea", [
+      track(1, "Artist A", "Global A", 40),
+      track(2, "Artist B", "Global B", 38),
+    ]),
+  });
+  const current = chart({
+    kr: country("South Korea", [
+      track(1, "Artist A", "Global A", 40),
+      track(2, "Artist B", "Global B", 38),
+    ]),
+  });
+
+  const items = computeWorklist({ current, previous, commentary: {} });
+
+  expect(items).toEqual([]);
+});
+
+test("a local-gem bypasses suppressLowConfidence", () => {
+  const current = chart({
+    jp: country("Japan", [
+      track(1, "Artist A", "Local Hit", 1),
+      track(2, "Artist B", "Global Hit", 40),
+    ]),
+  });
+
+  const items = computeWorklist({
+    current,
+    previous: null,
+    commentary: {},
+    options: { suppressLowConfidence: true },
+  });
+
+  expect(items.map((i) => i.name)).toEqual(["Local Hit"]);
+});
+
+test("a local-gem sorts ahead of similarly thin non-gems despite a worse rank", () => {
+  const current = chart({
+    jp: country("Japan", [
+      track(9, "Artist A", "Local Hit", 1),
+      track(1, "Artist B", "Filler", 40),
+    ]),
+    kr: country("South Korea", [track(2, "Artist C", "Thin Mover")]),
+  });
+
+  const items = computeWorklist({ current, previous: null, commentary: {} });
+
+  expect(items.map((i) => i.name)).toEqual([
+    "Local Hit",
+    "Filler",
+    "Thin Mover",
+  ]);
+  expect(items[0].isGem).toBe(true);
 });

--- a/scripts/commentary/worklist.ts
+++ b/scripts/commentary/worklist.ts
@@ -5,17 +5,23 @@ import {
   type CommentaryStore,
 } from "../../src/lib/commentary-store";
 import { COUNTRIES, type Region } from "../../src/lib/countries";
+import { selectGem } from "../../src/lib/select-gem";
 
 import { DEFAULT_MAX_ATTEMPTS, type DropsStore } from "./drops";
 
 /**
  * The worklist for a refinement pass: which charting tracks still need a blurb.
- * A track qualifies only if its movement is significant AND no blurb exists yet,
- * so a pass surfaces a tractable, deduped list instead of every charting track
- * (ADR-0007's quantitative gate, an analog to a significance trigger).
+ * A track qualifies if its movement is significant, OR it's some country's
+ * "today's gem" (ADR-0014), AND no blurb exists yet, so a pass surfaces a
+ * tractable, deduped list instead of every charting track (ADR-0007's
+ * quantitative gate, an analog to a significance trigger).
  */
 
-export type WorklistReason = "new-entry" | "rank-jump" | "top-debut";
+export type WorklistReason =
+  | "new-entry"
+  | "rank-jump"
+  | "top-debut"
+  | "local-gem";
 
 export interface WorklistItem {
   key: string;
@@ -24,6 +30,8 @@ export interface WorklistItem {
   bestRank: number;
   reason: WorklistReason;
   confidence: ConfidenceLevel;
+  /** Some country's selected gem (ADR-0014) — bypasses the low-confidence penalty below. */
+  isGem: boolean;
   countries: { cc: string; rank: number }[];
 }
 
@@ -128,6 +136,26 @@ export function chartConfidence(
   return "low";
 }
 
+/**
+ * The set of commentary keys currently selected as some country's gem with
+ * real evidence behind the pick (ADR-0014): "entirely their own" or "a local
+ * favorite", meaning an actual low-spread track exists. Excludes the
+ * "their most local pick today" fallback tier deliberately — that tier fires
+ * precisely when a market has no genuinely local track, so it carries the
+ * same thin evidence chartConfidence already distrusts, not a reason to
+ * bypass it.
+ */
+function gemKeys(chart: ChartFile, lang: string): Set<string> {
+  const keys = new Set<string>();
+  for (const country of Object.values(chart.countries)) {
+    if (!country.valid || country.tracks.length === 0) continue;
+    const { gem, tier } = selectGem(country.tracks);
+    if (tier === "their most local pick today") continue;
+    keys.add(commentaryKey(lang, gem.artist, gem.name));
+  }
+  return keys;
+}
+
 function bestRankByKey(
   chart: ChartFile | null,
   lang: string,
@@ -182,21 +210,31 @@ export function computeWorklist(input: {
   const current = aggregateByKey(input.current, lang);
   const previousBest = bestRankByKey(input.previous, lang);
   const hasHistory = input.previous !== null;
+  const gems = gemKeys(input.current, lang);
 
   const items: WorklistItem[] = [];
   for (const [key, agg] of current) {
     if (key in input.commentary) continue; // cache hit: never regenerate
     if ((drops[key]?.attempts ?? 0) >= maxAttempts) continue; // tombstoned: retries spent
-    const reason = classify(
+    const isGem = gems.has(key);
+    const movementReason = classify(
       agg.bestRank,
       previousBest.get(key),
       hasHistory,
       jumpBy,
       topDebutMax,
     );
+    // A gem queues even with no rank movement (e.g. a stable local #1 that
+    // would otherwise never re-trigger); a real movement reason still wins
+    // when both apply, since it's the more specific story.
+    const reason = movementReason ?? (isGem ? "local-gem" : null);
     if (!reason) continue;
     const confidence = chartConfidence(agg.countries);
-    if (confidence === "low" && suppressLowConfidence) continue;
+    // A gem is single-market by construction (that's what makes it a gem),
+    // which is exactly what chartConfidence reads as a thin-market quirk.
+    // Being selected as a gem is itself evidence the position is a real
+    // local story, so it bypasses that penalty (ADR-0014).
+    if (confidence === "low" && suppressLowConfidence && !isGem) continue;
     items.push({
       key,
       artist: agg.artist,
@@ -204,16 +242,20 @@ export function computeWorklist(input: {
       bestRank: agg.bestRank,
       reason,
       confidence,
+      isGem,
       countries: [...agg.countries].sort((a, b) => a.rank - b.rank),
     });
   }
 
   // Confident items first so a pass spends effort on them before any retained
-  // low-confidence ones; within a tier, by best rank then key for stability.
-  const confidenceWeight = (c: ConfidenceLevel) => (c === "low" ? 1 : 0);
+  // low-confidence ones; a gem always sorts as if confident, for the same
+  // reason it bypasses suppression above. Within a tier, by best rank then
+  // key for stability.
+  const confidenceWeight = (item: WorklistItem) =>
+    item.confidence === "low" && !item.isGem ? 1 : 0;
   return items.sort(
     (a, b) =>
-      confidenceWeight(a.confidence) - confidenceWeight(b.confidence) ||
+      confidenceWeight(a) - confidenceWeight(b) ||
       a.bestRank - b.bestRank ||
       a.key.localeCompare(b.key),
   );


### PR DESCRIPTION
A country's gem now gets a commentary shot even when it's a stable, unmoving hit — before this, the exact card built to make someone ask "why is this trending here?" was structurally the one least likely to have an answer.

The existing significance trigger only queues a track that recently moved rank; `chartConfidence` separately treats a thin cross-country footprint as reason to distrust a track. Both worked against gem selection, whose whole premise is a thin footprint (low spread) as a positive signal. Adds a `local-gem` worklist reason that fires with no rank movement and bypasses the confidence penalty — scoped to gems with real evidence (`"entirely their own"` / `"a local favorite"`), excluding the `"their most local pick today"` fallback tier, which has none. ADR-0014 has the full reasoning.

Found live while visually verifying #175's slices: `REDRED` by 코르티스, rank 1 in South Korea, selected as Korea's gem, `commentary: null`.

Closes #187.

## Test plan
- [x] `mise exec -- pnpm typecheck / lint / test / build` all pass (554 tests)
- [x] 4 new tests: stable gem queues, fallback-tier gem doesn't, confidence-suppression bypass, sort-order bypass
- [x] No existing test needed changes — none set `spread`, so all fall into the excluded fallback tier automatically

**Stacked on #184** (180-select-gem) — needs `selectGem`; not part of the 179→182 gem-card UI chain, can merge independently once 184 lands.
