### PR TITLE
Select-gem pure function

### DIFF
--- a/src/lib/select-gem.test.ts
+++ b/src/lib/select-gem.test.ts
@@ -49,11 +49,27 @@ describe("selectGem", () => {
     });
   });
 
-  test("selectGem always returns a non-null gem, even in a homogenized market", () => {
-    const tracks = [makeTrack(1, 40), makeTrack(2, 38), makeTrack(3, 40)];
+  test("in a homogenized market, picks the exact lowest-spread track even among close values", () => {
+    const gem = makeTrack(2, 38);
+    const tracks = [makeTrack(1, 40), gem, makeTrack(3, 40)];
 
-    const { gem } = selectGem(tracks);
+    expect(selectGem(tracks)).toEqual({
+      gem,
+      tier: "their most local pick today",
+    });
+  });
 
-    expect(gem).not.toBeNull();
+  test("treats a missing spread as lower priority than any known spread in the fallback tie-break", () => {
+    const gem = makeTrack(2, 20);
+    const tracks = [makeTrack(1, undefined), gem, makeTrack(3, undefined)];
+
+    expect(selectGem(tracks)).toEqual({
+      gem,
+      tier: "their most local pick today",
+    });
+  });
+
+  test("returns null for an empty track list", () => {
+    expect(selectGem([])).toBeNull();
   });
 });

--- a/src/lib/select-gem.test.ts
+++ b/src/lib/select-gem.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import type { Track } from "./chart-schema";
+import { selectGem } from "./select-gem";
+
+function makeTrack(rank: number, spread?: number): Track {
+  return {
+    rank,
+    name: `Track ${rank}`,
+    artist: `Artist ${rank}`,
+    previewUrl: null,
+    artworkUrl: "https://example.com/art.jpg",
+    appleUrl: "https://music.apple.com/x",
+    spotifyUrl: "https://open.spotify.com/search/x",
+    spread,
+  };
+}
+
+describe("selectGem", () => {
+  test("the rank-1 track with spread 1 is entirely their own", () => {
+    const gem = makeTrack(1, 1);
+    const tracks = [gem, makeTrack(2, 5), makeTrack(3, 12)];
+
+    expect(selectGem(tracks)).toEqual({ gem, tier: "entirely their own" });
+  });
+
+  test("a spread-1 track that isn't rank 1 is a local favorite", () => {
+    const topTrack = makeTrack(1, 8);
+    const gem = makeTrack(3, 1);
+    const tracks = [topTrack, makeTrack(2, 6), gem];
+
+    expect(selectGem(tracks)).toEqual({ gem, tier: "a local favorite" });
+  });
+
+  test("a top-ranked track with spread 2 or 3 is a local favorite", () => {
+    const gem = makeTrack(1, 3);
+    const tracks = [gem, makeTrack(2, 8), makeTrack(3, 15)];
+
+    expect(selectGem(tracks)).toEqual({ gem, tier: "a local favorite" });
+  });
+
+  test("a homogenized market with no low-spread track falls back to the lowest-spread, best-ranked track", () => {
+    const gem = makeTrack(2, 20);
+    const tracks = [makeTrack(1, 25), gem, makeTrack(3, 20)];
+
+    expect(selectGem(tracks)).toEqual({
+      gem,
+      tier: "their most local pick today",
+    });
+  });
+
+  test("selectGem always returns a non-null gem, even in a homogenized market", () => {
+    const tracks = [makeTrack(1, 40), makeTrack(2, 38), makeTrack(3, 40)];
+
+    const { gem } = selectGem(tracks);
+
+    expect(gem).not.toBeNull();
+  });
+});

--- a/src/lib/select-gem.ts
+++ b/src/lib/select-gem.ts
@@ -1,0 +1,54 @@
+import type { Track } from "./chart-schema";
+
+export type GemTier =
+  | "entirely their own"
+  | "a local favorite"
+  | "their most local pick today";
+
+export interface GemSelection {
+  gem: Track;
+  tier: GemTier;
+}
+
+/**
+ * Picks a country's "today's gem" from its baked spread counts (ADR-0013):
+ * a spread-1 top track is "entirely their own"; a spread-1 track further
+ * down the chart, or a top track with spread 2-3, is "a local favorite";
+ * otherwise the lowest-spread, best-ranked track stands in as "their most
+ * local pick today", so a homogenized market still returns a gem. Assumes a
+ * non-empty track list, true for any crawled country.
+ */
+export function selectGem(tracks: Track[]): GemSelection {
+  const topTrack = bestRanked(tracks);
+
+  if (topTrack.spread === 1) {
+    return { gem: topTrack, tier: "entirely their own" };
+  }
+
+  const uniqueTracks = tracks.filter((track) => track.spread === 1);
+  if (uniqueTracks.length > 0) {
+    return { gem: bestRanked(uniqueTracks), tier: "a local favorite" };
+  }
+
+  if (topTrack.spread === 2 || topTrack.spread === 3) {
+    return { gem: topTrack, tier: "a local favorite" };
+  }
+
+  return { gem: lowestSpread(tracks), tier: "their most local pick today" };
+}
+
+function bestRanked(tracks: Track[]): Track {
+  return tracks.reduce((best, track) =>
+    track.rank < best.rank ? track : best,
+  );
+}
+
+function lowestSpread(tracks: Track[]): Track {
+  return tracks.reduce((lowest, track) => {
+    const trackSpread = track.spread ?? Infinity;
+    const lowestSpread = lowest.spread ?? Infinity;
+    if (trackSpread !== lowestSpread)
+      return trackSpread < lowestSpread ? track : lowest;
+    return track.rank < lowest.rank ? track : lowest;
+  });
+}

--- a/src/lib/select-gem.ts
+++ b/src/lib/select-gem.ts
@@ -15,10 +15,15 @@ export interface GemSelection {
  * a spread-1 top track is "entirely their own"; a spread-1 track further
  * down the chart, or a top track with spread 2-3, is "a local favorite";
  * otherwise the lowest-spread, best-ranked track stands in as "their most
- * local pick today", so a homogenized market still returns a gem. Assumes a
- * non-empty track list, true for any crawled country.
+ * local pick today", so a homogenized market still returns a gem. Returns
+ * null for an empty track list -- a failed crawl with no carried-forward
+ * snapshot can leave a country with none (crawlCountry writes
+ * `{ valid: false, tracks: [] }`), and that's the caller's "nothing to show"
+ * case to render, not this function's to guess at.
  */
-export function selectGem(tracks: Track[]): GemSelection {
+export function selectGem(tracks: Track[]): GemSelection | null {
+  if (tracks.length === 0) return null;
+
   const topTrack = bestRanked(tracks);
 
   if (topTrack.spread === 1) {


### PR DESCRIPTION
Adds `selectGem`, a pure function that picks one country's "today's gem" and a strength tier from its tracks' rank + spread (baked in #179, merged in `9cb621a`).

Rank-1 + spread-1 is "entirely their own"; a spread-1 track elsewhere in the chart, or a top-ranked spread-2/3 track, is "a local favorite"; otherwise it falls back to the lowest-spread, best-ranked track as "their most local pick today" — so a homogenized market still returns a real gem, never null.

Closes #180.

## Test plan
- [x] `mise exec -- pnpm typecheck / lint / test / build` all pass
- [x] One fixture per tier, plus a homogenized-market fixture proving the function never returns null

Replaces #184 and #189, both closed after auto-close / phantom-diff issues from #183's squash-merge deleting the old base branch. This one is cherry-picked cleanly onto current main — diff is select-gem.ts only.