### PR TITLE
chore: release v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` 2.1.0 → 2.2.0 to cut the v2.2.0 release. Additive batch (discovery + playback navigation), so a minor (ADR-0005).

## Scope (since v2.1.0)

**Discovery**
- #175 today's hidden gem per country — one low-spread, high-local-rank track surfaced on every landing (#179 spread baked at crawl, #181 gem card, #187 commentary reconciliation)
- #177 shuffle to a random country; #178 its glass styling

**Playback navigation**
- #162 prev/next from the mini-player (buttons, swipe, OS media keys)
- #164 auto-scroll the open sheet to the now-playing row
- #163 double-tap the globe edge to skip tracks
- #170 keep rapid skips from wedging the player (fixes #92)

**Spotify deeplink accuracy**
- #159 resolve exact `/track/{id}` deeplinks at crawl (fixes #80)
- #160 parallelize the resolve, raise the crawl timeout
- #161 drop the legacy `spotifySearchUrl` migration shim

## Release steps
- [x] Bump `package.json` → 2.2.0
- [ ] Squash-merge
- [ ] Tag `v2.2.0` on the squash commit
- [ ] Publish the GitHub Release
- [ ] Move #88 Unreleased → Shipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **2.2.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->