### PR TITLE
UI: gem card visual polish

### DIFF
--- a/src/components/chart-sheet/gem-card.test.tsx
+++ b/src/components/chart-sheet/gem-card.test.tsx
@@ -146,6 +146,18 @@ describe("GemCard", () => {
   });
 });
 
+describe("GemCard tier strength meter", () => {
+  test.each([
+    ["entirely their own", 3],
+    ["a local favorite", 2],
+    ["their most local pick today", 1],
+  ] as const)('tier "%s" lights %i dot(s)', (tier, litCount) => {
+    const { container } = renderGemCard(makeTrack(), tier);
+
+    expect(container.querySelectorAll("[data-lit]")).toHaveLength(litCount);
+  });
+});
+
 describe("GemCard commentary", () => {
   const COMMENTARY = {
     lead: "Barely charts anywhere else.",

--- a/src/components/chart-sheet/gem-card.tsx
+++ b/src/components/chart-sheet/gem-card.tsx
@@ -32,6 +32,7 @@ function TierDots({ tier }: { tier: GemTier }) {
       {[1, 2, 3].map((dot) => (
         <span
           key={dot}
+          data-lit={dot <= lit || undefined}
           className={`h-1 w-1 rounded-full ${dot <= lit ? "bg-fg-1" : "bg-fg-1/15"}`}
         />
       ))}

--- a/src/components/chart-sheet/gem-card.tsx
+++ b/src/components/chart-sheet/gem-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GemIcon } from "@/components/icons/gem";
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
 import type { Track } from "@/lib/chart-schema";
@@ -12,6 +13,30 @@ export interface GemCardProps {
   track: Track;
   tier: GemTier;
   countryCode: string;
+}
+
+// Dots lit per tier, strongest to fallback, mirroring selectGem's own order
+// (select-gem.ts) so the meter and the wording never drift apart.
+const TIER_STRENGTH: Record<GemTier, number> = {
+  "entirely their own": 3,
+  "a local favorite": 2,
+  "their most local pick today": 1,
+};
+
+// A three-dot strength meter standing next to the tier label so the three
+// tiers read apart by shape, not only by wording or color.
+function TierDots({ tier }: { tier: GemTier }) {
+  const lit = TIER_STRENGTH[tier];
+  return (
+    <span aria-hidden className="flex shrink-0 items-center gap-0.5">
+      {[1, 2, 3].map((dot) => (
+        <span
+          key={dot}
+          className={`h-1 w-1 rounded-full ${dot <= lit ? "bg-fg-1" : "bg-fg-1/15"}`}
+        />
+      ))}
+    </span>
+  );
 }
 
 // The "today's gem" hero card: the play row mirrors TrackRow's (same store
@@ -37,7 +62,7 @@ export function GemCard({ track, tier, countryCode }: GemCardProps) {
   return (
     <section
       aria-label="Today's gem"
-      className="border-fg-1/10 mb-3 flex flex-col rounded-[14px] border px-3 py-2.5"
+      className="border-fg-1/10 bg-atmos mb-3 flex flex-col rounded-lg border px-3 py-2.5"
     >
       <button
         type="button"
@@ -61,7 +86,14 @@ export function GemCard({ track, tier, countryCode }: GemCardProps) {
           className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
         />
         <div className="min-w-0 flex-1">
-          <p className="text-fg-3 text-micro uppercase">{`Today's gem · ${tier}`}</p>
+          <p className="text-gold text-micro mb-0.5 flex items-center gap-1.5 font-medium tracking-wide uppercase">
+            <GemIcon className="h-3.5 w-3.5 shrink-0" />
+            {"Today's gem"}
+          </p>
+          <p className="text-fg-2 text-small mb-0.5 flex min-w-0 items-center gap-1.5">
+            <TierDots tier={tier} />
+            <span className="min-w-0 truncate">{tier}</span>
+          </p>
           <p
             className={`text-body truncate font-medium ${
               isCurrent ? "text-sunrise" : "text-fg-1"

--- a/src/components/icons/gem.tsx
+++ b/src/components/icons/gem.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from "react";
+
+// Vendored from Lucide (`gem`, MIT) — a faceted gem, marking the hero card as
+// this landing's one deliberately curated pick rather than another chart row.
+export function GemIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M10.5 3 8 9l4 13 4-13-2.5-6" />
+      <path d="M17 3a2 2 0 0 1 1.6.8l3 4a2 2 0 0 1 .013 2.382l-7.99 10.986a2 2 0 0 1-3.247 0l-7.99-10.986A2 2 0 0 1 2.4 7.8l2.998-3.997A2 2 0 0 1 7 3z" />
+      <path d="M2 9h20" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Styles the gem card so it reads as a deliberately curated pick rather than another chart row — no logic changes, presentation only.

Gives the card a distinct hero surface, adds a gold "Today's gem" eyebrow with a gem glyph, and a three-dot strength meter next to the tier label so the three tiers are distinguishable by shape, not color alone. Placement stays inside the sheet's scrollable list (a deliberate functional choice from #190, not a placeholder) — this PR finalizes it visually instead of moving it in the DOM.

Also includes the fix already reviewed on the original #186: added a `data-lit` attribute per dot and test coverage for all 3 tiers' lit-dot count.

Closes #182.

## Test plan
- [x] `mise exec -- pnpm typecheck / lint / test / build` all pass (566 tests)
- [x] Existing a11y/interaction tests pass unregressed after the restyle

Replaces #186. Stacked on #190 (181-gem-card-functional-v2).