### PR TITLE
feat(tour): reskin the edge-tap-skip cue to the wordless v2.3.0 language

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -256,7 +256,7 @@ function ChartScreenInner({
       />
       {/* Only while the globe is visible: at full the sheet covers it, so
           showing the hint there would burn its one-time display unseen. */}
-      <EdgeTapHint active={hasCurrentTrack && snap !== "full"} />
+      <EdgeTapHint active={hasCurrentTrack && snap !== "full"} snap={snap} />
       <SkipFlash skip={skipFlash} sheetSnap={snap} />
       <TourHost
         snap={snap}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -720,6 +720,174 @@
   animation: tour-tap-ripple 1.8s var(--ease-out) infinite;
 }
 
+/* Beat-4 skip cue, wordless. The contextual edge-tap hint renders a double-tap
+   hand at the right edge plus two aurora rails marking both skip zones, over the
+   shared dim. It teaches the double-tap-either-edge skip in the moment it first
+   becomes usable (a track plays and the sheet is below full). */
+
+/* The hand presses twice in place, holds, lifts, repeats: the literal
+   double-tap. Animate the wrapper, not the SVG, so the transform stays on the
+   compositor. */
+@keyframes tour-double-tap {
+  0% {
+    transform: scale(0.55);
+    opacity: 0;
+  }
+  9% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  17% {
+    transform: translateY(4px) scale(0.86);
+    opacity: 1;
+  }
+  25% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  33% {
+    transform: translateY(4px) scale(0.86);
+    opacity: 1;
+  }
+  41% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  74% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  88% {
+    transform: scale(0.55);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(0.55);
+    opacity: 0;
+  }
+}
+
+@keyframes tour-double-tap-ripple {
+  0%,
+  13% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.3);
+  }
+  19% {
+    opacity: 0.75;
+    transform: translate(-50%, -50%) scale(0.55);
+  }
+  29% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.7);
+  }
+  33% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.3);
+  }
+  39% {
+    opacity: 0.75;
+    transform: translate(-50%, -50%) scale(0.55);
+  }
+  49% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.7);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.7);
+  }
+}
+
+.tour-double-tap {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  color: var(--color-aurora);
+  animation: tour-double-tap 2000ms var(--ease-out) infinite;
+}
+
+.tour-double-tap::after {
+  content: "";
+  position: absolute;
+  top: 14%;
+  left: 35%;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-pill);
+  border: 2px solid rgba(107, 229, 197, 0.8);
+  transform: translate(-50%, -50%) scale(0.3);
+  animation: tour-double-tap-ripple 2000ms var(--ease-out) infinite;
+}
+
+/* Left-edge echo: the same touch ripple as the right hand's double-tap, mirrored
+   to the left edge with no hand and in sync, so "either edge" is shown, not only
+   worded. left 35% -> 65% mirrors the hand's fingertip so both land at the same
+   height; one ring only, matching the hand's single pulsing ::after. */
+.tour-edge-echo {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  /* Same bob + fade envelope as the hand, so the ripple rides it identically
+     (the hand icon is just absent). Without this the left ripple pulses on a
+     static parent and reads subtly different from the right. */
+  animation: tour-double-tap 2000ms var(--ease-out) infinite;
+}
+
+.tour-edge-echo::after {
+  content: "";
+  position: absolute;
+  top: 14%;
+  left: 65%;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-pill);
+  border: 2px solid rgba(107, 229, 197, 0.8);
+  transform: translate(-50%, -50%) scale(0.3);
+  animation: tour-double-tap-ripple 2000ms var(--ease-out) infinite;
+}
+
+/* Two full-height aurora washes, strongest at each screen edge and gone by the
+   centre, so the pair reads as "either side" where a single hand cannot. They
+   sit behind the sheet (a lower z), which masks their bottom with its own
+   rounded silhouette. One slow smooth swell, ease-in-out dwelling at both ends,
+   so it breathes rather than blinks. */
+@keyframes tour-rail-pulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.82;
+  }
+}
+
+.tour-rail {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  animation: tour-rail-pulse 1900ms ease-in-out infinite;
+}
+
+.tour-rail-l {
+  left: 0;
+  background: linear-gradient(
+    to right,
+    rgba(107, 229, 197, 0.34),
+    rgba(107, 229, 197, 0) 52%
+  );
+}
+
+.tour-rail-r {
+  right: 0;
+  background: linear-gradient(
+    to left,
+    rgba(107, 229, 197, 0.34),
+    rgba(107, 229, 197, 0) 52%
+  );
+}
+
 /* One-time commentary discovery hint: an aurora ring draws the eye while the
    chevron wrapper bobs down to say "open". Fires once, then the JS clears the
    attribute and the chevron returns to rest. Animate the wrapper, not the SVG,
@@ -852,14 +1020,25 @@
   .tour-pull,
   .tour-pull::after,
   .tour-tap,
-  .tour-tap::after {
+  .tour-tap::after,
+  .tour-double-tap,
+  .tour-double-tap::after,
+  .tour-edge-echo,
+  .tour-edge-echo::after {
     animation: none;
   }
   /* The touch-ripple rings read as motion; frozen they leave a stray dot at the
      fingertip. Hide them so reduced motion shows clean static finger icons. */
   .tour-swipe::after,
   .tour-pull::after,
-  .tour-tap::after {
+  .tour-tap::after,
+  .tour-double-tap::after,
+  .tour-edge-echo::after {
     display: none;
+  }
+  /* The rails keep marking the edges; drop the swell, rest at a steady level. */
+  .tour-rail {
+    animation: none;
+    opacity: 0.6;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -799,46 +799,27 @@
   }
 }
 
-.tour-double-tap {
-  position: relative;
-  width: 44px;
-  height: 44px;
-  color: var(--color-aurora);
-  animation: tour-double-tap 2000ms var(--ease-out) infinite;
-}
-
-.tour-double-tap::after {
-  content: "";
-  position: absolute;
-  top: 14%;
-  left: 35%;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-pill);
-  border: 2px solid rgba(107, 229, 197, 0.8);
-  transform: translate(-50%, -50%) scale(0.3);
-  animation: tour-double-tap-ripple 2000ms var(--ease-out) infinite;
-}
-
-/* Left-edge echo: the same touch ripple as the right hand's double-tap, mirrored
-   to the left edge with no hand and in sync, so "either edge" is shown, not only
-   worded. left 35% -> 65% mirrors the hand's fingertip so both land at the same
-   height; one ring only, matching the hand's single pulsing ::after. */
+/* The double-tap hand and the left-edge echo share one bob+fade envelope and one
+   touch ripple; only the ripple's horizontal origin mirrors (35% vs 65%) so both
+   rings sit at the same height. The echo carries no hand icon: it is the ripple
+   alone, riding the same envelope so it reads identically to the hand's. */
+.tour-double-tap,
 .tour-edge-echo {
   position: relative;
   width: 44px;
   height: 44px;
-  /* Same bob + fade envelope as the hand, so the ripple rides it identically
-     (the hand icon is just absent). Without this the left ripple pulses on a
-     static parent and reads subtly different from the right. */
   animation: tour-double-tap 2000ms var(--ease-out) infinite;
 }
 
+.tour-double-tap {
+  color: var(--color-aurora);
+}
+
+.tour-double-tap::after,
 .tour-edge-echo::after {
   content: "";
   position: absolute;
   top: 14%;
-  left: 65%;
   width: 30px;
   height: 30px;
   border-radius: var(--radius-pill);
@@ -847,11 +828,19 @@
   animation: tour-double-tap-ripple 2000ms var(--ease-out) infinite;
 }
 
-/* Two full-height aurora washes, strongest at each screen edge and gone by the
-   centre, so the pair reads as "either side" where a single hand cannot. They
-   sit behind the sheet (a lower z), which masks their bottom with its own
-   rounded silhouette. One slow smooth swell, ease-in-out dwelling at both ends,
-   so it breathes rather than blinks. */
+.tour-double-tap::after {
+  left: 35%;
+}
+
+.tour-edge-echo::after {
+  left: 65%;
+}
+
+/* Two full-height aurora washes marking each skip edge, strongest at the edge and
+   gone by the centre. They sit behind the sheet (a lower z), which masks their
+   bottom with its own rounded silhouette. The pair fades in with the dim (see
+   .tour-rails), then swells as one slow smooth breath, ease-in-out dwelling at
+   both ends, so it breathes rather than blinks. */
 @keyframes tour-rail-pulse {
   0%,
   100% {
@@ -886,6 +875,25 @@
     rgba(107, 229, 197, 0.34),
     rgba(107, 229, 197, 0) 52%
   );
+}
+
+/* The rails fade in over the dim-in window (the 620ms leading edge of tour-dim's
+   2380ms), so the globe-dim, rails, and sheet-dim all appear together instead of
+   the rails popping in at full while the dims fade up. The pulse rides this fade:
+   wrapper opacity (0 to 1) times each rail's pulse. */
+@keyframes tour-rails-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.tour-rails {
+  position: absolute;
+  inset: 0;
+  animation: tour-rails-in 620ms var(--ease-out) both;
 }
 
 /* One-time commentary discovery hint: an aurora ring draws the eye while the
@@ -1036,7 +1044,11 @@
   .tour-edge-echo::after {
     display: none;
   }
-  /* The rails keep marking the edges; drop the swell, rest at a steady level. */
+  /* The rails keep marking the edges; drop the swell and the fade-in, rest at a
+     steady level. */
+  .tour-rails {
+    animation: none;
+  }
   .tour-rail {
     animation: none;
     opacity: 0.6;

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -538,7 +538,10 @@ export function ChartSheet({
         transform: `translateY(${SNAP_Y[initialSnap]})`,
         willChange: "transform",
       }}
-      className="group bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 flex flex-col rounded-t-2xl border-t"
+      // Explicit z so the edge-tap hint can bracket the sheet: its aurora rails
+      // sit below (a lower z) and its sheet-dim above, reproducing the backdrop
+      // sandwich. Stays under the mini-player (z-50) and the tour overlay (z-60).
+      className="group bg-void text-fg-1 border-fg-1/10 shadow-sheet fixed inset-x-0 z-20 flex flex-col rounded-t-2xl border-t"
     >
       <div className="shrink-0 touch-none">
         <button

--- a/src/components/globe/edge-tap-hint.test.tsx
+++ b/src/components/globe/edge-tap-hint.test.tsx
@@ -1,0 +1,88 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { globeChartStore } from "@/lib/globe-chart-store";
+
+import { EdgeTapHint } from "./edge-tap-hint";
+
+function renderHint(active = true) {
+  return render(<EdgeTapHint active={active} snap="peek" />);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  globeChartStore.setState({ skipIntent: { dir: 1, nonce: 0 } });
+});
+
+afterEach(cleanup);
+
+describe("EdgeTapHint", () => {
+  test("shows the wordless skip cue only when active and unseen", () => {
+    expect(renderHint(false).queryByTestId("edge-tap-badge")).toBeNull();
+    cleanup();
+
+    const { getByTestId } = renderHint(true);
+    expect(getByTestId("edge-tap-badge").textContent).toMatch(
+      /double-tap either edge to skip/i,
+    );
+    expect(getByTestId("edge-tap-backdrop")).toBeTruthy();
+  });
+
+  test("does not show again once the flag is already set", () => {
+    localStorage.setItem("sounds-abroad:edge-tap-hint-seen:v1", "1");
+
+    expect(renderHint(true).queryByTestId("edge-tap-badge")).toBeNull();
+  });
+
+  test("marks itself seen on show", () => {
+    renderHint(true);
+
+    expect(localStorage.getItem("sounds-abroad:edge-tap-hint-seen:v1")).toBe(
+      "1",
+    );
+  });
+
+  test("dismisses when the user performs a real skip", () => {
+    const { queryByTestId } = renderHint(true);
+    expect(queryByTestId("edge-tap-badge")).toBeTruthy();
+
+    act(() => {
+      globeChartStore.getState().signalSkip(1);
+    });
+
+    expect(queryByTestId("edge-tap-badge")).toBeNull();
+  });
+
+  test("retires on the fallback timeout when no skip comes", () => {
+    vi.useFakeTimers();
+    try {
+      const { queryByTestId } = renderHint(true);
+      expect(queryByTestId("edge-tap-badge")).toBeTruthy();
+
+      act(() => {
+        vi.advanceTimersByTime(6000);
+      });
+
+      expect(queryByTestId("edge-tap-badge")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("renders the reskinned chrome, not the old chip-and-caption cue", () => {
+    const { container, getByTestId } = renderHint(true);
+
+    // The aurora rails are the new language; the old fade-in chip row is gone.
+    expect(container.querySelectorAll(".tour-rail")).toHaveLength(2);
+    expect(container.querySelector(".tour-fade")).toBeNull();
+    // The left edge echoes the double-tap so "either edge" is shown, not worded.
+    expect(getByTestId("edge-tap-echo")).toBeTruthy();
+    // Pointer-transparent so it never intercepts the taps it teaches.
+    expect(getByTestId("edge-tap-backdrop").className).toContain(
+      "pointer-events-none",
+    );
+    expect(getByTestId("edge-tap-foreground").className).toContain(
+      "pointer-events-none",
+    );
+  });
+});

--- a/src/components/globe/edge-tap-hint.test.tsx
+++ b/src/components/globe/edge-tap-hint.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { globeChartStore } from "@/lib/globe-chart-store";
 
 import { EdgeTapHint } from "./edge-tap-hint";
+import { edgeTapSeen } from "./seen-edge-tap-hint";
 
 function renderHint(active = true) {
   return render(<EdgeTapHint active={active} snap="peek" />);
@@ -29,7 +30,7 @@ describe("EdgeTapHint", () => {
   });
 
   test("does not show again once the flag is already set", () => {
-    localStorage.setItem("sounds-abroad:edge-tap-hint-seen:v1", "1");
+    edgeTapSeen.markSeen();
 
     expect(renderHint(true).queryByTestId("edge-tap-badge")).toBeNull();
   });
@@ -37,9 +38,7 @@ describe("EdgeTapHint", () => {
   test("marks itself seen on show", () => {
     renderHint(true);
 
-    expect(localStorage.getItem("sounds-abroad:edge-tap-hint-seen:v1")).toBe(
-      "1",
-    );
+    expect(edgeTapSeen.hasSeen()).toBe(true);
   });
 
   test("dismisses when the user performs a real skip", () => {

--- a/src/components/globe/edge-tap-hint.tsx
+++ b/src/components/globe/edge-tap-hint.tsx
@@ -1,64 +1,140 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { SkipBackIcon } from "@/components/icons/skip-back";
-import { SkipForwardIcon } from "@/components/icons/skip-forward";
+import type { SnapState } from "@/components/chart-sheet/sheet";
+import { PointerIcon } from "@/components/icons/pointer";
+import { useTourAnchor } from "@/components/tour/use-tour-anchor";
+import { globeChartStore } from "@/lib/globe-chart-store";
 
 import { edgeTapSeen } from "./seen-edge-tap-hint";
 
-const VISIBLE_MS = 2600;
+// If the user never performs the skip, retire the cue rather than let it linger
+// over their listening.
+const FALLBACK_MS = 6000;
 
-const CHIP_CLASS =
-  "bg-void/70 text-fg-1 ring-fg-1/10 shadow-sheet flex h-11 w-11 items-center justify-center rounded-full opacity-80 ring-1 backdrop-blur-sm";
-
-const CAPTION_CLASS =
-  "bg-void/70 text-fg-1 ring-fg-1/10 shadow-sheet rounded-full px-3 py-1.5 text-sm font-medium opacity-80 ring-1 backdrop-blur-sm";
-
-// One-time cue that a double-tap on the globe's left/right edge skips tracks
-// while a preview plays (a single tap still selects a country). Pointer-
-// transparent so it never intercepts the taps it teaches; shown once per device,
-// then the seen flag persists. Entrance uses the shared tour-fade, which
-// globals.css already drops under prefers-reduced-motion.
-export function EdgeTapHint({ active }: { active: boolean }) {
+// Contextual first-encounter cue for the double-tap-either-edge skip. Unlike the
+// linear onboarding tour, this waits for the moment the gesture first becomes
+// usable (a track plays and the sheet is below full, so the globe edges are
+// tappable), then teaches it in place. Shown once per device; the seen flag
+// persists. Pointer-transparent throughout so it never intercepts the taps it
+// teaches. Reskinned to the v2.3.0 wordless language: a globe-dim / sheet-dim
+// sandwich, two aurora edge rails behind the sheet, one right-edge double-tap
+// hand, and a "Double-tap either edge to skip" badge.
+export function EdgeTapHint({
+  active,
+  snap,
+}: {
+  active: boolean;
+  snap: SnapState;
+}) {
   // Read the persisted flag once at mount, before any track plays, so it holds
-  // the true prior-session value. Visibility is then derived from `active`, not
-  // toggled on synchronously in an effect; only the auto-dismiss flips state,
-  // from the timer callback.
+  // the true prior-session value. Visibility is derived from `active`, not
+  // latched in an effect.
   const [seenAtMount] = useState(() => edgeTapSeen.hasSeen());
   const [dismissed, setDismissed] = useState(false);
-  const armedRef = useRef(false);
 
   const visible = active && !seenAtMount && !dismissed;
 
+  // Measure the sheet so the sheet-dim covers exactly it, matching its rounded
+  // corners. `snap` is the watch signal: the sheet slides between snaps via
+  // transform, which moves its box without firing resize or scroll.
+  const sheetAnchor = useTourAnchor(
+    visible ? '[data-testid="chart-sheet"]' : null,
+    snap,
+  );
+
+  // Mark the cue seen and retire it once its lesson lands: dismiss the instant
+  // the user performs a real skip (a fresh skipIntent nonce during the show), or
+  // after FALLBACK_MS if they never do. Mirrors the tour's "complete only on a
+  // fresh gesture performed during the beat" rule.
   useEffect(() => {
-    // Reset the gate when the hint hides so a later show re-arms the timer; the
-    // gate keeps a single continuous show from re-arming.
-    if (!visible) {
-      armedRef.current = false;
-      return;
-    }
-    if (armedRef.current) return;
-    armedRef.current = true;
+    if (!visible) return;
+    // Mark seen on show, like the prior cue: one appearance per device even if
+    // the user leaves without skipping.
     edgeTapSeen.markSeen();
-    const id = window.setTimeout(() => setDismissed(true), VISIBLE_MS);
-    return () => window.clearTimeout(id);
+    const unsubscribe = globeChartStore.subscribe((state, prev) => {
+      // Only a nonce change after this subscription is a fresh skip performed
+      // during the show; a skip from before the cue appeared never counts.
+      if (state.skipIntent.nonce !== prev.skipIntent.nonce) setDismissed(true);
+    });
+    const fallback = window.setTimeout(() => setDismissed(true), FALLBACK_MS);
+    return () => {
+      unsubscribe();
+      window.clearTimeout(fallback);
+    };
   }, [visible]);
 
   if (!visible) return null;
 
+  const sheet = sheetAnchor?.rect;
+
   return (
-    <div
-      aria-hidden
-      className="tour-fade pointer-events-none fixed inset-y-0 right-0 left-0 z-40 flex items-center justify-between px-3"
-    >
-      <span className={CHIP_CLASS}>
-        <SkipBackIcon className="h-5 w-5" />
-      </span>
-      <span className={CAPTION_CLASS}>Double-tap to skip</span>
-      <span className={CHIP_CLASS}>
-        <SkipForwardIcon className="h-5 w-5" />
-      </span>
-    </div>
+    <>
+      {/* Backdrop: globe-dim + the two aurora rails, below the sheet (z-10 <
+          sheet z-20) so the sheet masks the rails' bottom with its own shape. */}
+      <div
+        aria-hidden
+        data-testid="edge-tap-backdrop"
+        className="pointer-events-none fixed inset-0 z-10"
+      >
+        <div className="tour-dim absolute inset-0 bg-[var(--scrim-tour)]" />
+        <div className="tour-rail tour-rail-l" />
+        <div className="tour-rail tour-rail-r" />
+      </div>
+
+      {/* Foreground: the sheet's own dim, the double-tap hand, and the badge,
+          above the sheet (z-40 > sheet z-20, below the mini-player z-50). */}
+      <div
+        aria-hidden={undefined}
+        data-testid="edge-tap-foreground"
+        className="pointer-events-none fixed inset-0 z-40"
+      >
+        {sheet ? (
+          <div
+            aria-hidden
+            className="tour-dim absolute bg-[var(--scrim-tour)]"
+            style={{
+              left: sheet.left,
+              top: sheet.top,
+              width: sheet.width,
+              height: sheet.height,
+              borderRadius: sheetAnchor?.radius ?? 0,
+            }}
+          />
+        ) : null}
+
+        <div
+          aria-hidden
+          className="fixed -translate-x-1/2 -translate-y-1/2"
+          style={{ left: "83.5%", top: "42%" }}
+        >
+          <div className="tour-double-tap">
+            <PointerIcon className="tour-swipe-hand" />
+          </div>
+        </div>
+
+        {/* Left edge: the same double-tap ripple, no hand, in sync, so "either
+            edge" is shown as well as worded. Mirrors the hand's position. */}
+        <div
+          aria-hidden
+          data-testid="edge-tap-echo"
+          className="fixed -translate-x-1/2 -translate-y-1/2"
+          style={{ left: "16.5%", top: "42%" }}
+        >
+          <div className="tour-edge-echo" />
+        </div>
+
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="edge-tap-badge"
+          className="tour-badge tour-badge-breathe tour-badge-glow"
+          style={{ left: "50%", top: "62%" }}
+        >
+          Double-tap either edge to skip
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/components/globe/edge-tap-hint.tsx
+++ b/src/components/globe/edge-tap-hint.tsx
@@ -13,14 +13,19 @@ import { edgeTapSeen } from "./seen-edge-tap-hint";
 // over their listening.
 const FALLBACK_MS = 6000;
 
+// The demonstrating hand's horizontal centre; the left echo mirrors it so the
+// pair stays symmetric when either moves.
+const HAND_EDGE_PCT = 83.5;
+const ECHO_EDGE_PCT = 100 - HAND_EDGE_PCT;
+
 // Contextual first-encounter cue for the double-tap-either-edge skip. Unlike the
 // linear onboarding tour, this waits for the moment the gesture first becomes
 // usable (a track plays and the sheet is below full, so the globe edges are
 // tappable), then teaches it in place. Shown once per device; the seen flag
 // persists. Pointer-transparent throughout so it never intercepts the taps it
-// teaches. Reskinned to the v2.3.0 wordless language: a globe-dim / sheet-dim
-// sandwich, two aurora edge rails behind the sheet, one right-edge double-tap
-// hand, and a "Double-tap either edge to skip" badge.
+// teaches. Wordless chrome: a globe-dim / sheet-dim sandwich, two aurora edge
+// rails behind the sheet, one right-edge double-tap hand with a synced left-edge
+// ripple echo, and a "Double-tap either edge to skip" badge.
 export function EdgeTapHint({
   active,
   snap,
@@ -79,14 +84,18 @@ export function EdgeTapHint({
         className="pointer-events-none fixed inset-0 z-10"
       >
         <div className="tour-dim absolute inset-0 bg-[var(--scrim-tour)]" />
-        <div className="tour-rail tour-rail-l" />
-        <div className="tour-rail tour-rail-r" />
+        {/* The rails fade in over the dim-in window so all three layers appear
+            together; the pulse rides that fade. */}
+        <div className="tour-rails">
+          <div className="tour-rail tour-rail-l" />
+          <div className="tour-rail tour-rail-r" />
+        </div>
       </div>
 
       {/* Foreground: the sheet's own dim, the double-tap hand, and the badge,
-          above the sheet (z-40 > sheet z-20, below the mini-player z-50). */}
+          above the sheet (z-40 > sheet z-20, below the mini-player z-50). Not
+          aria-hidden: it holds the status badge, the cue's a11y fallback. */}
       <div
-        aria-hidden={undefined}
         data-testid="edge-tap-foreground"
         className="pointer-events-none fixed inset-0 z-40"
       >
@@ -107,7 +116,7 @@ export function EdgeTapHint({
         <div
           aria-hidden
           className="fixed -translate-x-1/2 -translate-y-1/2"
-          style={{ left: "83.5%", top: "42%" }}
+          style={{ left: `${HAND_EDGE_PCT}%`, top: "42%" }}
         >
           <div className="tour-double-tap">
             <PointerIcon className="tour-swipe-hand" />
@@ -120,7 +129,7 @@ export function EdgeTapHint({
           aria-hidden
           data-testid="edge-tap-echo"
           className="fixed -translate-x-1/2 -translate-y-1/2"
-          style={{ left: "16.5%", top: "42%" }}
+          style={{ left: `${ECHO_EDGE_PCT}%`, top: "42%" }}
         >
           <div className="tour-edge-echo" />
         </div>


### PR DESCRIPTION
## What & why

Reskin the double-tap-either-edge skip cue to the v2.3.0 wordless language, and keep it a **contextual first-encounter hint** rather than absorbing it into the linear tour.

The skip gesture is only performable once a track plays and the sheet is below full (the globe edges must be tappable). The preceding "tap a track" beat leaves the sheet at full, occluding the globe, so folding skip into the linear sequence would strand the beat behind a full sheet or force the tour to drive the sheet down (both rejected by #211). The gesture's precondition is exactly the moment the contextual hint already waits for, so keeping it contextual removes the occlusion. This reverses one premise of PRD #210 (single teaching system); rationale recorded as a comment on #210.

## Changes

- Aurora edge rails behind the sheet (a lower z, so the sheet masks their bottom), one slow smooth swell at 1900ms.
- One right-edge double-tap hand plus a synced left-edge ripple echo, so "either edge" is shown, not only worded. The echo mirrors the hand's ripple exactly (same bob-and-fade envelope, mirrored horizontally, no hand icon).
- The "Double-tap either edge to skip" badge, over the globe-dim / sheet-dim / rails sandwich on the shared dim-to-settle timeline.
- End condition: retire on the real skip gesture (a fresh `skipIntent`) with a timeout fallback, replacing the fixed timer.
- `sheet.tsx` gains an explicit `z-20` so the hint can bracket it (rails below, sheet-dim above); stays under the mini-player and tour overlay.

## Test plan

- Local CI green: typecheck, lint, test (608), build.
- New `edge-tap-hint.test.tsx` (7): trigger gate, seen-on-show, dismiss-on-skip, fallback timeout, and the reskinned chrome (rails + left echo present, old chip-and-caption gone, pointer-transparent).
- On device (cloudflared tunnel): confirmed the cue appears at peek with a track playing and dismisses on a real edge double-tap. Rail and echo feel tuned by eye against the prototype.

## Notes

- The prototype is the source of truth over the written ACs (per #211's lesson); the "skipped via dim-tap" AC is superseded (X-only / gesture-advance, no dim-tap).
- #213 (learned-aware re-show) got a comment narrowing its scope to the linear beats; the contextual hint keeps its own seen-flag.

Closes #212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-place onboarding cue showing users how to double-tap either screen edge to skip.
  * Added animated edge rails, hand gestures, ripples, and a sheet-aligned dimming effect.
  * The cue now dismisses immediately after a successful skip or automatically after a short fallback period.
  * Added support for reduced-motion settings.

* **Bug Fixes**
  * Improved visual layering so the chart sheet and onboarding guidance display correctly.

* **Tests**
  * Added coverage for hint visibility, dismissal, persistence, timeout behavior, and touch interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->