### PR TITLE
refactor(globe): make the skip seam data-only

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -75,6 +75,10 @@ function ChartScreenInner({
 }) {
   const [snap, setSnap] = useState<SnapState>("peek");
   const [scrollSignal, setScrollSignal] = useState(0);
+  const [skipFlash, setSkipFlash] = useState<{
+    dir: 1 | -1;
+    nonce: number;
+  } | null>(null);
   const settleSignal = useGlobeChart((s) => s.settleSignal);
   // The gesture-driven selection (the tour's beat-1 signal). Not the countryCode
   // prop: that resolves from useSearchParams, which a replaceState-only globe
@@ -217,17 +221,25 @@ function ChartScreenInner({
     setSkipHandlers({ previoustrack: goPrev, nexttrack: goNext });
   }, [goPrev, goNext]);
 
-  // Mirror the listening gate and the shared step to the globe so an edge-tap on
-  // the layout-backdrop globe routes through the same prev/next. The globe sits
-  // outside the audio provider, so it can't read currentTrack or call step
-  // directly; this crosses the same seam selectedCountry already does.
+  // Mirror the listening gate to the globe so an edge-tap on the layout-backdrop
+  // globe knows a track is loaded and skips instead of selecting a country. The
+  // globe sits outside the audio provider, so it can't read currentTrack; this
+  // crosses the same seam selectedCountry already does.
   useEffect(() => {
     globeChartStore.getState().setListening(hasCurrentTrack);
     return () => globeChartStore.getState().setListening(false);
   }, [hasCurrentTrack]);
+
+  // A globe edge-tap raises a skip-intent; the chart owns adjacency, so it runs
+  // the shared step and flashes only on a real track change. Subscribing to the
+  // store sets flash state inside the change callback (the pattern for reacting
+  // to an external system) and spares the screen a re-render per skip. The nonce
+  // diff drops dep-only re-runs; step's own return gates the clamped end-of-list.
   useEffect(() => {
-    globeChartStore.getState().setSkip(step);
-    return () => globeChartStore.getState().setSkip(() => false);
+    return globeChartStore.subscribe((state, prev) => {
+      if (state.skipIntent.nonce === prev.skipIntent.nonce) return;
+      if (step(state.skipIntent.dir)) setSkipFlash(state.skipIntent);
+    });
   }, [step]);
 
   return (
@@ -252,7 +264,7 @@ function ChartScreenInner({
       {/* Only while the globe is visible: at full the sheet covers it, so
           showing the hint there would burn its one-time display unseen. */}
       <EdgeTapHint active={hasCurrentTrack && snap !== "full"} />
-      <SkipFlash sheetSnap={snap} />
+      <SkipFlash skip={skipFlash} sheetSnap={snap} />
       <TourHost
         snap={snap}
         hasCurrentTrack={hasCurrentTrack}

--- a/src/components/globe/skip-flash.tsx
+++ b/src/components/globe/skip-flash.tsx
@@ -4,7 +4,6 @@ import { type CSSProperties, useEffect, useRef, useState } from "react";
 
 import { SNAP_Y_PCT, type SnapState } from "@/components/chart-sheet/sheet";
 import { ChevronsRightIcon } from "@/components/icons/chevrons-right";
-import { useGlobeChart } from "@/lib/globe-chart-store";
 
 // Tune the skip cue here: how long the chevron stays on screen and how far it
 // slides toward the tapped edge. Kept brief so it confirms the skip without
@@ -18,20 +17,29 @@ const TRAVEL_PX = 24;
 // distinct from rotating to a country. Pointer-transparent so it never blocks
 // the taps below it; reduced motion drops the slide for a plain opacity flash
 // (handled in globals.css, matching the tour/hint idiom).
-export function SkipFlash({ sheetSnap }: { sheetSnap: SnapState }) {
-  const skipSignal = useGlobeChart((s) => s.skipSignal);
-  const prevNonceRef = useRef(skipSignal.nonce);
+export function SkipFlash({
+  skip,
+  sheetSnap,
+}: {
+  // The chart's skip cue: `dir` is the skipped direction and `nonce` bumps per
+  // skip so a repeat direction still replays. Null until the first skip. The
+  // chart raises it only on a real track change, so the cue never fires on a
+  // clamped end-of-list skip.
+  skip: { dir: 1 | -1; nonce: number } | null;
+  sheetSnap: SnapState;
+}) {
+  const prevNonceRef = useRef(skip?.nonce ?? null);
   const [flash, setFlash] = useState<{ dir: 1 | -1; nonce: number } | null>(
     null,
   );
 
-  // Ref-gated so only an actual skip (a bumped nonce) plays the cue, never a
+  // Ref-gated so only a fresh skip (a bumped nonce) plays the cue, never a
   // dep-only re-run or the mount baseline.
   useEffect(() => {
-    if (skipSignal.nonce === prevNonceRef.current) return;
-    prevNonceRef.current = skipSignal.nonce;
-    setFlash({ dir: skipSignal.dir, nonce: skipSignal.nonce });
-  }, [skipSignal]);
+    if (!skip || skip.nonce === prevNonceRef.current) return;
+    prevNonceRef.current = skip.nonce;
+    setFlash(skip);
+  }, [skip]);
 
   // Clear after the animation; keyed on the flash so a fresh skip resets it.
   useEffect(() => {

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -314,9 +314,9 @@ export function SpinSnapControls({
           // A skip moves no globe, so return the machine to rest instead of
           // leaving it at "drag" from the press.
           s.mode = "idle";
-          // Skip via the chart's adjacency owner; flash only on a real change.
-          if (globeChartStore.getState().skip(action.dir))
-            globeChartStore.getState().signalSkip(action.dir);
+          // Raise a skip-intent; the chart runs the skip and flashes on a real
+          // change. The globe emits data and learns no outcome.
+          globeChartStore.getState().signalSkip(action.dir);
           return;
         }
 

--- a/src/lib/globe-chart-store.test.ts
+++ b/src/lib/globe-chart-store.test.ts
@@ -7,12 +7,11 @@ describe("globeChartStore", () => {
     globeChartStore.setState({
       readMode: false,
       settleSignal: 0,
-      skipSignal: { dir: 1, nonce: 0 },
+      skipIntent: { dir: 1, nonce: 0 },
       shuffleSignal: 0,
       shuffleLanded: null,
       selectedCountry: null,
       listening: false,
-      skip: () => false,
     });
   });
 
@@ -35,10 +34,10 @@ describe("globeChartStore", () => {
     expect(globeChartStore.getState().settleSignal).toBe(2);
   });
 
-  test("signalSkip records the direction and bumps the nonce", () => {
+  test("signalSkip raises a skip-intent with the direction and a bumped nonce", () => {
     globeChartStore.getState().signalSkip(-1);
 
-    expect(globeChartStore.getState().skipSignal).toEqual({
+    expect(globeChartStore.getState().skipIntent).toEqual({
       dir: -1,
       nonce: 1,
     });
@@ -48,7 +47,7 @@ describe("globeChartStore", () => {
     globeChartStore.getState().signalSkip(1);
     globeChartStore.getState().signalSkip(1);
 
-    expect(globeChartStore.getState().skipSignal).toEqual({ dir: 1, nonce: 2 });
+    expect(globeChartStore.getState().skipIntent).toEqual({ dir: 1, nonce: 2 });
   });
 
   test("requestShuffle increments so each press is a distinct landing signal", () => {

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -26,16 +26,13 @@ export interface GlobeChartState {
   // the page's provider, which the layout-backdrop globe can't read, so the
   // chart mirrors the gate here alongside selectedCountry.
   listening: boolean;
-  // Routes a globe edge-tap to the chart's shared prev/next (dir -1/+1), the one
-  // place that owns the adjacency logic. Returns whether a track actually
-  // changed (false when it clamps at the first/last playable track) so the cue
-  // only flashes on a real skip. Default no-op until the chart publishes it.
-  skip: (dir: 1 | -1) => boolean;
-  // One-shot cue for the directional skip flash: `dir` is the skip direction and
-  // `nonce` bumps on each skip so the overlay replays even on a repeat direction
-  // (a plain `dir` diff would miss next-after-next). The globe edge-tap is the
-  // only producer, so the flash lands on the tapped edge, not on a button skip.
-  skipSignal: { dir: 1 | -1; nonce: number };
+  // The globe's edge-tap skip-intent, a plain data signal: `dir` is the
+  // direction (prev -1 / next +1) and `nonce` bumps on each tap so a repeat
+  // direction still fires (a plain `dir` diff would miss next-after-next). The
+  // chart subscribes, runs its shared step (the one owner of adjacency), and
+  // drives the skip flash from step's result. The globe carries no callback and
+  // learns no outcome, so the whole seam is data, not behavior.
+  skipIntent: { dir: 1 | -1; nonce: number };
   // Monotonic counter a "surprise me" button bumps to fling the globe to a
   // random country. The pick lives in the globe (where the anti-repeat `visited`
   // set does), so the button can't run it directly; it signals across this seam
@@ -51,7 +48,6 @@ export interface GlobeChartState {
   setReadMode: (readMode: boolean) => void;
   signalSettle: () => void;
   setListening: (listening: boolean) => void;
-  setSkip: (skip: (dir: 1 | -1) => boolean) => void;
   signalSkip: (dir: 1 | -1) => void;
   requestShuffle: () => void;
   // Land a shuffle draw: move the globe and record the landing to announce.
@@ -63,8 +59,7 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   readMode: false,
   settleSignal: 0,
   listening: false,
-  skip: () => false,
-  skipSignal: { dir: 1, nonce: 0 },
+  skipIntent: { dir: 1, nonce: 0 },
   shuffleSignal: 0,
   shuffleLanded: null,
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
@@ -72,10 +67,9 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   signalSettle: () =>
     set((state) => ({ settleSignal: state.settleSignal + 1 })),
   setListening: (listening) => set({ listening }),
-  setSkip: (skip) => set({ skip }),
   signalSkip: (dir) =>
     set((state) => ({
-      skipSignal: { dir, nonce: state.skipSignal.nonce + 1 },
+      skipIntent: { dir, nonce: state.skipIntent.nonce + 1 },
     })),
   requestShuffle: () =>
     set((state) => ({ shuffleSignal: state.shuffleSignal + 1 })),


### PR DESCRIPTION
The globe→chart skip stored a React closure (`setSkip(step)`) in the Zustand store, beside the pure-data `skipSignal` it mirrored, and risked a stale closure. Both are replaced by one `skipIntent` data field: the globe raises `{dir, nonce}`, the chart subscribes and runs its own `step` (the sole owner of adjacency), and drives the skip flash from `step`'s boolean result. The globe emits data, learns no outcome, and carries no callback.

Rebased onto `main`; the `skipIntent` rename was reconciled with #177's `shuffleSignal`/`shuffleTo` additions in the same store.

## Test plan
- Store test updated: `signalSkip` raises a `skipIntent` and bumps its nonce (a repeat direction still fires).
- `mise exec -- pnpm typecheck && pnpm lint && pnpm test` all green locally (573 pass).
- No behavior change: an edge-tap still skips and flashes only on a real track change; a clamped end-of-list skip flashes nothing.

Closes #166