### PR TITLE
refactor(player): route end-of-track auto-advance through step()

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -2,6 +2,8 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { CHARTS, CODE_BR, CODE_US, COUNTRY_US } from "@/lib/__fixtures__";
+import type { AudioEngine } from "@/lib/audio-engine";
+import type { ChartFile } from "@/lib/chart-schema";
 import { globeChartStore } from "@/lib/globe-chart-store";
 
 const mockSearchParams = vi.hoisted(() => ({
@@ -12,7 +14,111 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams.value,
 }));
 
+// A controllable stand-in for the browser audio engine so the component tree
+// can play and end a track under happy-dom, which has no AudioContext.
+const audioEngine = vi.hoisted(() => {
+  let listeners: Partial<Record<string, Array<() => void>>> = {};
+  return {
+    reset() {
+      listeners = {};
+    },
+    create(): AudioEngine {
+      let src = "";
+      return {
+        get src() {
+          return src;
+        },
+        set src(value: string) {
+          src = value;
+        },
+        play: () => Promise.resolve(),
+        pause: () => {},
+        setVolume: () => {},
+        addEventListener: (type, listener) => {
+          (listeners[type] ??= []).push(listener);
+        },
+        removeEventListener: () => {},
+      };
+    },
+    end() {
+      (listeners.ended ?? []).forEach((listener) => listener());
+    },
+  };
+});
+
+vi.mock("@/lib/audio-engine", () => ({
+  createBrowserAudioEngine: () => audioEngine.create(),
+}));
+
 import { ChartScreen } from "./chart-screen";
+
+// A chart whose middle track has no preview, so the correct next track from #1
+// is #3. Any "next" that walks a bare index would land on the unplayable #2.
+const ADJ_CODE = "zz";
+const ADJACENCY_CHARTS: ChartFile = {
+  lastUpdated: "2026-04-25T03:00:00Z",
+  countries: {
+    [ADJ_CODE]: {
+      name: "Chart under test",
+      valid: true,
+      tracks: [
+        {
+          rank: 1,
+          name: "Playable head",
+          artist: "Head artist",
+          previewUrl: "https://example.com/head.m4a",
+          artworkUrl: "https://example.com/head.jpg",
+          appleUrl: "https://music.apple.com/x/head",
+          spotifyUrl: "https://open.spotify.com/x/head",
+        },
+        {
+          rank: 2,
+          name: "Unplayable gap",
+          artist: "Gap artist",
+          previewUrl: null,
+          artworkUrl: "https://example.com/gap.jpg",
+          appleUrl: "https://music.apple.com/x/gap",
+          spotifyUrl: "https://open.spotify.com/x/gap",
+        },
+        {
+          rank: 3,
+          name: "Playable tail",
+          artist: "Tail artist",
+          previewUrl: "https://example.com/tail.m4a",
+          artworkUrl: "https://example.com/tail.jpg",
+          appleUrl: "https://music.apple.com/x/tail",
+          spotifyUrl: "https://open.spotify.com/x/tail",
+        },
+      ],
+    },
+  },
+};
+
+function playingRank(container: HTMLElement): string | null {
+  return (
+    container
+      .querySelector('li[data-state="playing"]')
+      ?.getAttribute("data-rank") ?? null
+  );
+}
+
+// Render the chart, start the head track, run one "advance" gesture, and report
+// the rank left playing.
+function advanceFromHead(advance: () => void): string | null {
+  audioEngine.reset();
+  const { container, unmount } = render(
+    <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+  );
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "Play preview of Playable head by Head artist",
+    }),
+  );
+  advance();
+  const rank = playingRank(container);
+  unmount();
+  return rank;
+}
 
 describe("ChartScreen", () => {
   let replaceState: ReturnType<typeof vi.spyOn>;
@@ -159,5 +265,49 @@ describe("ChartScreen globe coupling", () => {
     // The mini player only mounts once a track plays; its absence after a settle
     // shows the landing selected a country without starting audio.
     expect(screen.queryByRole("button", { name: "Reopen chart" })).toBeNull();
+  });
+});
+
+describe("ChartScreen auto-advance", () => {
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams(`cc=${ADJ_CODE}`);
+    audioEngine.reset();
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("a track ending advances to the next playable track, skipping one with no preview", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+    expect(playingRank(container)).toBe("1");
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    expect(playingRank(container)).toBe("3");
+  });
+
+  test("auto-advance lands on the track that pressing Next lands on", () => {
+    const viaEnded = advanceFromHead(() => {
+      act(() => {
+        audioEngine.end();
+      });
+    });
+    const viaNext = advanceFromHead(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+    });
+
+    expect(viaEnded).toBe("3");
+    expect(viaEnded).toBe(viaNext);
   });
 });

--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -310,4 +310,24 @@ describe("ChartScreen auto-advance", () => {
     expect(viaEnded).toBe("3");
     expect(viaEnded).toBe(viaNext);
   });
+
+  test("ending the last playable track falls silent instead of wrapping to the head", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable tail by Tail artist",
+      }),
+    );
+    expect(playingRank(container)).toBe("3");
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    // step(1) finds no track past the tail, returns false, and advances nothing,
+    // so the chart ends in silence rather than wrapping back to the head.
+    expect(playingRank(container)).toBeNull();
+  });
 });

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -113,25 +113,6 @@ function ChartScreenInner({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [audioStore]);
 
-  // Advance within the source country, not the visible one. Ref-gated so
-  // only an actual ended event triggers advance, never a dep-only re-run.
-  const prevEndedRef = useRef(endedSignal);
-  useEffect(() => {
-    if (endedSignal === prevEndedRef.current) return;
-    prevEndedRef.current = endedSignal;
-    if (endedSignal === 0) return;
-    const { currentTrack, currentCountryCode, toggle } = audioStore.getState();
-    if (currentTrack === null || currentCountryCode === null) return;
-    const source = charts.countries[currentCountryCode];
-    if (!source) return;
-    const next = findAdjacentPlayable(
-      source.tracks,
-      currentTrack.previewUrl,
-      1,
-    );
-    if (next) toggle(next, currentCountryCode);
-  }, [endedSignal, audioStore, charts.countries]);
-
   // Hidden sheet has no on-screen affordance; the next pointerdown anywhere
   // restores it.
   useEffect(() => {
@@ -194,6 +175,18 @@ function ChartScreenInner({
   );
   const goPrev = useCallback(() => step(-1), [step]);
   const goNext = useCallback(() => step(1), [step]);
+
+  // A track ending advances through the same step as the buttons, swipe, media
+  // keys, and edge-tap, so every "next track" shares one adjacency rule. Step
+  // no-ops past the last playable track, so the chart still ends in silence.
+  // Ref-gated so only an actual ended event advances, never a dep-only re-run.
+  const prevEndedRef = useRef(endedSignal);
+  useEffect(() => {
+    if (endedSignal === prevEndedRef.current) return;
+    prevEndedRef.current = endedSignal;
+    if (endedSignal === 0) return;
+    step(1);
+  }, [endedSignal, step]);
 
   const canPrev = useMemo(() => {
     if (currentTrack === null || currentCountryCode === null) return false;


### PR DESCRIPTION
The end-of-track effect reimplemented the adjacency walk (`findAdjacentPlayable` + `toggle`) that `step()` already owns, so a change to the skip rule would silently leave the natural-end path behind. It now calls `step(1)`, so buttons, swipe, media keys, edge-tap, and track-end all share one "next track" rule. `step` no-ops past the last playable track, so the chart still ends in silence.

## Test plan
- New `ChartScreen auto-advance` suite: a track ending advances to the next *playable* track (skipping one with no preview), and lands on the exact track pressing **Next** lands on.
- `mise exec -- pnpm typecheck && pnpm lint && pnpm test` all green locally (575 pass).

Closes #168