### PR TITLE
feat(tour): teach the 3 onboarding gestures with a wordless spotlight-nudge tour

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -260,7 +260,7 @@ function ChartScreenInner({
       <SkipFlash skip={skipFlash} sheetSnap={snap} />
       <TourHost
         snap={snap}
-        currentTrackId={currentTrack?.previewUrl ?? null}
+        currentTrackKey={currentTrack?.previewUrl ?? null}
         // Fall back to the resolved route code until the globe publishes its
         // first selection: a null baseline would make the tour read the store
         // populating itself as the user's first flick.

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -260,7 +260,7 @@ function ChartScreenInner({
       <SkipFlash skip={skipFlash} sheetSnap={snap} />
       <TourHost
         snap={snap}
-        hasCurrentTrack={hasCurrentTrack}
+        currentTrackId={currentTrack?.previewUrl ?? null}
         // Fall back to the resolved route code until the globe publishes its
         // first selection: a null baseline would make the tour read the store
         // populating itself as the user's first flick.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,6 +84,9 @@
   --scrim-light: rgba(245, 242, 236, 0.04);
   --scrim: rgba(5, 6, 8, 0.7);
   --scrim-deep: rgba(5, 6, 8, 0.92);
+  /* The onboarding tour's dim peak, tuned by eye in the v2.3.0 prototype;
+     lighter than --scrim-deep so the spotlit target reads through it. */
+  --scrim-tour: rgba(5, 6, 8, 0.82);
   --blur-glass: blur(24px) saturate(140%);
 
   --dur-fast: 160ms;
@@ -252,7 +255,7 @@
   }
 }
 
-/* Onboarding tour: the scrim fades in, the callout rises into place. */
+/* Shared plain fade-in, used by the edge-tap hint (and any other one-shot cue). */
 @keyframes tour-fade {
   from {
     opacity: 0;
@@ -262,23 +265,83 @@
   }
 }
 
-@keyframes tour-rise {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 .tour-fade {
   animation: tour-fade var(--dur-base) var(--ease-out);
 }
 
-.tour-rise {
-  animation: tour-rise var(--dur-base) var(--ease-out);
+/* Onboarding tour dim: the scrim darkens to a peak, holds, then settles to a
+   residual so the spotlit target stays visible and reachable rather than staying
+   fully blacked out. Percentages map the 620ms dim-in / 1000ms hold / 760ms
+   settle onto the 2380ms total; ending at 0.61 of the 0.82 (--scrim-tour) peak
+   lands the residual on the prototype's absolute 0.5. */
+@keyframes tour-dim {
+  0% {
+    opacity: 0;
+  }
+  26% {
+    opacity: 1;
+  }
+  68% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.61;
+  }
+}
+
+.tour-dim {
+  animation: tour-dim 2380ms var(--ease-out) forwards;
+}
+
+/* Nudge badge: one imperative naming the beat's gesture, breathing in time with
+   that beat's hand hint. The scale peak sits at 46% of the cycle to align with
+   the flick hand's rightmost whip; each beat sets its own --badge-ms period. */
+@keyframes tour-badge-breathe {
+  0%,
+  100% {
+    transform: translateX(-50%) scale(1);
+    opacity: 0.8;
+  }
+  46% {
+    transform: translateX(-50%) scale(1.045);
+    opacity: 1;
+  }
+}
+
+.tour-badge {
+  position: fixed;
+  transform: translateX(-50%);
+  font-size: 13px;
+  color: var(--color-fg-1);
+  background: rgba(5, 6, 8, 0.55);
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+  box-shadow: inset 0 0 0 1px rgba(245, 242, 236, 0.1);
+  backdrop-filter: blur(8px);
+}
+
+.tour-badge-breathe {
+  animation: tour-badge-breathe var(--badge-ms, 1900ms) var(--ease-out) infinite;
+}
+
+/* Aurora inner ring + outer bloom over the base pill shadow. */
+.tour-badge-glow {
+  box-shadow:
+    inset 0 0 0 1px rgba(107, 229, 197, 0.25),
+    0 0 20px rgba(107, 229, 197, 0.4);
+}
+
+.tour-badge-flick {
+  --badge-ms: 1900ms;
+}
+
+.tour-badge-sheet {
+  --badge-ms: 2000ms;
+}
+
+.tour-badge-tap {
+  --badge-ms: 1800ms;
 }
 
 /* The flick hint: a ghost hand presses onto the globe and flings it: a windup,
@@ -772,8 +835,13 @@
   :root {
     --badge-recede-rise: 0px;
   }
+  /* Rest the dim at its residual with no dim-in or settle motion. */
+  .tour-dim {
+    animation: none;
+    opacity: 0.61;
+  }
   .tour-fade,
-  .tour-rise,
+  .tour-badge-breathe,
   .tour-swipe,
   .tour-swipe::after,
   .tour-swipe-trail,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,9 +84,11 @@
   --scrim-light: rgba(245, 242, 236, 0.04);
   --scrim: rgba(5, 6, 8, 0.7);
   --scrim-deep: rgba(5, 6, 8, 0.92);
-  /* The onboarding tour's dim peak, tuned by eye in the v2.3.0 prototype;
-     lighter than --scrim-deep so the spotlit target reads through it. */
+  /* The onboarding tour's dim: a peak lighter than --scrim-deep so the spotlit
+     target reads through it, settling to --scrim-tour-rest of that peak (an
+     absolute 0.5) so the target stays visible. Both tuned by eye. */
   --scrim-tour: rgba(5, 6, 8, 0.82);
+  --scrim-tour-rest: 0.61;
   --blur-glass: blur(24px) saturate(140%);
 
   --dur-fast: 160ms;
@@ -272,8 +274,8 @@
 /* Onboarding tour dim: the scrim darkens to a peak, holds, then settles to a
    residual so the spotlit target stays visible and reachable rather than staying
    fully blacked out. Percentages map the 620ms dim-in / 1000ms hold / 760ms
-   settle onto the 2380ms total; ending at 0.61 of the 0.82 (--scrim-tour) peak
-   lands the residual on the prototype's absolute 0.5. */
+   settle onto the 2380ms total; ending at --scrim-tour-rest of the peak opacity
+   lands the residual at an absolute 0.5. */
 @keyframes tour-dim {
   0% {
     opacity: 0;
@@ -285,7 +287,7 @@
     opacity: 1;
   }
   100% {
-    opacity: 0.61;
+    opacity: var(--scrim-tour-rest);
   }
 }
 
@@ -838,7 +840,7 @@
   /* Rest the dim at its residual with no dim-in or settle motion. */
   .tour-dim {
     animation: none;
-    opacity: 0.61;
+    opacity: var(--scrim-tour-rest);
   }
   .tour-fade,
   .tour-badge-breathe,

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -81,16 +81,20 @@ function SceneContent() {
   // A landing is a selection: buzz where supported, write ?cc= (replaceState,
   // so rapid flinging doesn't flood history), record the country as visited,
   // and signal the chart tree so a dismissed sheet resurfaces the result.
-  const handleSettle = useCallback((code: string, changed: boolean) => {
-    // Every settle resurfaces the result (raises a dismissed sheet, re-arms the
-    // tour hint), even when the country is unchanged.
-    globeChartStore.getState().signalSettle();
-    if (!changed) return;
-    triggerLandingHaptic();
-    globeChartStore.getState().setSelectedCountry(code);
-    window.history.replaceState(null, "", `?cc=${code}`);
-    setVisited((prev) => addVisited(prev, code));
-  }, []);
+  const handleSettle = useCallback(
+    (code: string, changed: boolean, viaTap: boolean) => {
+      // Every settle resurfaces the result (raises a dismissed sheet, re-arms
+      // the tour hint), even when the country is unchanged. viaTap rides along
+      // so the tour can tell a tap-select from the flick it teaches.
+      globeChartStore.getState().signalSettle(viaTap);
+      if (!changed) return;
+      triggerLandingHaptic();
+      globeChartStore.getState().setSelectedCountry(code);
+      window.history.replaceState(null, "", `?cc=${code}`);
+      setVisited((prev) => addVisited(prev, code));
+    },
+    [],
+  );
 
   // "Surprise me": on a bumped shuffle signal, draw a fair random country and
   // publish it via shuffleTo — sets selectedCountry (the globe's targetCode

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -59,7 +59,9 @@ interface SpinSnapControlsProps {
   readMode: boolean;
   // `changed` is false when the settle re-lands the country already shown, so
   // the caller can fire on every settle but gate country-change side effects.
-  onSettle: (code: string, changed: boolean) => void;
+  // `viaTap` is true only for a bare tap-select, so the tour can tell an
+  // accidental tap from the flick it teaches.
+  onSettle: (code: string, changed: boolean, viaTap: boolean) => void;
 }
 
 // Drives the camera as a spun globe: drag to rotate, release to fling with
@@ -155,7 +157,7 @@ export function SpinSnapControls({
   // onSettle no matter how we got here (fling, tap, or an external ?cc=
   // change), then either cuts instantly (reduced motion) or hands off to the
   // snap spring in useFrame.
-  const settleTo = (code: string | null) => {
+  const settleTo = (code: string | null, viaTap = false) => {
     const s = sim.current;
     const country = code ? COUNTRY_BY_CODE.get(code) : null;
     if (!country) {
@@ -169,7 +171,7 @@ export function SpinSnapControls({
     // caller gate the country-change side effects (?cc=, visited, haptic).
     const changed = s.settledCode !== country.code;
     s.settledCode = country.code;
-    onSettleRef.current(country.code, changed);
+    onSettleRef.current(country.code, changed, viaTap);
 
     if (cfg.current.reducedMotion) {
       // Instant cut: jump straight to the spring's end state so the next
@@ -295,7 +297,9 @@ export function SpinSnapControls({
             cy - rect.top,
             TAP_HIT_PX,
           );
-          settleTo(hit ?? sim.current.settledCode);
+          // viaTap: a bare tap-select, so the tour's gesture beat can ignore it
+          // rather than treat an accidental tap as the flick it teaches.
+          settleTo(hit ?? sim.current.settledCode, true);
         };
 
         const action = classifyTap({

--- a/src/components/tour/tour-host.test.tsx
+++ b/src/components/tour/tour-host.test.tsx
@@ -24,7 +24,7 @@ function stubMatchMedia(reduced: boolean) {
 function renderHost(overrides: Partial<TourHostProps> = {}) {
   const props: TourHostProps = {
     snap: "peek" as SnapState,
-    currentTrackId: null,
+    currentTrackKey: null,
     selectedCode: "us",
     ...overrides,
   };
@@ -165,7 +165,7 @@ describe("TourHost", () => {
       rerenderWith({
         selectedCode: "jp",
         snap: "full",
-        currentTrackId: "kr-1",
+        currentTrackKey: "kr-1",
       });
     });
 
@@ -176,14 +176,20 @@ describe("TourHost", () => {
   test("a track already previewing when the audio beat opens does not skip it", () => {
     stubMatchMedia(false);
     // A track was played earlier (e.g. an accidental tap during beats 1-2).
-    const { getByTestId, rerenderWith } = renderHost({ currentTrackId: "pre" });
+    const { getByTestId, rerenderWith } = renderHost({
+      currentTrackKey: "pre",
+    });
     makeGlobeReady();
 
     act(() => {
-      rerenderWith({ selectedCode: "jp", currentTrackId: "pre" });
+      rerenderWith({ selectedCode: "jp", currentTrackKey: "pre" });
     });
     act(() => {
-      rerenderWith({ selectedCode: "jp", snap: "full", currentTrackId: "pre" });
+      rerenderWith({
+        selectedCode: "jp",
+        snap: "full",
+        currentTrackKey: "pre",
+      });
     });
 
     // The audio beat baselines the already-playing track, so it keeps teaching
@@ -191,14 +197,17 @@ describe("TourHost", () => {
     expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe("audio");
   });
 
-  test("mounts the badge without an inline animation under reduced motion", () => {
+  test("keeps the badge and its accessible text under reduced motion", () => {
     stubMatchMedia(true);
     const { getByTestId } = renderHost();
     makeGlobeReady();
 
+    // The badge stays mounted as the wordless tour's a11y fallback. The breathe
+    // and hand animations are suppressed by a CSS media query, which jsdom does
+    // not evaluate, so that suppression is device-verified, not asserted here.
     const badge = getByTestId("tour-badge");
-    expect(badge).toBeTruthy();
-    expect(badge.style.animation).toBe("");
+    expect(badge.getAttribute("aria-hidden")).toBeNull();
+    expect(badge.textContent).toMatch(/flick to spin/i);
   });
 
   test("withholds the track spotlight until the sheet finishes rising", () => {

--- a/src/components/tour/tour-host.test.tsx
+++ b/src/components/tour/tour-host.test.tsx
@@ -24,7 +24,7 @@ function stubMatchMedia(reduced: boolean) {
 function renderHost(overrides: Partial<TourHostProps> = {}) {
   const props: TourHostProps = {
     snap: "peek" as SnapState,
-    hasCurrentTrack: false,
+    currentTrackId: null,
     selectedCode: "us",
     ...overrides,
   };
@@ -43,6 +43,7 @@ function makeGlobeReady() {
 afterEach(() => {
   vi.restoreAllMocks();
   localStorage.clear();
+  globeChartStore.setState({ lastSettleViaTap: false });
   act(() => {
     tourBridge.getState().setGlobeReady(false);
   });
@@ -67,54 +68,55 @@ describe("TourHost", () => {
     expect(queryByTestId("tour-overlay")).toBeNull();
   });
 
-  test("opens on the gesture beat inviting a flick, with no Next yet", () => {
+  test("opens on the gesture beat with the flick hint and its badge", () => {
     stubMatchMedia(false);
 
-    const { getByTestId, getByText, queryByRole } = renderHost();
+    const { getByTestId } = renderHost();
     makeGlobeReady();
 
     expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe(
       "gesture",
     );
-    expect(getByText(/flick the globe/i)).toBeTruthy();
     expect(getByTestId("tour-flick-hint")).toBeTruthy();
-    expect(queryByRole("button", { name: "Next" })).toBeNull();
+    const badge = getByTestId("tour-badge");
+    expect(badge.getAttribute("role")).toBe("status");
+    expect(badge.textContent).toMatch(/flick to spin/i);
   });
 
-  test("the user's first selection reveals Next without leaving the gesture beat", () => {
+  test("the user's first selection advances to the sheet beat", () => {
     stubMatchMedia(false);
-    const { getByTestId, getByRole, rerenderWith } = renderHost();
+    const { getByTestId, rerenderWith } = renderHost();
     makeGlobeReady();
 
     act(() => {
       rerenderWith({ selectedCode: "jp" });
     });
-
-    expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe(
-      "gesture",
-    );
-    expect(getByRole("button", { name: "Next" })).toBeTruthy();
-  });
-
-  test("Next advances to the sheet beat once the user has flicked", () => {
-    stubMatchMedia(false);
-    const { getByTestId, getByRole, rerenderWith } = renderHost();
-    makeGlobeReady();
-
-    act(() => {
-      rerenderWith({ selectedCode: "jp" });
-    });
-    fireEvent.click(getByRole("button", { name: "Next" }));
 
     expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe("sheet");
   });
 
-  test("Skip ends the tour and records it as seen", () => {
+  test("a bare globe tap-select does not skip the gesture beat", () => {
+    stubMatchMedia(false);
+    const { getByTestId, rerenderWith } = renderHost();
+    makeGlobeReady();
+
+    act(() => {
+      // The country changed, but the settle came from a tap, not the flick.
+      globeChartStore.getState().signalSettle(true);
+      rerenderWith({ selectedCode: "jp" });
+    });
+
+    expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe(
+      "gesture",
+    );
+  });
+
+  test("the X control ends the tour and records it as seen", () => {
     stubMatchMedia(false);
     const { getByRole, queryByTestId } = renderHost();
     makeGlobeReady();
 
-    fireEvent.click(getByRole("button", { name: "Skip tour" }));
+    fireEvent.click(getByRole("button", { name: "Dismiss tour" }));
 
     expect(queryByTestId("tour-overlay")).toBeNull();
     expect(localStorage.getItem(KEY)).toBe("1");
@@ -135,13 +137,12 @@ describe("TourHost", () => {
 
   test("advances to the audio beat when the sheet is pulled to full", () => {
     stubMatchMedia(false);
-    const { getByTestId, getByRole, rerenderWith } = renderHost();
+    const { getByTestId, rerenderWith } = renderHost();
     makeGlobeReady();
 
     act(() => {
       rerenderWith({ selectedCode: "jp" });
     });
-    fireEvent.click(getByRole("button", { name: "Next" }));
     act(() => {
       rerenderWith({ selectedCode: "jp", snap: "full" });
     });
@@ -151,22 +152,53 @@ describe("TourHost", () => {
 
   test("completes and records as seen when a track previews on the audio beat", () => {
     stubMatchMedia(false);
-    const { getByRole, queryByTestId, rerenderWith } = renderHost();
+    const { queryByTestId, rerenderWith } = renderHost();
     makeGlobeReady();
 
     act(() => {
       rerenderWith({ selectedCode: "jp" });
     });
-    fireEvent.click(getByRole("button", { name: "Next" }));
     act(() => {
       rerenderWith({ selectedCode: "jp", snap: "full" });
     });
     act(() => {
-      rerenderWith({ selectedCode: "jp", snap: "full", hasCurrentTrack: true });
+      rerenderWith({
+        selectedCode: "jp",
+        snap: "full",
+        currentTrackId: "kr-1",
+      });
     });
 
     expect(queryByTestId("tour-overlay")).toBeNull();
     expect(localStorage.getItem(KEY)).toBe("1");
+  });
+
+  test("a track already previewing when the audio beat opens does not skip it", () => {
+    stubMatchMedia(false);
+    // A track was played earlier (e.g. an accidental tap during beats 1-2).
+    const { getByTestId, rerenderWith } = renderHost({ currentTrackId: "pre" });
+    makeGlobeReady();
+
+    act(() => {
+      rerenderWith({ selectedCode: "jp", currentTrackId: "pre" });
+    });
+    act(() => {
+      rerenderWith({ selectedCode: "jp", snap: "full", currentTrackId: "pre" });
+    });
+
+    // The audio beat baselines the already-playing track, so it keeps teaching
+    // rather than auto-completing on a preview from before the beat.
+    expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe("audio");
+  });
+
+  test("mounts the badge without an inline animation under reduced motion", () => {
+    stubMatchMedia(true);
+    const { getByTestId } = renderHost();
+    makeGlobeReady();
+
+    const badge = getByTestId("tour-badge");
+    expect(badge).toBeTruthy();
+    expect(badge.style.animation).toBe("");
   });
 
   test("withholds the track spotlight until the sheet finishes rising", () => {
@@ -176,13 +208,11 @@ describe("TourHost", () => {
     sheet.innerHTML = '<ol><li data-rank="1">track</li></ol>';
     document.body.appendChild(sheet);
 
-    const { getByTestId, getByRole, queryByTestId, rerenderWith } =
-      renderHost();
+    const { getByTestId, queryByTestId, rerenderWith } = renderHost();
     makeGlobeReady();
     act(() => {
       rerenderWith({ selectedCode: "jp" });
     });
-    fireEvent.click(getByRole("button", { name: "Next" }));
     act(() => {
       rerenderWith({ selectedCode: "jp", snap: "full" });
     });
@@ -203,7 +233,7 @@ describe("TourHost", () => {
 
   test("hides the flick hand on a globe grab, then re-arms it on a no-op settle", () => {
     stubMatchMedia(false);
-    const { getByTestId, queryByRole, queryByTestId } = renderHost();
+    const { getByTestId, queryByTestId } = renderHost();
     makeGlobeReady();
 
     expect(getByTestId("tour-flick-hint")).toBeTruthy();
@@ -216,7 +246,6 @@ describe("TourHost", () => {
     expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe(
       "gesture",
     );
-    expect(queryByRole("button", { name: "Next" })).toBeNull();
 
     act(() => {
       globeChartStore.getState().signalSettle();
@@ -231,7 +260,7 @@ describe("TourHost", () => {
     sheet.setAttribute("data-testid", "chart-sheet");
     document.body.appendChild(sheet);
 
-    const { getByTestId, queryByTestId } = renderHost();
+    const { getByTestId } = renderHost();
     makeGlobeReady();
 
     expect(getByTestId("tour-flick-hint")).toBeTruthy();
@@ -240,7 +269,7 @@ describe("TourHost", () => {
       fireEvent.pointerDown(sheet);
     });
 
-    expect(queryByTestId("tour-flick-hint")).toBeTruthy();
+    expect(getByTestId("tour-flick-hint")).toBeTruthy();
 
     document.body.removeChild(sheet);
   });

--- a/src/components/tour/tour-host.tsx
+++ b/src/components/tour/tour-host.tsx
@@ -19,10 +19,11 @@ export interface TourHostProps {
   // selection in beat 1. Wired when the host is mounted (the chart-screen
   // edit), not by this file.
   snap: SnapState;
-  // The previewing track's id, or null when nothing plays. An id (not a
-  // boolean) so the audio beat can baseline what was already playing on entry
-  // and complete only on a fresh preview, never on a track from before the beat.
-  currentTrackId: string | null;
+  // A key for the previewing track (its preview URL), or null when nothing
+  // plays. A key, not a boolean, so the audio beat can baseline what was already
+  // playing on entry and complete only on a fresh preview, never on a track from
+  // before the beat.
+  currentTrackKey: string | null;
   selectedCode: string | null;
 }
 
@@ -30,7 +31,7 @@ export interface TourHostProps {
 // then hands off to the runner, which owns the step machine.
 export function TourHost({
   snap,
-  currentTrackId,
+  currentTrackKey,
   selectedCode,
 }: TourHostProps) {
   const { seen, markSeen } = useSeenFlag(tourSeen);
@@ -50,7 +51,7 @@ export function TourHost({
   return (
     <TourRunner
       snap={snap}
-      currentTrackId={currentTrackId}
+      currentTrackKey={currentTrackKey}
       selectedCode={selectedCode}
       onDone={handleDone}
     />
@@ -63,7 +64,7 @@ interface TourRunnerProps extends TourHostProps {
 
 function TourRunner({
   snap,
-  currentTrackId,
+  currentTrackKey,
   selectedCode,
   onDone,
 }: TourRunnerProps) {
@@ -182,16 +183,16 @@ function TourRunner({
     if (state.beat !== "audio") return;
     if (!audioArmedRef.current) {
       audioArmedRef.current = true;
-      audioBaselineRef.current = currentTrackId;
+      audioBaselineRef.current = currentTrackKey;
       return;
     }
     if (
-      currentTrackId !== null &&
-      currentTrackId !== audioBaselineRef.current
+      currentTrackKey !== null &&
+      currentTrackKey !== audioBaselineRef.current
     ) {
       dispatch({ type: "TRACK_PREVIEWED" });
     }
-  }, [currentTrackId, state.beat]);
+  }, [currentTrackKey, state.beat]);
 
   // ESC dismisses from any beat (counts as seen). Window-level, like the Space
   // play/pause handler in chart-screen.tsx.

--- a/src/components/tour/tour-host.tsx
+++ b/src/components/tour/tour-host.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useStore } from "zustand";
 
 import type { SnapState } from "@/components/chart-sheet/sheet";
-import { useGlobeChart } from "@/lib/globe-chart-store";
+import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
 import { tourBridge } from "@/lib/tour-bridge";
 import { useSeenFlag } from "@/lib/use-seen-flag";
 
@@ -14,11 +14,15 @@ import { initialTourState, tourReducer } from "./tour-step";
 import { useTourAnchor } from "./use-tour-anchor";
 
 export interface TourHostProps {
-  // Observed from ChartScreenInner. The sheet snap and a live preview drive
-  // beats 2 and 3; the resolved country code marks a real selection in beat 1.
-  // Wired when the host is mounted (the chart-screen edit), not by this file.
+  // Observed from ChartScreenInner. The sheet snap and the previewing track's
+  // identity drive beats 2 and 3; the resolved country code marks a real
+  // selection in beat 1. Wired when the host is mounted (the chart-screen
+  // edit), not by this file.
   snap: SnapState;
-  hasCurrentTrack: boolean;
+  // The previewing track's id, or null when nothing plays. An id (not a
+  // boolean) so the audio beat can baseline what was already playing on entry
+  // and complete only on a fresh preview, never on a track from before the beat.
+  currentTrackId: string | null;
   selectedCode: string | null;
 }
 
@@ -26,7 +30,7 @@ export interface TourHostProps {
 // then hands off to the runner, which owns the step machine.
 export function TourHost({
   snap,
-  hasCurrentTrack,
+  currentTrackId,
   selectedCode,
 }: TourHostProps) {
   const { seen, markSeen } = useSeenFlag(tourSeen);
@@ -46,7 +50,7 @@ export function TourHost({
   return (
     <TourRunner
       snap={snap}
-      hasCurrentTrack={hasCurrentTrack}
+      currentTrackId={currentTrackId}
       selectedCode={selectedCode}
       onDone={handleDone}
     />
@@ -59,7 +63,7 @@ interface TourRunnerProps extends TourHostProps {
 
 function TourRunner({
   snap,
-  hasCurrentTrack,
+  currentTrackId,
   selectedCode,
   onDone,
 }: TourRunnerProps) {
@@ -72,14 +76,14 @@ function TourRunner({
   // doesn't strand them with no hint and no Next.
   const [engaged, setEngaged] = useState(false);
   useEffect(() => {
-    if (state.beat !== "gesture" || state.gesturePhase !== "try") return;
+    if (state.beat !== "gesture") return;
     const onDown = (e: PointerEvent) => {
       const target = e.target as HTMLElement | null;
       // Engage on a globe grab, not on the other interactive surfaces in view:
-      // a tap on the callout or the peek sheet isn't the user starting a flick.
+      // a tap on the badge, the X, or the peek sheet isn't the user flicking.
       if (
         target?.closest(
-          '[data-testid="tour-callout"], [data-testid="chart-sheet"]',
+          '[data-testid="tour-badge"], [data-testid="chart-sheet"]',
         )
       )
         return;
@@ -91,7 +95,7 @@ function TourRunner({
     });
     return () =>
       window.removeEventListener("pointerdown", onDown, { capture: true });
-  }, [state.beat, state.gesturePhase]);
+  }, [state.beat]);
 
   // A settle ends the spin: if it changed the country the gesture beat advances
   // (the hand is already gone); if not, re-arm the hand. Ref-gated so the mount
@@ -137,13 +141,14 @@ function TourRunner({
     };
   }, [state.beat]);
 
-  // The user's first selection (a flick, or a pick from the a11y list) reveals
-  // Next rather than advancing. On the first render we snapshot the baseline so
-  // the country the globe loaded on isn't mistaken for that selection.
+  // The user's first selection (a flick, or a pick from the a11y list) advances
+  // the gesture beat: doing the gesture is the advance. On the first render we
+  // snapshot the baseline so the country the globe loaded on isn't mistaken for
+  // that selection.
   const prevCodeRef = useRef(selectedCode);
   const tryArmedRef = useRef(false);
   useEffect(() => {
-    if (state.beat !== "gesture" || state.gesturePhase !== "try") return;
+    if (state.beat !== "gesture") return;
     if (!tryArmedRef.current) {
       tryArmedRef.current = true;
       prevCodeRef.current = selectedCode;
@@ -151,9 +156,13 @@ function TourRunner({
     }
     if (selectedCode !== prevCodeRef.current) {
       prevCodeRef.current = selectedCode;
+      // A bare globe tap-select changes the country but is not the flick this
+      // beat teaches, so an accidental tap must not skip it. A real fling or a
+      // deliberate list pick (both leave lastSettleViaTap false) still advances.
+      if (globeChartStore.getState().lastSettleViaTap) return;
       dispatch({ type: "USER_SELECTED" });
     }
-  }, [selectedCode, state.beat, state.gesturePhase]);
+  }, [selectedCode, state.beat]);
 
   // Beat 2 advances when the user pulls the sheet to full; beat 3 when a track
   // starts. Both observe, never drive. Show, don't tell.
@@ -163,11 +172,26 @@ function TourRunner({
     }
   }, [snap, state.beat]);
 
+  // Beat 3 baselines whatever is already previewing when it opens, so a track
+  // played earlier (even an accidental tap during beats 1-2) never auto-skips
+  // the "tap a track" teaching. Only a fresh preview started during the beat
+  // advances. Mirrors the gesture beat's baseline snapshot above.
+  const audioBaselineRef = useRef<string | null>(null);
+  const audioArmedRef = useRef(false);
   useEffect(() => {
-    if (state.beat === "audio" && hasCurrentTrack) {
+    if (state.beat !== "audio") return;
+    if (!audioArmedRef.current) {
+      audioArmedRef.current = true;
+      audioBaselineRef.current = currentTrackId;
+      return;
+    }
+    if (
+      currentTrackId !== null &&
+      currentTrackId !== audioBaselineRef.current
+    ) {
       dispatch({ type: "TRACK_PREVIEWED" });
     }
-  }, [hasCurrentTrack, state.beat]);
+  }, [currentTrackId, state.beat]);
 
   // ESC dismisses from any beat (counts as seen). Window-level, like the Space
   // play/pause handler in chart-screen.tsx.
@@ -204,13 +228,9 @@ function TourRunner({
   return (
     <TourOverlay
       beat={beat}
-      gesturePhase={state.gesturePhase}
       spotlight={spotlightReady ? (anchor?.rect ?? null) : null}
       spotlightRadius={anchor?.radius ?? 0}
       hideFlickHint={engaged}
-      passThrough={beat === "gesture"}
-      isLastBeat={beat === "audio"}
-      onNext={() => dispatch({ type: "NEXT" })}
       onSkip={() => dispatch({ type: "SKIP" })}
     />
   );

--- a/src/components/tour/tour-overlay.test.tsx
+++ b/src/components/tour/tour-overlay.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
 import { TourOverlay, type TourOverlayProps } from "./tour-overlay";
@@ -6,11 +6,7 @@ import { TourOverlay, type TourOverlayProps } from "./tour-overlay";
 function renderOverlay(overrides: Partial<TourOverlayProps> = {}) {
   const props: TourOverlayProps = {
     beat: "gesture",
-    gesturePhase: "ready",
     spotlight: null,
-    passThrough: true,
-    isLastBeat: false,
-    onNext: vi.fn(),
     onSkip: vi.fn(),
     ...overrides,
   };
@@ -29,49 +25,48 @@ const rect = (over: Partial<DOMRect> = {}): DOMRect =>
   }) as DOMRect;
 
 describe("TourOverlay", () => {
-  test("invites the user to flick and shows the hint on the try phase", () => {
-    const { getByText, getByTestId, queryByRole } = renderOverlay({
-      gesturePhase: "try",
-    });
+  test("names the beat's gesture in a politely-announced badge", () => {
+    const { getByTestId } = renderOverlay({ beat: "gesture" });
 
-    expect(getByText(/flick the globe/i)).toBeTruthy();
-    expect(getByText(/pick one from the list/i)).toBeTruthy();
-    expect(getByTestId("tour-flick-hint")).toBeTruthy();
-    // Next is withheld until the user has flicked, so they aren't rushed past it.
-    expect(queryByRole("button", { name: "Next" })).toBeNull();
+    const badge = getByTestId("tour-badge");
+    expect(badge.textContent).toMatch(/flick to spin/i);
+    // The badge is the wordless look's a11y fallback, so it stays in the tree.
+    expect(badge.getAttribute("role")).toBe("status");
+    expect(badge.getAttribute("aria-live")).toBe("polite");
+    expect(badge.getAttribute("aria-hidden")).toBeNull();
   });
 
-  test("reveals Next and drops the hint once the user has flicked", () => {
-    const { getByRole, queryByTestId } = renderOverlay({
-      gesturePhase: "ready",
-    });
-
-    expect(getByRole("button", { name: "Next" })).toBeTruthy();
-    expect(queryByTestId("tour-flick-hint")).toBeNull();
+  test("labels each later beat's gesture", () => {
+    expect(
+      renderOverlay({ beat: "sheet" }).getByTestId("tour-badge").textContent,
+    ).toMatch(/pull up the chart/i);
+    cleanup();
+    expect(
+      renderOverlay({ beat: "audio" }).getByTestId("tour-badge").textContent,
+    ).toMatch(/tap a track/i);
   });
 
-  test("labels the primary button Done on the last beat", () => {
-    const { getByRole } = renderOverlay({ beat: "audio", isLastBeat: true });
+  test("renders no text callout card or dialog", () => {
+    const { queryByTestId, queryByRole } = renderOverlay({ beat: "sheet" });
 
-    expect(getByRole("button", { name: "Done" })).toBeTruthy();
+    expect(queryByTestId("tour-callout")).toBeNull();
+    expect(queryByRole("dialog")).toBeNull();
   });
 
-  test("fires onNext and onSkip from the two buttons", () => {
+  test("shows the flick hint on the gesture beat and drops it once grabbed", () => {
+    expect(renderOverlay().queryByTestId("tour-flick-hint")).toBeTruthy();
+    cleanup();
+    expect(
+      renderOverlay({ hideFlickHint: true }).queryByTestId("tour-flick-hint"),
+    ).toBeNull();
+  });
+
+  test("dismisses the tour from the X control", () => {
     const { props, getByRole } = renderOverlay();
 
-    fireEvent.click(getByRole("button", { name: "Next" }));
-    fireEvent.click(getByRole("button", { name: "Skip tour" }));
+    fireEvent.click(getByRole("button", { name: "Dismiss tour" }));
 
-    expect(props.onNext).toHaveBeenCalledOnce();
     expect(props.onSkip).toHaveBeenCalledOnce();
-  });
-
-  test("exposes the callout as a non-modal dialog", () => {
-    const { getByRole } = renderOverlay();
-
-    const dialog = getByRole("dialog");
-    expect(dialog.getAttribute("aria-label")).toBe("App tour");
-    expect(dialog.getAttribute("aria-modal")).toBe("false");
   });
 
   test("draws no scrim cutout when there is no spotlight", () => {
@@ -80,26 +75,24 @@ describe("TourOverlay", () => {
     expect(queryByTestId("tour-scrim")).toBeNull();
   });
 
-  test("frames the spotlight and lets it capture pointer events when not passing through", () => {
-    const { getByTestId } = renderOverlay({
-      beat: "sheet",
-      spotlight: rect(),
-      passThrough: false,
-    });
+  test("frames the spotlight with four dim strips that never block", () => {
+    const { getByTestId } = renderOverlay({ beat: "sheet", spotlight: rect() });
 
     const scrim = getByTestId("tour-scrim");
+    // Four dim strips plus the aurora halo frame the cutout.
     expect(scrim.children.length).toBe(5);
-    expect(scrim.firstElementChild?.className).toContain("pointer-events-auto");
+    const strip = scrim.firstElementChild as HTMLElement;
+    // The dim is visual only; it must not capture pointer events, so every
+    // gesture reaches the live target under it.
+    expect(strip.className).not.toContain("pointer-events-auto");
   });
 
-  test("lets the scrim pass pointer events through on the gesture beat", () => {
-    const { getByTestId } = renderOverlay({
-      spotlight: rect(),
-      passThrough: true,
-    });
+  test("captures pointer events only on the X control", () => {
+    const { getByTestId, getByRole } = renderOverlay({ beat: "sheet" });
 
-    expect(getByTestId("tour-scrim").firstElementChild?.className).toContain(
-      "pointer-events-none",
+    expect(getByTestId("tour-overlay").style.pointerEvents).toBe("none");
+    expect(getByRole("button", { name: "Dismiss tour" }).className).toContain(
+      "pointer-events-auto",
     );
   });
 });

--- a/src/components/tour/tour-overlay.tsx
+++ b/src/components/tour/tour-overlay.tsx
@@ -262,8 +262,8 @@ export function TourOverlay({
           data-testid="tour-vignette"
           className="tour-dim pointer-events-none fixed inset-0"
           style={{
-            // Prototype's soft vignette: peak 0.82 at the edges through a
-            // half-strength midpoint, settling to the shared 0.5 residual.
+            // Soft vignette: peak 0.82 at the edges through a half-strength
+            // midpoint, settling with the scrim to the shared 0.5 residual.
             background:
               "radial-gradient(ellipse 46% 26% at 50% 44%, transparent 40%, rgba(5, 6, 8, 0.41) 70%, rgba(5, 6, 8, 0.82) 100%)",
           }}

--- a/src/components/tour/tour-overlay.tsx
+++ b/src/components/tour/tour-overlay.tsx
@@ -4,14 +4,13 @@ import type { CSSProperties } from "react";
 
 import { PointerIcon } from "@/components/icons/pointer";
 
-import type { Beat, GesturePhase } from "./tour-step";
+import type { Beat } from "./tour-step";
 
 // "done" never renders an overlay; the host unmounts at that point.
 export type VisibleBeat = Exclude<Beat, "done">;
 
 export interface TourOverlayProps {
   beat: VisibleBeat;
-  gesturePhase: GesturePhase;
   // Screen box to spotlight, or null for a full-screen beat (the gesture beat
   // has no cutout: the whole globe is the target) or before the box is read.
   spotlight: DOMRect | null;
@@ -19,46 +18,64 @@ export interface TourOverlayProps {
   // to 0 (square) when unset.
   spotlightRadius?: number;
   // Drop the gesture demo hand once the user has grabbed the globe; they're
-  // already flicking, so the "do this" cue is in the way. The callout copy and
-  // Next stay driven by the actual selection, not by this.
+  // already flicking, so the "do this" cue is in the way.
   hideFlickHint?: boolean;
-  // The gesture beat lets flings reach the globe, so its scrim must not capture
-  // pointer events; the sheet/audio beats dim and block everything but the hole.
-  passThrough: boolean;
-  isLastBeat: boolean;
-  onNext: () => void;
   onSkip: () => void;
 }
 
-// Per beat: a verb-first eyebrow (the gesture) over a body that states the
-// payoff. The gesture body also names the non-gesture path so a keyboard or SR
-// user is never told to only fling.
-function calloutCopy(
-  beat: VisibleBeat,
-  phase: GesturePhase,
-): { eyebrow: string; body: string } {
+// One imperative naming the gesture, per beat. This text is the accessibility
+// fallback for the wordless visual, so it lives in the a11y tree (see the badge
+// role below), not as a separate sr-only string.
+function badgeLabel(beat: VisibleBeat): string {
   switch (beat) {
     case "gesture":
-      return phase === "try"
-        ? {
-            eyebrow: "Flick the globe",
-            body: "Spin to a new country, or pick one from the list.",
-          }
-        : {
-            eyebrow: "Nice, you've got it",
-            body: "Spin as much as you like, then continue.",
-          };
+      return "Flick to spin";
     case "sheet":
-      return {
-        eyebrow: "Pull up the chart",
-        body: "See every track, not just the top few.",
-      };
+      return "Pull up the chart";
     case "audio":
-      return {
-        eyebrow: "Tap a track",
-        body: "Hear a preview; it follows you as you explore.",
-      };
+      return "Tap a track";
   }
+}
+
+// The nudge badge is announced politely on appear and carries the per-beat
+// breathe rhythm (matched to that beat's hand hint) plus the aurora glow. It is
+// not aria-hidden: its text is the tour's a11y fallback for the wordless look.
+function NudgeBadge({
+  beat,
+  spotlight,
+}: {
+  beat: VisibleBeat;
+  spotlight: DOMRect | null;
+}) {
+  // Gesture and sheet badges sit at a fixed screen fraction (globe centre, and
+  // above the sheet handle); the tap badge tracks the spotlit row, below it.
+  const style: CSSProperties =
+    beat === "audio" && spotlight
+      ? {
+          left: spotlight.left + spotlight.width / 2,
+          top: spotlight.bottom + 24,
+        }
+      : beat === "gesture"
+        ? { left: "50%", top: "53%" }
+        : { left: "50%", top: "38%" };
+  const rhythm =
+    beat === "gesture"
+      ? "tour-badge-flick"
+      : beat === "sheet"
+        ? "tour-badge-sheet"
+        : "tour-badge-tap";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="tour-badge"
+      className={`tour-badge tour-badge-breathe tour-badge-glow ${rhythm}`}
+      style={style}
+    >
+      {badgeLabel(beat)}
+    </div>
+  );
 }
 
 // A ghost hand that presses onto the globe and flings it (windup, whip,
@@ -190,23 +207,12 @@ function padHole(rect: DOMRect): Rect {
 
 export function TourOverlay({
   beat,
-  gesturePhase,
   spotlight,
   spotlightRadius = 0,
   hideFlickHint = false,
-  passThrough,
-  isLastBeat,
-  onNext,
   onSkip,
 }: TourOverlayProps) {
-  const { eyebrow, body } = calloutCopy(beat, gesturePhase);
   const hole = spotlight ? padHole(spotlight) : null;
-  const scrimPointer = passThrough
-    ? "pointer-events-none"
-    : "pointer-events-auto";
-  // The flick hint invites the first gesture; once the user has flicked (phase
-  // "ready") it gives way to Next, so they aren't rushed past beat one.
-  const inviting = beat === "gesture" && gesturePhase === "try";
 
   return (
     <div
@@ -220,7 +226,10 @@ export function TourOverlay({
           {scrimStrips(hole).map(({ key, style }) => (
             <div
               key={key}
-              className={`tour-fade fixed bg-[var(--scrim-deep)] ${scrimPointer}`}
+              // Visual only: the whole overlay is pointer-events:none, so the
+              // dim never blocks. Every gesture reaches the live target beneath
+              // it, which is what advances the beat.
+              className="tour-dim fixed bg-[var(--scrim-tour)]"
               style={style}
             />
           ))}
@@ -251,15 +260,17 @@ export function TourOverlay({
         <div
           aria-hidden
           data-testid="tour-vignette"
-          className="tour-fade pointer-events-none fixed inset-0"
+          className="tour-dim pointer-events-none fixed inset-0"
           style={{
+            // Prototype's soft vignette: peak 0.82 at the edges through a
+            // half-strength midpoint, settling to the shared 0.5 residual.
             background:
-              "radial-gradient(circle at 50% 44%, transparent 14%, rgba(5, 6, 8, 0.88) 82%)",
+              "radial-gradient(ellipse 46% 26% at 50% 44%, transparent 40%, rgba(5, 6, 8, 0.41) 70%, rgba(5, 6, 8, 0.82) 100%)",
           }}
         />
       ) : null}
 
-      {inviting && !hideFlickHint ? <FlickHint /> : null}
+      {beat === "gesture" && !hideFlickHint ? <FlickHint /> : null}
 
       {beat === "sheet" && spotlight ? (
         <SheetPullHint spotlight={spotlight} />
@@ -267,36 +278,26 @@ export function TourOverlay({
 
       {beat === "audio" && spotlight ? <TapHint spotlight={spotlight} /> : null}
 
-      <div
-        role="dialog"
-        aria-modal={false}
-        aria-label="App tour"
-        data-testid="tour-callout"
-        className="tour-rise border-fg-1/10 bg-dusk/95 pointer-events-auto fixed inset-x-4 bottom-[max(env(safe-area-inset-bottom),20px)] mx-auto max-w-sm rounded-[var(--radius-lg)] border p-5 shadow-[var(--shadow-lg)] backdrop-blur-md"
+      <NudgeBadge beat={beat} spotlight={spotlight} />
+
+      <button
+        type="button"
+        onClick={onSkip}
+        aria-label="Dismiss tour"
+        className="text-fg-1 focus-visible:outline-aurora pointer-events-auto fixed top-[56px] right-4 grid h-[42px] w-[42px] place-items-center rounded-full bg-[rgba(10,11,16,0.62)] shadow-[inset_0_0_0_1px_rgba(245,242,236,0.14)] backdrop-blur-md focus-visible:outline-2 focus-visible:outline-offset-2"
       >
-        <p className="text-small text-sunrise font-medium tracking-wide uppercase">
-          {eyebrow}
-        </p>
-        <p className="text-body text-fg-1 mt-1">{body}</p>
-        <div className="mt-4 flex items-center justify-between">
-          <button
-            type="button"
-            onClick={onSkip}
-            className="text-small text-fg-3 hover:text-fg-2 focus-visible:outline-aurora transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
-          >
-            Skip tour
-          </button>
-          {inviting ? null : (
-            <button
-              type="button"
-              onClick={onNext}
-              className="text-small bg-sunrise text-void focus-visible:outline-aurora rounded-[var(--radius-pill)] px-4 py-2 font-medium transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97]"
-            >
-              {isLastBeat ? "Done" : "Next"}
-            </button>
-          )}
-        </div>
-      </div>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          className="h-5 w-5"
+        >
+          <line x1="6" y1="6" x2="18" y2="18" />
+          <line x1="18" y1="6" x2="6" y2="18" />
+        </svg>
+      </button>
     </div>
   );
 }

--- a/src/components/tour/tour-step.test.ts
+++ b/src/components/tour/tour-step.test.ts
@@ -2,43 +2,27 @@ import { describe, expect, test } from "vitest";
 
 import { initialTourState, tourReducer, type TourState } from "./tour-step";
 
-const gestureTry: TourState = { beat: "gesture", gesturePhase: "try" };
-const gestureReady: TourState = { beat: "gesture", gesturePhase: "ready" };
-const onSheet: TourState = { beat: "sheet", gesturePhase: "ready" };
-const onAudio: TourState = { beat: "audio", gesturePhase: "ready" };
+const onGesture: TourState = { beat: "gesture" };
+const onSheet: TourState = { beat: "sheet" };
+const onAudio: TourState = { beat: "audio" };
 
 describe("initialTourState", () => {
-  test("opens on the gesture beat inviting the user to try", () => {
-    expect(initialTourState()).toEqual({
-      beat: "gesture",
-      gesturePhase: "try",
-    });
+  test("opens on the gesture beat", () => {
+    expect(initialTourState()).toEqual({ beat: "gesture" });
   });
 });
 
 describe("tourReducer gesture beat", () => {
-  test("the first selection reveals Next without advancing the beat", () => {
-    const next = tourReducer(gestureTry, { type: "USER_SELECTED" });
-
-    expect(next).toEqual({ beat: "gesture", gesturePhase: "ready" });
-  });
-
-  test("Next advances the gesture beat to the sheet once the user is ready", () => {
-    const next = tourReducer(gestureReady, { type: "NEXT" });
+  test("performing the gesture advances to the sheet beat", () => {
+    const next = tourReducer(onGesture, { type: "USER_SELECTED" });
 
     expect(next.beat).toBe("sheet");
   });
 
   test("an unrelated event leaves the gesture beat unchanged", () => {
-    const next = tourReducer(gestureTry, { type: "SHEET_OPENED" });
+    const next = tourReducer(onGesture, { type: "SHEET_OPENED" });
 
-    expect(next).toEqual(gestureTry);
-  });
-
-  test("Next does nothing until the user has flicked", () => {
-    const next = tourReducer(gestureTry, { type: "NEXT" });
-
-    expect(next).toEqual(gestureTry);
+    expect(next).toEqual(onGesture);
   });
 });
 
@@ -60,25 +44,19 @@ describe("tourReducer later beats", () => {
 
     expect(next.beat).toBe("done");
   });
-
-  test("Next on the audio beat finishes the tour", () => {
-    const next = tourReducer(onAudio, { type: "NEXT" });
-
-    expect(next.beat).toBe("done");
-  });
 });
 
 describe("tourReducer exit", () => {
   test("Skip ends the tour from any beat", () => {
-    expect(tourReducer(gestureTry, { type: "SKIP" }).beat).toBe("done");
+    expect(tourReducer(onGesture, { type: "SKIP" }).beat).toBe("done");
     expect(tourReducer(onSheet, { type: "SKIP" }).beat).toBe("done");
     expect(tourReducer(onAudio, { type: "SKIP" }).beat).toBe("done");
   });
 
   test("done is terminal", () => {
-    const done: TourState = { beat: "done", gesturePhase: "ready" };
+    const done: TourState = { beat: "done" };
 
-    const next = tourReducer(done, { type: "NEXT" });
+    const next = tourReducer(done, { type: "USER_SELECTED" });
 
     expect(next).toEqual(done);
   });

--- a/src/components/tour/tour-step.ts
+++ b/src/components/tour/tour-step.ts
@@ -5,54 +5,39 @@
 
 export type Beat = "gesture" | "sheet" | "audio" | "done";
 
-// Only meaningful while beat === "gesture": "try" invites the first flick (hint
-// shown, no Next); "ready" appears once the user has flicked, revealing Next so
-// they advance when they choose instead of being rushed on by their selection.
-export type GesturePhase = "try" | "ready";
-
 export interface TourState {
   beat: Beat;
-  gesturePhase: GesturePhase;
 }
 
 export type TourEvent =
   | { type: "USER_SELECTED" } // the user flung or tapped a country
   | { type: "SHEET_OPENED" } // the user pulled the chart sheet to full
   | { type: "TRACK_PREVIEWED" } // the user tapped a track to preview it
-  | { type: "NEXT" } // the explicit Next control
-  | { type: "SKIP" }; // Skip, dismiss, or Escape
+  | { type: "SKIP" }; // dismiss (the X) or Escape
 
 // No auto-demo: the gesture beat opens inviting the user to flick the globe
 // themselves, so the tour never moves the globe or changes the selection on the
 // user's behalf. A hint, not a scripted motion, teaches the gesture.
 export function initialTourState(): TourState {
-  return { beat: "gesture", gesturePhase: "try" };
+  return { beat: "gesture" };
 }
 
 export function tourReducer(state: TourState, event: TourEvent): TourState {
   // Skip ends the tour from any beat; dismissing counts as seen.
-  if (event.type === "SKIP") return { ...state, beat: "done" };
+  if (event.type === "SKIP") return { beat: "done" };
   if (state.beat === "done") return state;
 
   switch (state.beat) {
     case "gesture":
-      // The first flick does not advance; it reveals Next (phase "ready") so the
-      // user isn't rushed past the gesture they just learned. Next then advances.
-      if (event.type === "USER_SELECTED")
-        return { ...state, gesturePhase: "ready" };
-      // Next only advances once the user has flicked. The UI already withholds
-      // the button until then; the guard keeps the machine honest on its own.
-      if (event.type === "NEXT" && state.gesturePhase === "ready")
-        return { ...state, beat: "sheet" };
-      return state;
+      // Each beat advances only when the user performs its real gesture on the
+      // live target under the pass-through dim; there is no tap-to-skip a step.
+      // The single exit is the X (SKIP), so the dim never competes with the
+      // gesture for the same tap.
+      return event.type === "USER_SELECTED" ? { beat: "sheet" } : state;
     case "sheet":
-      return event.type === "SHEET_OPENED" || event.type === "NEXT"
-        ? { ...state, beat: "audio" }
-        : state;
+      return event.type === "SHEET_OPENED" ? { beat: "audio" } : state;
     case "audio":
-      return event.type === "TRACK_PREVIEWED" || event.type === "NEXT"
-        ? { ...state, beat: "done" }
-        : state;
+      return event.type === "TRACK_PREVIEWED" ? { beat: "done" } : state;
     default:
       return state;
   }

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -21,6 +21,11 @@ export interface GlobeChartState {
   // raise a dismissed sheet, so re-landing on the same country still raises
   // (a plain ?cc= diff would miss that).
   settleSignal: number;
+  // Whether the most recent settle came from a bare globe tap (vs a fling, an
+  // external ?cc=/list pick, or a snap). The onboarding tour's gesture beat
+  // reads this so an accidental tap-select does not count as performing the
+  // flick it teaches; a real fling or a deliberate list pick still advances.
+  lastSettleViaTap: boolean;
   // A track is loaded (the "listening" state), so a no-movement tap on the globe
   // edge skips a track instead of selecting a country. The audio store lives in
   // the page's provider, which the layout-backdrop globe can't read, so the
@@ -46,7 +51,7 @@ export interface GlobeChartState {
   shuffleLanded: { code: string; nonce: number } | null;
   setSelectedCountry: (code: string | null) => void;
   setReadMode: (readMode: boolean) => void;
-  signalSettle: () => void;
+  signalSettle: (viaTap?: boolean) => void;
   setListening: (listening: boolean) => void;
   signalSkip: (dir: 1 | -1) => void;
   requestShuffle: () => void;
@@ -58,14 +63,18 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   selectedCountry: null,
   readMode: false,
   settleSignal: 0,
+  lastSettleViaTap: false,
   listening: false,
   skipIntent: { dir: 1, nonce: 0 },
   shuffleSignal: 0,
   shuffleLanded: null,
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
   setReadMode: (readMode) => set({ readMode }),
-  signalSettle: () =>
-    set((state) => ({ settleSignal: state.settleSignal + 1 })),
+  signalSettle: (viaTap = false) =>
+    set((state) => ({
+      settleSignal: state.settleSignal + 1,
+      lastSettleViaTap: viaTap,
+    })),
   setListening: (listening) => set({ listening }),
   signalSkip: (dir) =>
     set((state) => ({


### PR DESCRIPTION
Slice 1 of the v2.3.0 wordless-tour redesign (PRD #210). Replaces the text callout cards for the three existing beats (flick / pull / tap) with the spotlight-nudge chrome, and settles the interaction model against the locked prototype.

## What changed

- **Wordless chrome.** Each beat dims onto its target (peak `0.82`) and settles to a residual (`0.5`) so the target stays visible, carried by a single per-beat nudge badge that breathes in time with its hand (flick 1900ms / pull 2000ms / tap 1800ms). The existing hand animations are untouched. Locked values are lifted from the prototype.
- **X-only dismiss, gesture-advances.** No Next button and no tap-to-skip: the dim is `pointer-events: none` on every beat, so the real gesture reaches the live target underneath and advances the beat; an X (or Escape) is the sole dismiss. This matches the prototype, whose dim layers are all pass-through. The step machine drops the try/ready phase and the `NEXT` event. See #210 / #211 comments for the design change (the earlier \"tap the dim to skip a step\" AC is superseded).
- **Each beat completes only on a fresh gesture during it**, so out-of-order or accidental actions never skip a step:
  - An accidental globe **tap-select is not a flick**, so it no longer skips the gesture beat. The globe now flags a settle as tap-vs-fling (`lastSettleViaTap`); a real fling or a deliberate list pick still advances.
  - A track **played earlier keeps the audio beat teaching** until a fresh preview, rather than auto-completing on a track from before the beat (baseline snapshot, mirroring the gesture beat).
  - The sheet beat needs no such guard: an already-full sheet puts the globe in read mode (input frozen), so the flick that ends beat 1 forces the sheet back down first.

Persistence stays the boolean seen flag. Beat 4 (double-tap skip) is #212; the learned-aware re-show is #213.

## Test plan

- Full local CI: typecheck, lint, format, 602 unit tests, production build.
- New/updated tour tests: X and Escape dismiss; dim is pass-through (pointer events only on the X); badge text is in the a11y tree; reduced-motion renders without the breathe; a bare tap-select does not skip the gesture beat; a pre-existing preview does not skip the audio beat.
- On-device (cloudflared tunnel, iOS + Mac): dim/badge feel verified against the prototype; the three edge cases confirmed by hand (tap-select, pre-play, sheet-full).

Closes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved onboarding guidance with clearer visual cues, badges, spotlight dimming, and accessibility announcements.
  * The tour now advances based on meaningful actions, including selecting a location and previewing a track.
  * Added support for reduced-motion preferences during onboarding.
  * Direct taps and flick gestures are handled distinctly for more accurate tour progression.

* **Bug Fixes**
  * Prevented the tour from skipping steps when an existing track is already previewing.
  * Improved tour dismissal behavior and ensured it is remembered.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->