### PR TITLE
fix(commentary): salvage valid entries when one fails the schema

### DIFF
--- a/scripts/commentary/draft-batch.ts
+++ b/scripts/commentary/draft-batch.ts
@@ -4,7 +4,10 @@ import { fetchPublishedCharts } from "../crawl/published-charts";
 
 import { createClaudeDrafter, draftEntry } from "./draft";
 import { dropsUrlFrom, recordAttempts } from "./drops";
-import { fetchCommentaryStoreRaw } from "./fetch-commentary";
+import {
+  fetchCommentaryStoreRaw,
+  salvageCommentaryStore,
+} from "./fetch-commentary";
 import { fetchDrops } from "./fetch-drops";
 import { createClaudeJudge, fetchSourceText, groundEntry } from "./ground";
 import { routeStore } from "./route";
@@ -66,12 +69,24 @@ const existing: CommentaryStore = commentaryUrl
 const dropsUrl = commentaryUrl ? dropsUrlFrom(commentaryUrl) : undefined;
 const priorDrops = dropsUrl ? await fetchDrops(dropsUrl) : {};
 
+// The worklist diffs against the validated view, not the raw base: an entry
+// the tightened schema rejects bakes as no card, so its key must re-queue for
+// drafting instead of blocking its own regeneration. The raw `existing` stays
+// the merge base below, so the fresh draft overwrites the invalid entry and
+// the store converges back to valid.
+const { store: validExisting, droppedKeys } = salvageCommentaryStore(existing);
+if (droppedKeys.length > 0) {
+  console.warn(
+    `[draft] ${droppedKeys.length} invalid entr${droppedKeys.length === 1 ? "y" : "ies"} re-queued for drafting: ${droppedKeys.join(", ")}`,
+  );
+}
+
 // Suppress thin-market low-confidence positions: don't spend a drafter call on
 // noise the worklist would rank last anyway (#117).
 const worklist = computeWorklist({
   current,
   previous,
-  commentary: existing,
+  commentary: validExisting,
   drops: priorDrops,
   options: { suppressLowConfidence: true },
 });

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -61,10 +61,45 @@ test("returns null on invalid JSON", async () => {
   expect(result).toBeNull();
 });
 
-test("returns null on schema mismatch", async () => {
+test("keeps valid entries when another entry fails the schema", async () => {
+  // One entry a since-tightened schema rejects must cost only itself: the
+  // bake is authoritative, so voiding the whole store would clear every
+  // freshly-crawled card.
+  const store = validStore();
+  const mixed = { ...store, "en:a|b": { lead: "" } };
+
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ body: JSON.stringify(mixed) }),
+  );
+
+  expect(result).toEqual(store);
+});
+
+test("returns null when no entry survives validation", async () => {
+  // Total loss on a non-empty store reads as schema drift, not content:
+  // skipping the bake beats baking an empty store over every card.
   const result = await fetchCommentaryStore(
     URL,
     fakeFetch({ body: JSON.stringify({ "en:a|b": { lead: "" } }) }),
+  );
+
+  expect(result).toBeNull();
+});
+
+test("returns an empty store as-is, distinct from total validation loss", async () => {
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ body: JSON.stringify({}) }),
+  );
+
+  expect(result).toEqual({});
+});
+
+test("returns null on a payload that is not an object", async () => {
+  const result = await fetchCommentaryStore(
+    URL,
+    fakeFetch({ body: JSON.stringify([validStore()]) }),
   );
 
   expect(result).toBeNull();
@@ -80,9 +115,9 @@ test("returns null when fetch rejects", async () => {
   expect(result).toBeNull();
 });
 
-test("fetchCommentaryStoreRaw keeps an entry the strict schema would reject", async () => {
-  // The strict read returns null for this same body (see "schema mismatch");
-  // the raw read preserves it so one stale entry cannot void the whole store.
+test("fetchCommentaryStoreRaw keeps an entry the schema would reject", async () => {
+  // The baking read drops this entry (see "no entry survives"); the raw read
+  // preserves it verbatim so a merge-then-overwrite cannot erase it.
   const body = JSON.stringify({ "en:a|b": { lead: "" } });
 
   const store = await fetchCommentaryStoreRaw(URL, fakeFetch({ body }));

--- a/scripts/commentary/fetch-commentary.test.ts
+++ b/scripts/commentary/fetch-commentary.test.ts
@@ -1,15 +1,19 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
-import { commentaryKey } from "../../src/lib/commentary-store";
+import {
+  commentaryKey,
+  type CommentaryStore,
+} from "../../src/lib/commentary-store";
 
 import {
   fetchCommentaryStore,
   fetchCommentaryStoreRaw,
+  withCommentaryDegradationSignal,
 } from "./fetch-commentary";
 
 const URL = "https://blob/commentary/v1/commentary.json";
 
-function validStore() {
+function validStore(): CommentaryStore {
   return {
     [commentaryKey("en", "Artist", "Song")]: {
       lead: "A blurb about the song.",
@@ -138,4 +142,44 @@ test("fetchCommentaryStoreRaw throws on a non-object payload rather than merging
   await expect(
     fetchCommentaryStoreRaw(URL, fakeFetch({ body: JSON.stringify([]) })),
   ).rejects.toThrow();
+});
+
+test("withCommentaryDegradationSignal fires on a null read and passes the null through", async () => {
+  const onUnavailable = vi.fn();
+  const wrapped = withCommentaryDegradationSignal(
+    async () => null,
+    onUnavailable,
+  );
+
+  const result = await wrapped();
+
+  expect(result).toBeNull();
+  expect(onUnavailable).toHaveBeenCalledTimes(1);
+});
+
+test("withCommentaryDegradationSignal stays silent on an empty store", async () => {
+  const onUnavailable = vi.fn();
+  const wrapped = withCommentaryDegradationSignal(
+    async () => ({}),
+    onUnavailable,
+  );
+
+  const result = await wrapped();
+
+  expect(result).toEqual({});
+  expect(onUnavailable).not.toHaveBeenCalled();
+});
+
+test("withCommentaryDegradationSignal passes a loaded store through untouched", async () => {
+  const store = validStore();
+  const onUnavailable = vi.fn();
+  const wrapped = withCommentaryDegradationSignal(
+    async () => store,
+    onUnavailable,
+  );
+
+  const result = await wrapped();
+
+  expect(result).toBe(store);
+  expect(onUnavailable).not.toHaveBeenCalled();
 });

--- a/scripts/commentary/fetch-commentary.ts
+++ b/scripts/commentary/fetch-commentary.ts
@@ -1,12 +1,15 @@
-import {
-  CommentaryStoreSchema,
-  type CommentaryStore,
-} from "../../src/lib/commentary-store";
+import { CommentarySchema } from "../../src/lib/chart-schema";
+import { type CommentaryStore } from "../../src/lib/commentary-store";
 
 /**
  * Reads the published commentary store for the crawl to bake in and for the
- * worklist to diff against. Degrades to null on any failure — commentary is
- * additive and must never abort the crawl (mirrors the carry-forward read).
+ * worklist to diff against. Validates per entry, dropping only the entries
+ * that fail — one entry invalidated by a since-tightened schema must not void
+ * the whole store (the bake is authoritative, so a voided store would clear
+ * every freshly-crawled card). Degrades to null on a failed read, a payload
+ * that is not an object, or a non-empty store where no entry survives (total
+ * loss reads as schema drift, not an empty store) — commentary is additive
+ * and must never abort the crawl.
  */
 export async function fetchCommentaryStore(
   url: string,
@@ -16,8 +19,27 @@ export async function fetchCommentaryStore(
     const res = await fetchImpl(url);
     if (!res.ok) return null;
     const json: unknown = await res.json();
-    const parsed = CommentaryStoreSchema.safeParse(json);
-    return parsed.success ? parsed.data : null;
+    if (json === null || typeof json !== "object" || Array.isArray(json)) {
+      return null;
+    }
+
+    const store: CommentaryStore = {};
+    const dropped: string[] = [];
+    for (const [key, value] of Object.entries(json)) {
+      const parsed = CommentarySchema.safeParse(value);
+      if (parsed.success) {
+        store[key] = parsed.data;
+      } else {
+        dropped.push(key);
+      }
+    }
+    if (dropped.length > 0) {
+      console.warn(
+        `[commentary] dropped ${dropped.length} invalid entr${dropped.length === 1 ? "y" : "ies"}: ${dropped.join(", ")}`,
+      );
+    }
+    if (dropped.length > 0 && Object.keys(store).length === 0) return null;
+    return store;
   } catch {
     return null;
   }
@@ -25,14 +47,15 @@ export async function fetchCommentaryStore(
 
 /**
  * Read the store as raw JSON for a writer that merges new entries in, preserving
- * every existing entry verbatim. Two differences from the strict read make it
- * safe to overwrite from: it does NOT validate, so one entry that fails the
- * since-tightened schema cannot void the whole store; and it THROWS on a failed
- * read instead of degrading to null, so a merge-then-overwrite aborts rather
- * than wiping the live cards when a read transiently fails. Per-entry VALUES go
- * unvalidated (a merge only spreads and re-keys them), but the top-level shape
- * is checked: a non-object payload (null, an array) would otherwise spread into
- * an empty or malformed merge and persist a broken store.
+ * every existing entry verbatim. Two differences from the baking read make it
+ * safe to overwrite from: it preserves even entries the schema rejects (the
+ * baking read drops them, which is fine for display but would erase them from
+ * a merge-then-overwrite); and it THROWS on a failed read instead of degrading
+ * to null, so a merge-then-overwrite aborts rather than wiping the live cards
+ * when a read transiently fails. Per-entry VALUES go unvalidated (a merge only
+ * spreads and re-keys them), but the top-level shape is checked: a non-object
+ * payload (null, an array) would otherwise spread into an empty or malformed
+ * merge and persist a broken store.
  */
 export async function fetchCommentaryStoreRaw(
   url: string,

--- a/scripts/commentary/fetch-commentary.ts
+++ b/scripts/commentary/fetch-commentary.ts
@@ -1,14 +1,40 @@
 import { CommentarySchema } from "../../src/lib/chart-schema";
 import { type CommentaryStore } from "../../src/lib/commentary-store";
 
+export interface SalvagedStore {
+  store: CommentaryStore;
+  droppedKeys: string[];
+}
+
+/**
+ * Validates a store per entry, keeping the survivors and naming the dropped
+ * keys. Pure and shared by both consumers of the raw payload: the baking read
+ * keeps only valid entries, and the draft batch re-queues exactly the keys
+ * dropped here, so a preserved-but-invalid entry cannot block its own
+ * regeneration.
+ */
+export function salvageCommentaryStore(raw: object): SalvagedStore {
+  const store: CommentaryStore = {};
+  const droppedKeys: string[] = [];
+  for (const [key, value] of Object.entries(raw)) {
+    const parsed = CommentarySchema.safeParse(value);
+    if (parsed.success) {
+      store[key] = parsed.data;
+    } else {
+      droppedKeys.push(key);
+    }
+  }
+  return { store, droppedKeys };
+}
+
 /**
  * Reads the published commentary store for the crawl to bake in and for the
  * worklist to diff against. Validates per entry, dropping only the entries
- * that fail — one entry invalidated by a since-tightened schema must not void
+ * that fail: one entry invalidated by a since-tightened schema must not void
  * the whole store (the bake is authoritative, so a voided store would clear
  * every freshly-crawled card). Degrades to null on a failed read, a payload
  * that is not an object, or a non-empty store where no entry survives (total
- * loss reads as schema drift, not an empty store) — commentary is additive
+ * loss reads as schema drift, not an empty store); commentary is additive
  * and must never abort the crawl.
  */
 export async function fetchCommentaryStore(
@@ -23,26 +49,34 @@ export async function fetchCommentaryStore(
       return null;
     }
 
-    const store: CommentaryStore = {};
-    const dropped: string[] = [];
-    for (const [key, value] of Object.entries(json)) {
-      const parsed = CommentarySchema.safeParse(value);
-      if (parsed.success) {
-        store[key] = parsed.data;
-      } else {
-        dropped.push(key);
-      }
-    }
-    if (dropped.length > 0) {
+    const { store, droppedKeys } = salvageCommentaryStore(json);
+    if (droppedKeys.length > 0) {
       console.warn(
-        `[commentary] dropped ${dropped.length} invalid entr${dropped.length === 1 ? "y" : "ies"}: ${dropped.join(", ")}`,
+        `[commentary] dropped ${droppedKeys.length} invalid entr${droppedKeys.length === 1 ? "y" : "ies"}: ${droppedKeys.join(", ")}`,
       );
     }
-    if (dropped.length > 0 && Object.keys(store).length === 0) return null;
+    if (droppedKeys.length > 0 && Object.keys(store).length === 0) return null;
     return store;
   } catch {
     return null;
   }
+}
+
+/**
+ * Wraps a commentary read so a null result fires the degradation signal and
+ * still passes through to the caller. The wrapper exists to be testable: the
+ * signal is the only trace that a configured store failed to bake, and an
+ * inline try/catch at the wiring site had no test able to reach it.
+ */
+export function withCommentaryDegradationSignal(
+  fetchStore: () => Promise<CommentaryStore | null>,
+  onUnavailable: () => void,
+): () => Promise<CommentaryStore | null> {
+  return async () => {
+    const store = await fetchStore();
+    if (store === null) onUnavailable();
+    return store;
+  };
 }
 
 /**

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -2,7 +2,10 @@ import "./sentry-init";
 import * as Sentry from "@sentry/node";
 
 import { COUNTRIES } from "../../src/lib/countries";
-import { fetchCommentaryStore } from "../commentary/fetch-commentary";
+import {
+  fetchCommentaryStore,
+  withCommentaryDegradationSignal,
+} from "../commentary/fetch-commentary";
 
 import { fetchAppleRss } from "./apple-rss";
 import { createItunesFetchers } from "./itunes-fetchers";
@@ -83,19 +86,18 @@ try {
         // skips and freshly-crawled cards ship without commentary, so the
         // degradation must surface in Sentry, not just the run log.
         fetchCommentary: commentaryUrl
-          ? async () => {
-              const store = await fetchCommentaryStore(commentaryUrl);
-              if (store === null) {
+          ? withCommentaryDegradationSignal(
+              () => fetchCommentaryStore(commentaryUrl),
+              () => {
                 console.warn(
-                  "[crawl] commentary store unreadable — bake skipped this run.",
+                  "[crawl] commentary store unreadable: bake skipped this run.",
                 );
                 Sentry.captureMessage("commentary:unavailable", {
                   level: "warning",
                   extra: { run_id: process.env.GITHUB_RUN_ID },
                 });
-              }
-              return store;
-            }
+              },
+            )
           : undefined,
       });
 

--- a/scripts/crawl/cron.ts
+++ b/scripts/crawl/cron.ts
@@ -79,8 +79,23 @@ try {
         fetchPrevious: previousUrl
           ? () => fetchPublishedCharts(previousUrl)
           : undefined,
+        // A configured store that reads back null means the bake silently
+        // skips and freshly-crawled cards ship without commentary, so the
+        // degradation must surface in Sentry, not just the run log.
         fetchCommentary: commentaryUrl
-          ? () => fetchCommentaryStore(commentaryUrl)
+          ? async () => {
+              const store = await fetchCommentaryStore(commentaryUrl);
+              if (store === null) {
+                console.warn(
+                  "[crawl] commentary store unreadable — bake skipped this run.",
+                );
+                Sentry.captureMessage("commentary:unavailable", {
+                  level: "warning",
+                  extra: { run_id: process.env.GITHUB_RUN_ID },
+                });
+              }
+              return store;
+            }
           : undefined,
       });
 


### PR DESCRIPTION
One invalid commentary entry made the crawl-side read return null (whole-store strict parse), which silently skipped the bake and cleared commentary on every freshly-crawled country: all 63 at normal operation, with no log and no Sentry event. The repo's own raw reader already documented the correct posture ("one entry that fails the since-tightened schema must not void the whole store") but only on the writer side.

`fetchCommentaryStore` now validates per entry, dropping only the failing entries (warn-logged with their keys). Null is reserved for a failed read, a non-object payload, or a non-empty store where NO entry survives: total loss reads as schema drift, and baking `{}` over every card would reproduce the original bug through a different door. An empty store stays `{}`, distinct from total loss. When `COMMENTARY_BLOB_URL` is set but the fetch yields null, cron emits `commentary:unavailable` (warning) to Sentry, mirroring the `charts:degraded` pattern. `parse-store.ts` (the publish gate) is deliberately untouched: its whole-store strictness is the intended hard-block per ADR-0009.

## Test plan

- The old "returns null on schema mismatch" test split into the actual invariants: mixed-validity store → partial survival; all-invalid non-empty store → null; empty store → `{}`; non-object payload → null.
- Full local matrix green: format, lint, typecheck, test (581), build.

Closes #202