### PR TITLE
fix(crawl): give every retry attempt its own throttle slot

### DIFF
--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -4,11 +4,10 @@ import * as Sentry from "@sentry/node";
 import { COUNTRIES } from "../../src/lib/countries";
 import { fetchCommentaryStore } from "../commentary/fetch-commentary";
 
-import { AppleRssError, fetchAppleRss } from "./apple-rss";
+import { fetchAppleRss } from "./apple-rss";
+import { createItunesFetchers } from "./itunes-fetchers";
 import { lookupTrack } from "./itunes-lookup";
-import { withLookupRetry } from "./lookup-retry";
 import { fetchPublishedCharts } from "./published-charts";
-import { withRetry } from "./retry";
 import { triggerRevalidate } from "./revalidate-trigger";
 import { crawlAll, summarizeValidity, type SpotifyResolution } from "./run";
 import { createSpotifyResolver } from "./spotify-resolve";
@@ -64,17 +63,16 @@ try {
   await Sentry.withMonitor(
     "charts-crawl",
     async () => {
+      const itunes = createItunesFetchers({
+        fetchRss: fetchAppleRss,
+        lookupTrack,
+        throttle: createThrottle(),
+        sleep,
+      });
       const result = await crawlAll({
         countries: COUNTRIES,
-        fetchRss: (cc) =>
-          withRetry(() => fetchAppleRss(cc), {
-            retries: 2,
-            backoffMs: 500,
-            sleep,
-            shouldRetry: (err) => err instanceof AppleRssError,
-          }),
-        lookupTrack: withLookupRetry(lookupTrack, { sleep }),
-        throttle: createThrottle(),
+        fetchRss: itunes.fetchRss,
+        lookupTrack: itunes.lookupTrack,
         spotify,
         uploadCharts,
         triggerRevalidate,

--- a/scripts/crawl/itunes-fetchers.test.ts
+++ b/scripts/crawl/itunes-fetchers.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { AppleRssError } from "./apple-rss";
+import { createItunesFetchers } from "./itunes-fetchers";
+import { ItunesLookupError } from "./itunes-lookup";
+import { createThrottle } from "./throttle";
+
+const GAP_MS = 3000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("a failing lookup's retry attempts each take their own throttle slot", async () => {
+  // The gap encodes a per-IP request budget, so it must bound REQUESTS, not
+  // logical fetches: attempts packed into one slot amplify the very
+  // rate-limiting being retried.
+  const attemptTimes: number[] = [];
+  const lookupTrack = vi.fn(async (id: string, cc: string) => {
+    attemptTimes.push(Date.now());
+    throw new ItunesLookupError(id, cc, "http", "429 Too Many Requests");
+  });
+  const itunes = createItunesFetchers({
+    fetchRss: vi.fn(async () => []),
+    lookupTrack,
+    throttle: createThrottle(GAP_MS),
+  });
+
+  const promise = itunes.lookupTrack("1", "kr").catch((err: unknown) => err);
+  await vi.runAllTimersAsync();
+  const err = await promise;
+
+  expect(err).toBeInstanceOf(ItunesLookupError);
+  expect(attemptTimes.length).toBeGreaterThan(1);
+  for (let i = 1; i < attemptTimes.length; i++) {
+    expect(attemptTimes[i] - attemptTimes[i - 1]).toBeGreaterThanOrEqual(
+      GAP_MS,
+    );
+  }
+});
+
+test("a failing RSS fetch's retry attempts each take their own throttle slot", async () => {
+  const attemptTimes: number[] = [];
+  const fetchRss = vi.fn(async (cc: string) => {
+    attemptTimes.push(Date.now());
+    throw new AppleRssError(cc, "429 Too Many Requests");
+  });
+  const itunes = createItunesFetchers({
+    fetchRss,
+    lookupTrack: vi.fn(async (id) => ({ id, previewUrl: "https://p/1.m4a" })),
+    throttle: createThrottle(GAP_MS),
+  });
+
+  const promise = itunes.fetchRss("kr").catch((err: unknown) => err);
+  await vi.runAllTimersAsync();
+  const err = await promise;
+
+  expect(err).toBeInstanceOf(AppleRssError);
+  expect(attemptTimes.length).toBeGreaterThan(1);
+  for (let i = 1; i < attemptTimes.length; i++) {
+    expect(attemptTimes[i] - attemptTimes[i - 1]).toBeGreaterThanOrEqual(
+      GAP_MS,
+    );
+  }
+});
+
+test("both fetchers draw from the one shared throttle budget", async () => {
+  const requestTimes: number[] = [];
+  const itunes = createItunesFetchers({
+    fetchRss: vi.fn(async () => {
+      requestTimes.push(Date.now());
+      return [];
+    }),
+    lookupTrack: vi.fn(async (id) => {
+      requestTimes.push(Date.now());
+      return { id, previewUrl: "https://p/1.m4a" };
+    }),
+    throttle: createThrottle(GAP_MS),
+  });
+
+  const promise = Promise.all([
+    itunes.fetchRss("kr"),
+    itunes.lookupTrack("1", "kr"),
+  ]);
+  await vi.runAllTimersAsync();
+  await promise;
+
+  expect(requestTimes).toHaveLength(2);
+  expect(requestTimes[1] - requestTimes[0]).toBeGreaterThanOrEqual(GAP_MS);
+});
+
+test("a lookup that recovers within the retry budget still resolves", async () => {
+  const previewUrl = "https://p/1.m4a";
+  let attempt = 0;
+  const lookupTrack = vi.fn(async (id: string, cc: string) => {
+    attempt += 1;
+    if (attempt === 1)
+      throw new ItunesLookupError(id, cc, "network", "socket hang up");
+    return { id, previewUrl };
+  });
+  const itunes = createItunesFetchers({
+    fetchRss: vi.fn(async () => []),
+    lookupTrack,
+    throttle: createThrottle(GAP_MS),
+  });
+
+  const promise = itunes.lookupTrack("1", "kr");
+  await vi.runAllTimersAsync();
+
+  await expect(promise).resolves.toEqual({ id: "1", previewUrl });
+});

--- a/scripts/crawl/itunes-fetchers.ts
+++ b/scripts/crawl/itunes-fetchers.ts
@@ -1,0 +1,43 @@
+import { AppleRssError, type AppleRssTrack } from "./apple-rss";
+import type { LookupResult } from "./itunes-lookup";
+import { withLookupRetry } from "./lookup-retry";
+import { withRetry } from "./retry";
+import type { Throttle } from "./throttle";
+
+export interface ItunesFetchers {
+  fetchRss: (cc: string) => Promise<AppleRssTrack[]>;
+  lookupTrack: (id: string, cc: string) => Promise<LookupResult>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Composes both iTunes fetchers over ONE shared throttle, with the retry
+ * wrapped around the throttled call so every attempt — not every logical
+ * fetch — takes its own slot. Composing the other way lets one slot issue
+ * three requests under a failure storm, tripling the per-IP budget the
+ * throttle gap encodes and feeding the very rate-limiting being retried.
+ */
+export function createItunesFetchers(deps: {
+  fetchRss: (cc: string) => Promise<AppleRssTrack[]>;
+  lookupTrack: (id: string, cc: string) => Promise<LookupResult>;
+  throttle: Throttle;
+  sleep?: (ms: number) => Promise<void>;
+}): ItunesFetchers {
+  const { throttle } = deps;
+  const sleep = deps.sleep ?? defaultSleep;
+  return {
+    fetchRss: (cc) =>
+      withRetry(() => throttle(() => deps.fetchRss(cc)), {
+        retries: 2,
+        backoffMs: 500,
+        sleep,
+        shouldRetry: (err) => err instanceof AppleRssError,
+      }),
+    lookupTrack: withLookupRetry(
+      (id, cc) => throttle(() => deps.lookupTrack(id, cc)),
+      { sleep },
+    ),
+  };
+}

--- a/scripts/crawl/main.ts
+++ b/scripts/crawl/main.ts
@@ -1,6 +1,7 @@
 import { COUNTRIES } from "../../src/lib/countries";
 
 import { fetchAppleRss } from "./apple-rss";
+import { createItunesFetchers } from "./itunes-fetchers";
 import { lookupTrack } from "./itunes-lookup";
 import { crawlAll, crawlCountry, type SpotifyResolution } from "./run";
 import { createSpotifyResolver } from "./spotify-resolve";
@@ -36,14 +37,17 @@ async function runSingleCountry(cc: string): Promise<void> {
     );
   }
 
-  const throttle = createThrottle();
+  const itunes = createItunesFetchers({
+    fetchRss: fetchAppleRss,
+    lookupTrack,
+    throttle: createThrottle(),
+  });
   console.log(`[crawl ${cc}] starting single-country debug crawl...`);
   const { country } = await crawlCountry({
     cc,
     name: entry.name,
-    fetchRss: fetchAppleRss,
-    lookupTrack,
-    throttle,
+    fetchRss: itunes.fetchRss,
+    lookupTrack: itunes.lookupTrack,
     spotify: spotifyFromEnv(),
   });
   console.log(
@@ -59,12 +63,15 @@ async function runAllCountries(): Promise<void> {
       "BLOB_READ_WRITE_TOKEN missing. Run with: pnpm crawl (loads .env.local via tsx --env-file).",
     );
   }
-  const throttle = createThrottle();
-  await crawlAll({
-    countries: COUNTRIES,
+  const itunes = createItunesFetchers({
     fetchRss: fetchAppleRss,
     lookupTrack,
-    throttle,
+    throttle: createThrottle(),
+  });
+  await crawlAll({
+    countries: COUNTRIES,
+    fetchRss: itunes.fetchRss,
+    lookupTrack: itunes.lookupTrack,
     spotify: spotifyFromEnv(),
     uploadCharts,
     // Local debug entry never hits production revalidate — cron.ts injects the real one.

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -66,7 +66,6 @@ function makeCrawlCountryDeps(
     lookupTrack: vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
       async (id) => ({ id, previewUrl: previewUrlForId(id) }),
     ),
-    throttle: async (fn) => fn(),
     ...overrides,
   };
 }
@@ -242,20 +241,6 @@ test("crawlCountry rethrows non-ItunesLookupError from lookupTrack", async () =>
   await expect(promise).rejects.toThrow(errorMessage);
 });
 
-test("crawlCountry routes every external call through the injected throttle", async () => {
-  let count = 0;
-  const throttle = async <T>(fn: () => Promise<T>): Promise<T> => {
-    count += 1;
-    return fn();
-  };
-  const deps = makeCrawlCountryDeps({ throttle });
-  const expectedCount = 1 + sampleRssTracks().length; // 1 RSS + N Lookups
-
-  await crawlCountry(deps);
-
-  expect(count).toBe(expectedCount);
-});
-
 const FROZEN_NOW = new Date("2026-05-15T12:00:00.000Z");
 const BLOB_URL = "https://blob/charts/v1/charts.json";
 
@@ -284,7 +269,6 @@ function makeCrawlAllDeps(input: {
     lookupTrack: vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
       async (id, cc) => ({ id, previewUrl: `https://preview/${cc}/${id}.m4a` }),
     ),
-    throttle: async (fn) => fn(),
     uploadCharts: vi.fn(async () => BLOB_URL),
     triggerRevalidate: vi.fn(async () => {}),
     fetchPrevious: input.fetchPrevious,

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -23,9 +23,11 @@ export interface SpotifyResolution {
 export interface CrawlCountryDeps {
   cc: string;
   name: string;
+  // Both iTunes fetchers arrive rate-limited and retry-wrapped (they share one
+  // throttle, and the retry must sit around the throttle so each attempt takes
+  // its own slot — see createItunesFetchers). The orchestrator never throttles.
   fetchRss: (cc: string) => Promise<AppleRssTrack[]>;
   lookupTrack: (id: string, cc: string) => Promise<LookupResult>;
-  throttle: Throttle;
   spotify?: SpotifyResolution;
 }
 
@@ -36,9 +38,9 @@ export interface CrawlCountryResult {
 
 export interface CrawlAllDeps {
   countries: readonly CountryEntry[];
+  // Rate-limited and retry-wrapped, as in CrawlCountryDeps.
   fetchRss: (cc: string) => Promise<AppleRssTrack[]>;
   lookupTrack: (id: string, cc: string) => Promise<LookupResult>;
-  throttle: Throttle;
   spotify?: SpotifyResolution;
   uploadCharts: (chartFile: ChartFile) => Promise<string>;
   triggerRevalidate: () => Promise<void>;
@@ -114,10 +116,9 @@ async function previewUrlFor(
   rank: number,
   cc: string,
   lookupTrack: CrawlCountryDeps["lookupTrack"],
-  throttle: Throttle,
 ): Promise<string | null> {
   try {
-    const lookup = await throttle(() => lookupTrack(id, cc));
+    const lookup = await lookupTrack(id, cc);
     return lookup.previewUrl;
   } catch (err) {
     if (!(err instanceof ItunesLookupError)) throw err;
@@ -131,11 +132,11 @@ async function previewUrlFor(
 export async function crawlCountry(
   deps: CrawlCountryDeps,
 ): Promise<CrawlCountryResult> {
-  const { cc, name, fetchRss, lookupTrack, throttle, spotify } = deps;
+  const { cc, name, fetchRss, lookupTrack, spotify } = deps;
 
   let rssTracks: AppleRssTrack[];
   try {
-    rssTracks = await throttle(() => fetchRss(cc));
+    rssTracks = await fetchRss(cc);
   } catch (err) {
     if (!(err instanceof AppleRssError)) throw err;
     console.warn(`[crawl ${cc}] RSS failed: ${err.message}`);
@@ -145,7 +146,7 @@ export async function crawlCountry(
   const tracks: Track[] = [];
   for (const rss of rssTracks) {
     const [previewUrl, spotifyUrl] = await Promise.all([
-      previewUrlFor(rss.id, rss.rank, cc, lookupTrack, throttle),
+      previewUrlFor(rss.id, rss.rank, cc, lookupTrack),
       spotifyUrlFor(rss.name, rss.artist, cc, spotify),
     ]);
     tracks.push({
@@ -211,7 +212,6 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
     countries,
     fetchRss,
     lookupTrack,
-    throttle,
     spotify,
     uploadCharts,
     triggerRevalidate,
@@ -231,7 +231,6 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
       name: entry.name,
       fetchRss,
       lookupTrack,
-      throttle,
       spotify,
     });
 


### PR DESCRIPTION
Retry composed inside the throttle let one 3s slot issue three iTunes requests during a failure storm: ~60 req/min against the 20/min budget the throttle gap encodes, amplifying the very rate-limiting being retried (audit live test: exactly 60 requests in 20 slots). 429s retry, so a sustained outage sustained the tripled rate.

New `createItunesFetchers` composes retry AROUND one shared throttle for both iTunes fetchers, so each attempt takes its own slot; `crawlCountry`/`crawlAll` drop the `throttle` dep and consume ready-made, rate-limited fetchers. Both entries (cron and local-debug `main.ts`) wire through the factory; local debug previously had throttle but no retry and now matches production. The issue's inline sketch (`withRetry(() => throttle(fn))` at the call site) could not work alone: `run.ts` also throttled, which would double-throttle every lookup and blow the 120-minute Sentry monitor window, so the composition seam moved into the factory. The Spotify bundle is untouched (no retry exists on that path).

## Test plan

- New `itunes-fetchers.test.ts` (fake timers, real `createThrottle`): failing-lookup and failing-RSS attempts spaced ≥ the gap; both fetchers draw consecutive slots from one budget; recovery within the retry budget still resolves.
- `run.test.ts`'s throttle-routing test moved with the invariant into the factory test; deps factories updated.
- Full local matrix green: format, lint, typecheck, test (63 files / 581), build.

**Merge order:** merge this PR first. The branches `fix/outage-publishes-healthy-201` and `fix/prev-snapshot-205` touch the same `run.ts`/`cron.ts` and need a rebase after this lands.

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved iTunes data retrieval with centralized retry and rate-limiting behavior.
  * Ensured retry attempts and concurrent RSS and track lookups share consistent throttle scheduling.

* **Bug Fixes**
  * Improved handling of temporary iTunes lookup failures so eligible requests can succeed after retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->