### PR TITLE
fix(commentary): write the prev-chart snapshot the movement triggers diff against

### DIFF
--- a/docs/commentary-playbook.md
+++ b/docs/commentary-playbook.md
@@ -17,7 +17,7 @@ It is never the song's lyrics. Commentary describes a song; it does not reproduc
 
 ## Per-pass steps
 
-1. **Get the worklist.** Run `pnpm commentary:todo`. It lists significant movers that have no blurb yet, deduped across countries, so a track is written once and reused everywhere it charts. The list is pre-filtered; work straight down it.
+1. **Get the worklist.** Run `pnpm commentary:todo`. It lists significant movers that have no blurb yet, deduped across countries, so a track is written once and reused everywhere it charts. The list is pre-filtered; work straight down it. The new-entry and rank-jump triggers need `CHARTS_PREV_BLOB_URL` in the environment, pointing at the crawl-maintained `charts/v1/charts-prev.json` snapshot; the script states on stderr whether movement triggers are live. Without the snapshot it falls back to absolute prominence (top-debut and local-gem only).
 2. **Research each track** under the source policy below. Establish what the song is and why it is moving. If two credible sources do not support a "why it is charting" claim, keep the blurb to what the song is, or skip the track.
 3. **Write the entry** in the style below, into a candidate file keyed by the worklist key (`pnpm commentary:todo --json` emits the keys).
 4. **Sanity-check the blurbs** as you draft: no reproduced lyrics, claims match the sources, no overstatement. The publish gate is the load-bearing guard now (ADR-0009); this read only catches drafting slips early.

--- a/scripts/commentary/draft-batch.ts
+++ b/scripts/commentary/draft-batch.ts
@@ -7,6 +7,7 @@ import { dropsUrlFrom, recordAttempts } from "./drops";
 import { fetchCommentaryStoreRaw } from "./fetch-commentary";
 import { fetchDrops } from "./fetch-drops";
 import { createClaudeJudge, fetchSourceText, groundEntry } from "./ground";
+import { loadPreviousCharts } from "./previous-charts";
 import { routeStore } from "./route";
 import { backupCommentary, uploadCommentary } from "./upload-commentary";
 import { uploadDrops } from "./upload-drops";
@@ -48,8 +49,7 @@ if (!current) {
   throw new Error(`Could not read published charts from ${chartsUrl}.`);
 }
 
-const prevUrl = process.env.CHARTS_PREV_BLOB_URL;
-const previous = prevUrl ? await fetchPublishedCharts(prevUrl) : null;
+const previous = await loadPreviousCharts(process.env.CHARTS_PREV_BLOB_URL);
 
 // Read the live store raw, never schema-validated: one entry that fails the
 // since-tightened schema must not void the whole store, and a failed read must

--- a/scripts/commentary/previous-charts.test.ts
+++ b/scripts/commentary/previous-charts.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import type { ChartFile } from "../../src/lib/chart-schema";
+
+import { loadPreviousCharts } from "./previous-charts";
+
+const PREV_URL = "https://blob/charts/v1/charts-prev.json";
+
+function chartFile(): ChartFile {
+  return {
+    lastUpdated: "2026-05-15T12:00:00.000Z",
+    countries: {
+      kr: { name: "South Korea", valid: true, tracks: [] },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("returns the snapshot and reports movement triggers live", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const previous = chartFile();
+  const fetchCharts = vi.fn(async () => previous);
+
+  const result = await loadPreviousCharts(PREV_URL, fetchCharts);
+
+  expect(result).toBe(previous);
+  expect(fetchCharts).toHaveBeenCalledWith(PREV_URL);
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("movement triggers live"),
+  );
+});
+
+test("returns null and reports inert triggers when the URL is not set", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const fetchCharts = vi.fn(async () => chartFile());
+
+  const result = await loadPreviousCharts(undefined, fetchCharts);
+
+  expect(result).toBeNull();
+  expect(fetchCharts).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("movement triggers inert"),
+  );
+});
+
+test("returns null and reports inert triggers when the snapshot is unreadable", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const fetchCharts = vi.fn(async () => null);
+
+  const result = await loadPreviousCharts(PREV_URL, fetchCharts);
+
+  expect(result).toBeNull();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("movement triggers inert"),
+  );
+});

--- a/scripts/commentary/previous-charts.ts
+++ b/scripts/commentary/previous-charts.ts
@@ -1,0 +1,32 @@
+import type { ChartFile } from "../../src/lib/chart-schema";
+import { fetchPublishedCharts } from "../crawl/published-charts";
+
+/**
+ * Loads the crawl-maintained previous-chart snapshot for the worklist's
+ * rank-movement triggers, and states on stderr (clear of --json stdout)
+ * whether those triggers are live this run. Without the snapshot the
+ * worklist silently falls back to absolute prominence, which reads like a
+ * working feature while quietly narrowing ADR-0007's significance trigger.
+ */
+export async function loadPreviousCharts(
+  prevUrl: string | undefined,
+  fetchCharts: (
+    url: string,
+  ) => Promise<ChartFile | null> = fetchPublishedCharts,
+): Promise<ChartFile | null> {
+  if (!prevUrl) {
+    console.warn(
+      "[worklist] CHARTS_PREV_BLOB_URL not set: movement triggers inert; only top-debut and local-gem fire.",
+    );
+    return null;
+  }
+  const previous = await fetchCharts(prevUrl);
+  if (!previous) {
+    console.warn(
+      `[worklist] previous snapshot unreadable at ${prevUrl}: movement triggers inert this run.`,
+    );
+    return null;
+  }
+  console.warn("[worklist] movement triggers live (previous snapshot loaded).");
+  return previous;
+}

--- a/scripts/commentary/todo.ts
+++ b/scripts/commentary/todo.ts
@@ -1,6 +1,7 @@
 import { fetchPublishedCharts } from "../crawl/published-charts";
 
 import { fetchCommentaryStore } from "./fetch-commentary";
+import { loadPreviousCharts } from "./previous-charts";
 import { computeWorklist } from "./worklist";
 
 // Prints the tracks a refinement pass still needs to write: significant movers
@@ -18,10 +19,10 @@ if (!current) {
   throw new Error(`Could not read published charts from ${chartsUrl}.`);
 }
 
-// Optional prior snapshot. Without it, the worklist falls back to absolute
-// prominence (top-ranked tracks) instead of rank movement.
-const prevUrl = process.env.CHARTS_PREV_BLOB_URL;
-const previous = prevUrl ? await fetchPublishedCharts(prevUrl) : null;
+// Optional prior snapshot (the crawl maintains it next to the live charts).
+// Without it, the worklist falls back to absolute prominence (top-ranked
+// tracks) instead of rank movement; loadPreviousCharts says which on stderr.
+const previous = await loadPreviousCharts(process.env.CHARTS_PREV_BLOB_URL);
 
 const commentaryUrl = process.env.COMMENTARY_BLOB_URL;
 const commentary = commentaryUrl

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -12,7 +12,7 @@ import { triggerRevalidate } from "./revalidate-trigger";
 import { crawlAll, summarizeValidity, type SpotifyResolution } from "./run";
 import { createSpotifyResolver } from "./spotify-resolve";
 import { createSpotifyThrottle, createThrottle } from "./throttle";
-import { uploadCharts } from "./upload-blob";
+import { uploadCharts, uploadPreviousCharts } from "./upload-blob";
 
 if (!process.env.BLOB_READ_WRITE_TOKEN) {
   throw new Error("BLOB_READ_WRITE_TOKEN missing.");
@@ -75,6 +75,22 @@ try {
         lookupTrack: itunes.lookupTrack,
         spotify,
         uploadCharts,
+        // Never rejects: a lost snapshot generation only lags the movement
+        // diff one run, which must not abort a finished crawl. It still pages,
+        // because a silently dead snapshot is how the triggers went inert.
+        uploadPrevious: async (chartFile) => {
+          try {
+            await uploadPreviousCharts(chartFile);
+          } catch (err) {
+            console.warn(
+              `[crawl] prev snapshot write failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            Sentry.captureMessage("charts:prev-snapshot-failed", {
+              level: "warning",
+              extra: { run_id: process.env.GITHUB_RUN_ID },
+            });
+          }
+        },
         triggerRevalidate,
         fetchPrevious: previousUrl
           ? () => fetchPublishedCharts(previousUrl)

--- a/scripts/crawl/main.ts
+++ b/scripts/crawl/main.ts
@@ -3,10 +3,11 @@ import { COUNTRIES } from "../../src/lib/countries";
 import { fetchAppleRss } from "./apple-rss";
 import { createItunesFetchers } from "./itunes-fetchers";
 import { lookupTrack } from "./itunes-lookup";
+import { fetchPublishedCharts } from "./published-charts";
 import { crawlAll, crawlCountry, type SpotifyResolution } from "./run";
 import { createSpotifyResolver } from "./spotify-resolve";
 import { createSpotifyThrottle, createThrottle } from "./throttle";
-import { uploadCharts } from "./upload-blob";
+import { uploadCharts, uploadPreviousCharts } from "./upload-blob";
 
 // Spotify resolution for local debug: enabled only when both credentials are in
 // .env.local; otherwise links fall back to the search URL, same as production.
@@ -63,6 +64,15 @@ async function runAllCountries(): Promise<void> {
       "BLOB_READ_WRITE_TOKEN missing. Run with: pnpm crawl (loads .env.local via tsx --env-file).",
     );
   }
+  // This run publishes to the live pathname, so it must keep the same
+  // read/snapshot pair as cron: without them a local run overwrites the
+  // outgoing charts unsnapshotted and skips carry-forward.
+  const previousUrl = process.env.CHARTS_BLOB_URL;
+  if (!previousUrl) {
+    console.warn(
+      "[crawl] CHARTS_BLOB_URL not set: carry-forward and prev snapshot skipped this run.",
+    );
+  }
   const itunes = createItunesFetchers({
     fetchRss: fetchAppleRss,
     lookupTrack,
@@ -74,6 +84,18 @@ async function runAllCountries(): Promise<void> {
     lookupTrack: itunes.lookupTrack,
     spotify: spotifyFromEnv(),
     uploadCharts,
+    fetchPrevious: previousUrl
+      ? () => fetchPublishedCharts(previousUrl)
+      : undefined,
+    uploadPrevious: async (chartFile) => {
+      try {
+        await uploadPreviousCharts(chartFile);
+      } catch (err) {
+        console.warn(
+          `[crawl] prev snapshot write failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    },
     // Local debug entry never hits production revalidate — cron.ts injects the real one.
     triggerRevalidate: async () => {
       console.log("[crawl] revalidate skipped (local debug)");

--- a/scripts/crawl/run.test.ts
+++ b/scripts/crawl/run.test.ts
@@ -279,7 +279,9 @@ function makeCrawlAllDeps(input: {
   fetchRss?: (cc: string) => Promise<AppleRssTrack[]>;
   lookupTrack?: (id: string, cc: string) => Promise<LookupResult>;
   fetchPrevious?: () => Promise<ChartFile | null>;
+  uploadPrevious?: (chartFile: ChartFile) => Promise<unknown>;
   fetchCommentary?: () => Promise<CommentaryStore | null>;
+  uploadCharts?: (chartFile: ChartFile) => Promise<string>;
 }): CrawlAllDeps {
   return {
     countries: input.countries,
@@ -292,9 +294,10 @@ function makeCrawlAllDeps(input: {
           previewUrl: `https://preview/${cc}/${id}.m4a`,
         }),
       ),
-    uploadCharts: vi.fn(async () => BLOB_URL),
+    uploadCharts: input.uploadCharts ?? vi.fn(async () => BLOB_URL),
     triggerRevalidate: vi.fn(async () => {}),
     fetchPrevious: input.fetchPrevious,
+    uploadPrevious: input.uploadPrevious,
     fetchCommentary: input.fetchCommentary,
     now: () => FROZEN_NOW,
   };
@@ -493,6 +496,45 @@ test("crawlAll publishes a zero-playable country as invalid when no prior data e
     fakeRssFor(NG.code).length,
   );
   expect(result.carriedCodes).toEqual([]);
+});
+
+test("crawlAll snapshots the outgoing charts before overwriting them", async () => {
+  // Order is the invariant: once the in-place overwrite runs, the outgoing
+  // payload is unrecoverable and the movement diff loses a generation.
+  const events: string[] = [];
+  const previous = previousChartFile({ kr: priorCountry(KR.name, 2) });
+  const uploadPrevious = vi.fn(async () => {
+    events.push("snapshot");
+  });
+  const uploadCharts = vi.fn(async () => {
+    events.push("publish");
+    return BLOB_URL;
+  });
+  const deps = makeCrawlAllDeps({
+    countries: [KR],
+    fetchPrevious: vi.fn(async () => previous),
+    uploadPrevious,
+    uploadCharts,
+  });
+
+  await crawlAll(deps);
+
+  expect(uploadPrevious).toHaveBeenCalledWith(previous);
+  expect(events).toEqual(["snapshot", "publish"]);
+});
+
+test("crawlAll skips the snapshot when no previous payload exists", async () => {
+  const uploadPrevious = vi.fn(async () => {});
+  const deps = makeCrawlAllDeps({
+    countries: [KR],
+    fetchPrevious: vi.fn(async () => null),
+    uploadPrevious,
+  });
+
+  await crawlAll(deps);
+
+  expect(uploadPrevious).not.toHaveBeenCalled();
+  expect(deps.uploadCharts).toHaveBeenCalledTimes(1);
 });
 
 test("crawlAll keeps a failed country invalid when fetchPrevious returns null", async () => {

--- a/scripts/crawl/run.ts
+++ b/scripts/crawl/run.ts
@@ -47,6 +47,11 @@ export interface CrawlAllDeps {
   // Source for carrying forward a country that fails this run. Must resolve
   // null (never reject) when unavailable, which skips carry-forward.
   fetchPrevious?: () => Promise<ChartFile | null>;
+  // Snapshots the outgoing charts before uploadCharts overwrites them in
+  // place; the worklist's rank-movement triggers diff against it. Like
+  // fetchPrevious, must resolve (never reject): losing one snapshot
+  // generation is cheaper than aborting a finished crawl.
+  uploadPrevious?: (chartFile: ChartFile) => Promise<unknown>;
   // Out-of-band commentary baked into the served charts. Like fetchPrevious,
   // must resolve null (never reject) when unavailable, which skips the bake and
   // leaves charts untouched. The crawl only ever reads this store (ADR-0007).
@@ -278,6 +283,12 @@ export async function crawlAll(deps: CrawlAllDeps): Promise<CrawlAllResult> {
     lastUpdated: now().toISOString(),
     countries: countriesMap,
   };
+
+  // Snapshot strictly before the overwrite: once uploadCharts runs, the
+  // outgoing payload is gone and the movement diff loses a generation.
+  if (deps.uploadPrevious && previous) {
+    await deps.uploadPrevious(previous);
+  }
 
   const url = await uploadCharts(chartFile);
   console.log(`[crawl] uploaded → ${url}`);

--- a/scripts/crawl/upload-blob.ts
+++ b/scripts/crawl/upload-blob.ts
@@ -3,10 +3,14 @@ import { put } from "@vercel/blob";
 import type { ChartFile } from "../../src/lib/chart-schema";
 
 const BLOB_PATHNAME = "charts/v1/charts.json";
+const PREV_BLOB_PATHNAME = "charts/v1/charts-prev.json";
 
-export async function uploadCharts(chartFile: ChartFile): Promise<string> {
+async function putCharts(
+  pathname: string,
+  chartFile: ChartFile,
+): Promise<string> {
   const body = JSON.stringify(chartFile, null, 2);
-  const result = await put(BLOB_PATHNAME, body, {
+  const result = await put(pathname, body, {
     access: "public",
     addRandomSuffix: false,
     allowOverwrite: true,
@@ -14,4 +18,19 @@ export async function uploadCharts(chartFile: ChartFile): Promise<string> {
     cacheControlMaxAge: 60,
   });
   return result.url;
+}
+
+export async function uploadCharts(chartFile: ChartFile): Promise<string> {
+  return putCharts(BLOB_PATHNAME, chartFile);
+}
+
+/**
+ * Snapshots the outgoing charts before the publish overwrites them in place:
+ * the worklist's rank-movement triggers (ADR-0007) diff the live charts
+ * against this copy, read back via CHARTS_PREV_BLOB_URL.
+ */
+export async function uploadPreviousCharts(
+  chartFile: ChartFile,
+): Promise<string> {
+  return putCharts(PREV_BLOB_PATHNAME, chartFile);
 }


### PR DESCRIPTION
ADR-0007's new-entry and rank-jump commentary triggers have never fired: nothing in the repo wrote the previous-chart snapshot they diff against, so `movementReason` silently fell back to absolute prominence (top-debut and local-gem only) since the feature shipped.

The crawl now snapshots the outgoing charts to `charts/v1/charts-prev.json` strictly before `uploadCharts` overwrites the live blob in place; the content is the already-fetched carry-forward read, so no extra GET, and single-writer (the no-cancel cron concurrency group) makes mid-run drift impossible. The dep contract mirrors `fetchPrevious`: never rejects, since losing one snapshot generation is cheaper than aborting a finished 80-minute crawl; a failed write warns and emits `charts:prev-snapshot-failed` to Sentry. The worklist readers (`todo`, `draft-batch`) share a new `loadPreviousCharts` that states on stderr (clear of `--json` stdout) whether movement triggers are live, distinguishing URL-not-set from snapshot-unreadable. No workflow change: the writer derives its pathname, and the readers are laptop-run session tools whose `CHARTS_PREV_BLOB_URL` belongs in `.env.local`. The playbook documents the setup.

**Operator follow-up after merge:** once the first crawl run writes the blob, set `CHARTS_PREV_BLOB_URL` in `.env.local` (same host as `CHARTS_BLOB_URL`, path `charts/v1/charts-prev.json`).

## Test plan

- `run.test.ts`: snapshot written before publish (event-order assertion) and skipped when no previous payload exists.
- New `previous-charts.test.ts`: snapshot loaded → triggers reported live; URL unset or unreadable → null and reported inert.
- Full local matrix green: format, lint, typecheck, test (63 files / 583), build.

**Merge order:** rebase on main after `fix/retry-throttle-rate-203` (PR #214) and `fix/outage-publishes-healthy-201` (PR #215) land; all three touch `run.ts`/`cron.ts`.

Closes #205