### PR TITLE
fix(crawl): stop publishing lookup outages and carried staleness as healthy

### DIFF
--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -91,15 +91,20 @@ try {
           run_id: process.env.GITHUB_RUN_ID,
           country_count: summary.total,
           valid_count: summary.validCount,
+          carried_codes: result.carriedCodes,
           blob_url: result.url,
         },
       });
-      if (summary.invalidCodes.length > 0) {
+      // Carried-forward entries republish stale data as valid, so validity
+      // alone under-reports degradation — a run that carried anything is a
+      // degraded run even when every published entry parses as healthy.
+      if (summary.invalidCodes.length > 0 || result.carriedCodes.length > 0) {
         Sentry.captureMessage("charts:degraded", {
           level: "warning",
           extra: {
             run_id: process.env.GITHUB_RUN_ID,
             invalid_codes: summary.invalidCodes,
+            carried_codes: result.carriedCodes,
             valid_count: summary.validCount,
             country_count: summary.total,
           },

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -202,6 +202,23 @@ test("crawlCountry inserts a placeholder with previewUrl=null on lookup failure"
   expect(failingTrack?.artworkUrl).toBe(failingRss.artworkUrl);
 });
 
+test("crawlCountry returns valid=false when every lookup fails, keeping the placeholders", async () => {
+  // Zero playable previews means a lookup-host outage, not a real chart:
+  // the entry must read as failed so carry-forward can prefer prior data.
+  const lookupTrack = vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
+    async (id, cc) => {
+      throw new ItunesLookupError(id, cc, "http", "503 Service Unavailable");
+    },
+  );
+  const deps = makeCrawlCountryDeps({ lookupTrack });
+
+  const { country } = await crawlCountry(deps);
+
+  expect(country.valid).toBe(false);
+  expect(country.tracks).toHaveLength(sampleRssTracks().length);
+  expect(country.tracks.every((t) => t.previewUrl === null)).toBe(true);
+});
+
 test("crawlCountry returns valid=false with empty tracks when RSS throws AppleRssError", async () => {
   const fetchRss = vi.fn(async () => {
     throw new AppleRssError("kr", "503 Service Unavailable");
@@ -260,15 +277,21 @@ function fakeRssFor(cc: string): AppleRssTrack[] {
 function makeCrawlAllDeps(input: {
   countries: readonly CountryEntry[];
   fetchRss?: (cc: string) => Promise<AppleRssTrack[]>;
+  lookupTrack?: (id: string, cc: string) => Promise<LookupResult>;
   fetchPrevious?: () => Promise<ChartFile | null>;
   fetchCommentary?: () => Promise<CommentaryStore | null>;
 }): CrawlAllDeps {
   return {
     countries: input.countries,
     fetchRss: input.fetchRss ?? vi.fn(async (cc) => fakeRssFor(cc)),
-    lookupTrack: vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
-      async (id, cc) => ({ id, previewUrl: `https://preview/${cc}/${id}.m4a` }),
-    ),
+    lookupTrack:
+      input.lookupTrack ??
+      vi.fn<(id: string, cc: string) => Promise<LookupResult>>(
+        async (id, cc) => ({
+          id,
+          previewUrl: `https://preview/${cc}/${id}.m4a`,
+        }),
+      ),
     uploadCharts: vi.fn(async () => BLOB_URL),
     triggerRevalidate: vi.fn(async () => {}),
     fetchPrevious: input.fetchPrevious,
@@ -368,6 +391,7 @@ test("crawlAll assembles a valid ChartFile, uploads once, and revalidates once",
   expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
   expect(deps.uploadCharts).toHaveBeenCalledWith(result.chartFile);
   expect(deps.triggerRevalidate).toHaveBeenCalledTimes(1);
+  expect(result.carriedCodes).toEqual([]);
 });
 
 test("crawlAll publishes whatever succeeded when one country's RSS fails", async () => {
@@ -424,6 +448,51 @@ test("crawlAll carries forward the previous entry when a country fails but prior
 
   expect(result.chartFile.countries.ng).toEqual(priorNg);
   expect(result.chartFile.countries.kr.valid).toBe(true);
+  expect(result.carriedCodes).toEqual([NG.code]);
+});
+
+test("crawlAll carries forward the previous entry when a country's lookups all fail", async () => {
+  const priorNg = priorCountry(NG.name, 3);
+  const failNgLookups = vi.fn<
+    (id: string, cc: string) => Promise<LookupResult>
+  >(async (id, cc) => {
+    if (cc === NG.code)
+      throw new ItunesLookupError(id, cc, "http", "503 Service Unavailable");
+    return { id, previewUrl: `https://preview/${cc}/${id}.m4a` };
+  });
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    lookupTrack: failNgLookups,
+    fetchPrevious: vi.fn(async () => previousChartFile({ ng: priorNg })),
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng).toEqual(priorNg);
+  expect(result.chartFile.countries.kr.valid).toBe(true);
+  expect(result.carriedCodes).toEqual([NG.code]);
+});
+
+test("crawlAll publishes a zero-playable country as invalid when no prior data exists", async () => {
+  const failNgLookups = vi.fn<
+    (id: string, cc: string) => Promise<LookupResult>
+  >(async (id, cc) => {
+    if (cc === NG.code)
+      throw new ItunesLookupError(id, cc, "http", "503 Service Unavailable");
+    return { id, previewUrl: `https://preview/${cc}/${id}.m4a` };
+  });
+  const deps = makeCrawlAllDeps({
+    countries: [KR, NG],
+    lookupTrack: failNgLookups,
+  });
+
+  const result = await crawlAll(deps);
+
+  expect(result.chartFile.countries.ng.valid).toBe(false);
+  expect(result.chartFile.countries.ng.tracks).toHaveLength(
+    fakeRssFor(NG.code).length,
+  );
+  expect(result.carriedCodes).toEqual([]);
 });
 
 test("crawlAll keeps a failed country invalid when fetchPrevious returns null", async () => {

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -60,6 +60,10 @@ export interface CrawlAllDeps {
 export interface CrawlAllResult {
   url: string;
   chartFile: ChartFile;
+  // Countries republished from the previous payload this run. Carried entries
+  // keep `valid: true`, so they are invisible to summarizeValidity — this is
+  // the only signal that data is going stale.
+  carriedCodes: string[];
 }
 
 export interface ValiditySummary {
@@ -160,7 +164,18 @@ export async function crawlCountry(
     });
   }
 
-  return { cc, country: { name, valid: true, tracks } };
+  // A successful lookup always carries a preview URL, so zero playable tracks
+  // means every lookup failed — a lookup-host outage, not a real chart. Marked
+  // invalid so carry-forward keeps the last playable data instead of letting
+  // an unplayable chart overwrite it while telemetry reports healthy.
+  const playable = tracks.some((t) => t.previewUrl !== null);
+  if (tracks.length > 0 && !playable) {
+    console.warn(
+      `[crawl ${cc}] all ${tracks.length} lookups failed — zero playable previews`,
+    );
+  }
+
+  return { cc, country: { name, valid: playable, tracks } };
 }
 
 /**
@@ -225,6 +240,7 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
   const previous = deps.fetchPrevious ? await deps.fetchPrevious() : null;
 
   const countriesMap: ChartFile["countries"] = {};
+  const carriedCodes: string[] = [];
   for (const entry of countries) {
     const { cc, country } = await crawlCountry({
       cc: entry.code,
@@ -238,6 +254,7 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
     const prior = previous?.countries[cc];
     if (!country.valid && prior?.valid && prior.tracks.length > 0) {
       countriesMap[cc] = prior;
+      carriedCodes.push(cc);
       console.log(
         `[crawl ${cc}] crawl failed — carried forward last-good (${prior.tracks.length} tracks)`,
       );
@@ -266,5 +283,5 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
   console.log(`[crawl] uploaded → ${url}`);
   await triggerRevalidate();
 
-  return { url, chartFile };
+  return { url, chartFile, carriedCodes };
 }


### PR DESCRIPTION
Two silent-degradation paths on one seam. A sustained iTunes Lookup outage produced a fully unplayable chart still marked `valid: true`: every lookup degraded per-track to a null preview, carry-forward never triggered (it only watched RSS failures), the zero-playable chart overwrote last-good data, and `charts:degraded` stayed silent. Separately, carried-forward countries republished stale data as valid forever, invisible to `summarizeValidity` and Sentry.

A country now reads `valid: playable` (at least one track has a preview URL). A successful lookup always carries a preview (`z.url()` required in the lookup schema), so zero playable means every lookup failed: a host outage, not a real chart. The threshold is deliberately all-failed rather than a ratio: a partial outage keeps fresh rank data, which beats stale-but-playable carry-forward, and a ratio would be a product call the issue does not settle. `crawlAll` returns `carriedCodes`; `charts:published` carries them and `charts:degraded` now fires when anything was carried, not only when validity fails, since a carried run is a degraded run even when every published entry parses healthy. A zero-playable country with no prior data still publishes its tracks (browsable, flagged invalid) rather than nothing.

## Test plan

- New tests: all-lookups-fail country → `valid: false` with placeholder tracks kept; all-lookups-fail with prior → carried forward and `carriedCodes` populated; zero-playable without prior → published flagged invalid. Existing healthy-run and RSS carry-forward tests extended with `carriedCodes` assertions.
- Full local matrix green: format, lint, typecheck, test (581), build.

**Merge order:** rebase on main after `fix/retry-throttle-rate-203` (PR #214) lands; both touch `run.ts`/`cron.ts`.

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart publishing reliability when track preview lookups fail.
  * Countries with no playable previews are now marked invalid instead of appearing fully valid.
  * Previously published playable data is preserved when a crawl cannot produce valid replacements.
  * Crawl monitoring now reports degraded results and identifies countries using carried-forward data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->