### PR TITLE
fix(gem-card): show preview-failure feedback instead of silently reverting

### DIFF
--- a/src/components/chart-sheet/gem-card.test.tsx
+++ b/src/components/chart-sheet/gem-card.test.tsx
@@ -156,6 +156,26 @@ describe("GemCard", () => {
 
     expect(container.querySelector(".eq")).toBeNull();
   });
+
+  test("error message renders when lastError matches the gem's previewUrl", () => {
+    const track = makeTrack();
+
+    renderGemCard(track, "entirely their own", {
+      lastError: { previewUrl: track.previewUrl },
+    });
+
+    expect(screen.getByText(/Preview unavailable/)).toBeDefined();
+  });
+
+  test("error message hidden when lastError matches a different track", () => {
+    const track = makeTrack();
+
+    renderGemCard(track, "entirely their own", {
+      lastError: { previewUrl: "https://example.com/other.m4a" },
+    });
+
+    expect(screen.queryByText(/Preview unavailable/)).toBeNull();
+  });
 });
 
 describe("GemCard tier strength meter", () => {

--- a/src/components/chart-sheet/gem-card.tsx
+++ b/src/components/chart-sheet/gem-card.tsx
@@ -47,6 +47,9 @@ export function GemCard({ track, tier, countryCode }: GemCardProps) {
       s.currentTrack?.previewUrl === track.previewUrl &&
       s.currentCountryCode === countryCode,
   );
+  const hasError = useAudioStore(
+    (s) => s.lastError?.previewUrl === track.previewUrl,
+  );
   const toggle = useAudioStore((s) => s.toggle);
 
   const hasPreview = track.previewUrl !== null;
@@ -108,6 +111,11 @@ export function GemCard({ track, tier, countryCode }: GemCardProps) {
           <p className="text-fg-2 text-small truncate">
             {hasPreview ? track.artist : `No preview · ${track.artist}`}
           </p>
+          {hasError && (
+            <p className="text-error text-micro mt-1">
+              Preview unavailable, try another track
+            </p>
+          )}
         </div>
       </button>
       {commentary ? <TrackCommentary commentary={commentary} /> : null}


### PR DESCRIPTION
When the gem card's preview failed (dead CDN URL, iOS gesture rejection), `handlePlayRejection` cleared `isPlaying` and the pause icon silently flipped back to play. The only visible "Preview unavailable" message rendered on the same track's ranked row further down the sheet, likely off-screen at peek height, so the hero surface built to catch the first tap gave no feedback at all.

The card now mirrors TrackRow exactly: the same `lastError` selector (byte-identical, keeping the card's "same store reads" contract) and the same error line under the artist. The deeper `useTrackPlayback` hook extraction the issue floats is deliberately not taken here: it overlaps with the stable-identity work #206 owns, and extracting it in this branch would preempt that design. The chart-sheet DOM shell (reserved for #200 and the v2.3.0 tour swap) is untouched; the change lives inside GemCard's existing button block.

## Test plan

- Two tests mirroring track-row's lastError pattern: matching previewUrl renders the message; non-matching hides it.
- Full local matrix green: format, lint, typecheck, test (580), build.

Closes #208