### PR TITLE
feat(tour): re-teach only the gestures the user hasn't learned

### DIFF
--- a/src/components/chart-sheet/use-commentary-hint-pulse.ts
+++ b/src/components/chart-sheet/use-commentary-hint-pulse.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useStore } from "zustand";
 
-import { tourSeen } from "@/components/tour/seen-tour";
+import { tourConcluded } from "@/components/tour/tour-concluded";
+import { tourBridge } from "@/lib/tour-bridge";
 import { useSeenFlag } from "@/lib/use-seen-flag";
 
 import { commentarySeen } from "./seen-commentary-hint";
@@ -33,17 +35,21 @@ export interface CommentaryHintPulse {
 // that row, so its store reads and observer cost are paid once, not per row.
 export function useCommentaryHintPulse(): CommentaryHintPulse {
   const tourDone = useSyncExternalStore(
-    tourSeen.subscribe,
-    tourSeen.hasSeen,
+    tourConcluded.subscribe,
+    tourConcluded.isConcluded,
     tourServerSnapshot,
   );
+  // A capped final appearance marks the record concluded while the tour is still
+  // on screen; wait for it to leave so the pulse isn't spent under the tour dim.
+  const tourActive = useStore(tourBridge, (s) => s.tourActive);
   const { seen: hintSeen, markSeen } = useSeenFlag(commentarySeen);
   const chevronRef = useRef<HTMLSpanElement>(null);
   const [pulsing, setPulsing] = useState(false);
 
   // Both flags are booleans (null during SSR), so the effect keys off a single
-  // primitive: only arm once the tour is done and the hint hasn't fired.
-  const armable = tourDone === true && hintSeen === false;
+  // primitive: only arm once the tour is done, off screen, and the hint hasn't
+  // fired.
+  const armable = tourDone === true && !tourActive && hintSeen === false;
 
   useEffect(() => {
     if (!armable) return;

--- a/src/components/tour/seen-tour.ts
+++ b/src/components/tour/seen-tour.ts
@@ -1,6 +1,0 @@
-import { createSeenFlag } from "@/lib/create-seen-flag";
-
-// First-run gate for the onboarding tour, persisted across sessions (unlike the
-// per-session visited set). The commentary hint subscribes to this flag so it
-// can arm once the tour is dismissed mid-session, not just at its own mount.
-export const tourSeen = createSeenFlag("sounds-abroad:tour-seen:v1");

--- a/src/components/tour/tour-concluded.ts
+++ b/src/components/tour/tour-concluded.ts
@@ -1,0 +1,12 @@
+import { hasConcluded } from "./tour-record";
+import { readRecord, subscribeRecord } from "./tour-record-store";
+
+// The tour-done gate the commentary hint arms off, derived from the learned-aware
+// record: the tour has "concluded" once it will never show again (dismissed,
+// every gesture learned, or the appearance cap reached). subscribe fires on every
+// record write so a mid-session conclusion reaches the hint, which outlives the
+// tour. A boolean reactive-store shape (subscribe + snapshot) for useSyncExternalStore.
+export const tourConcluded = {
+  isConcluded: (): boolean => hasConcluded(readRecord()),
+  subscribe: subscribeRecord,
+};

--- a/src/components/tour/tour-host.test.tsx
+++ b/src/components/tour/tour-host.test.tsx
@@ -6,8 +6,8 @@ import { globeChartStore } from "@/lib/globe-chart-store";
 import { tourBridge } from "@/lib/tour-bridge";
 
 import { TourHost, type TourHostProps } from "./tour-host";
-
-const KEY = "sounds-abroad:tour-seen:v1";
+import type { TourRecord } from "./tour-record";
+import { readRecord, writeRecord } from "./tour-record-store";
 
 function stubMatchMedia(reduced: boolean) {
   vi.spyOn(window, "matchMedia").mockImplementation(
@@ -19,6 +19,10 @@ function stubMatchMedia(reduced: boolean) {
         removeEventListener: vi.fn(),
       }) as unknown as MediaQueryList,
   );
+}
+
+function seedRecord(record: TourRecord) {
+  writeRecord(record);
 }
 
 function renderHost(overrides: Partial<TourHostProps> = {}) {
@@ -46,13 +50,24 @@ afterEach(() => {
   globeChartStore.setState({ lastSettleViaTap: false });
   act(() => {
     tourBridge.getState().setGlobeReady(false);
+    tourBridge.getState().setTourActive(false);
   });
 });
 
 describe("TourHost", () => {
-  test("stays hidden for a returning user even once the globe is ready", () => {
+  test("stays hidden for a user who dismissed the tour, even once the globe is ready", () => {
     stubMatchMedia(false);
-    localStorage.setItem(KEY, "1");
+    seedRecord({ learned: [], shows: 1, dismissed: true });
+
+    const { queryByTestId } = renderHost();
+    makeGlobeReady();
+
+    expect(queryByTestId("tour-overlay")).toBeNull();
+  });
+
+  test("stays hidden once the appearance cap is reached", () => {
+    stubMatchMedia(false);
+    seedRecord({ learned: ["gesture"], shows: 2, dismissed: false });
 
     const { queryByTestId } = renderHost();
     makeGlobeReady();
@@ -83,6 +98,17 @@ describe("TourHost", () => {
     expect(badge.textContent).toMatch(/flick to spin/i);
   });
 
+  test("re-teaches only the un-learned beats, opening on the first of them", () => {
+    stubMatchMedia(false);
+    seedRecord({ learned: ["gesture"], shows: 1, dismissed: false });
+
+    const { getByTestId } = renderHost();
+    makeGlobeReady();
+
+    // The gesture is already learned, so the tour opens on the sheet beat.
+    expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe("sheet");
+  });
+
   test("the user's first selection advances to the sheet beat", () => {
     stubMatchMedia(false);
     const { getByTestId, rerenderWith } = renderHost();
@@ -111,7 +137,7 @@ describe("TourHost", () => {
     );
   });
 
-  test("the X control ends the tour and records it as seen", () => {
+  test("the X control ends the tour and latches dismissed permanently", () => {
     stubMatchMedia(false);
     const { getByRole, queryByTestId } = renderHost();
     makeGlobeReady();
@@ -119,10 +145,10 @@ describe("TourHost", () => {
     fireEvent.click(getByRole("button", { name: "Dismiss tour" }));
 
     expect(queryByTestId("tour-overlay")).toBeNull();
-    expect(localStorage.getItem(KEY)).toBe("1");
+    expect(readRecord().dismissed).toBe(true);
   });
 
-  test("Escape dismisses the tour and records it as seen", () => {
+  test("Escape dismisses the tour and latches dismissed permanently", () => {
     stubMatchMedia(false);
     const { queryByTestId } = renderHost();
     makeGlobeReady();
@@ -132,7 +158,7 @@ describe("TourHost", () => {
     });
 
     expect(queryByTestId("tour-overlay")).toBeNull();
-    expect(localStorage.getItem(KEY)).toBe("1");
+    expect(readRecord().dismissed).toBe(true);
   });
 
   test("advances to the audio beat when the sheet is pulled to full", () => {
@@ -150,7 +176,7 @@ describe("TourHost", () => {
     expect(getByTestId("tour-overlay").getAttribute("data-beat")).toBe("audio");
   });
 
-  test("completes and records as seen when a track previews on the audio beat", () => {
+  test("completes and records every beat as learned when a track previews", () => {
     stubMatchMedia(false);
     const { queryByTestId, rerenderWith } = renderHost();
     makeGlobeReady();
@@ -170,7 +196,7 @@ describe("TourHost", () => {
     });
 
     expect(queryByTestId("tour-overlay")).toBeNull();
-    expect(localStorage.getItem(KEY)).toBe("1");
+    expect(readRecord().learned).toEqual(["gesture", "sheet", "audio"]);
   });
 
   test("a track already previewing when the audio beat opens does not skip it", () => {

--- a/src/components/tour/tour-host.tsx
+++ b/src/components/tour/tour-host.tsx
@@ -6,11 +6,17 @@ import { useStore } from "zustand";
 import type { SnapState } from "@/components/chart-sheet/sheet";
 import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
 import { tourBridge } from "@/lib/tour-bridge";
-import { useSeenFlag } from "@/lib/use-seen-flag";
 
-import { tourSeen } from "./seen-tour";
 import { TourOverlay } from "./tour-overlay";
-import { initialTourState, tourReducer } from "./tour-step";
+import { decideShow, recordLearned, recordShown } from "./tour-record";
+import { readRecord, writeRecord } from "./tour-record-store";
+import {
+  currentBeat,
+  initialTourState,
+  learnedSoFar,
+  type TeachBeat,
+  tourReducer,
+} from "./tour-step";
 import { useTourAnchor } from "./use-tour-anchor";
 
 export interface TourHostProps {
@@ -27,29 +33,28 @@ export interface TourHostProps {
   selectedCode: string | null;
 }
 
-// Gate only. Runs once the user is known to be first-run and the globe is live,
-// then hands off to the runner, which owns the step machine.
+// Gate only. Runs once the globe is live and the record says there is still
+// something to teach, then hands off to the runner, which owns the step machine.
 export function TourHost({
   snap,
   currentTrackKey,
   selectedCode,
 }: TourHostProps) {
-  const { seen, markSeen } = useSeenFlag(tourSeen);
   const globeReady = useStore(tourBridge, (s) => s.globeReady);
-  const [dismissed, setDismissed] = useState(false);
+  // Decided once, from the record as it stood at mount (before this appearance is
+  // counted): which un-learned beats to run this launch, or nothing.
+  const [decision] = useState(() => decideShow(readRecord()));
+  const [done, setDone] = useState(false);
 
-  const handleDone = useCallback(() => {
-    markSeen();
-    setDismissed(true);
-  }, [markSeen]);
+  const handleDone = useCallback(() => setDone(true), []);
 
-  // Derived, not latched in an effect. seen === false is a definite first-run
-  // (null means the SSR/first-paint read hasn't resolved); once dismissed it
-  // stays gone. globeReady only ever turns true here, so this won't flicker.
-  const active = globeReady && seen === false && !dismissed;
+  // Derived, not latched in an effect. globeReady only ever turns true here, so
+  // this won't flicker; once done it stays gone.
+  const active = globeReady && decision.show && !done;
   if (!active) return null;
   return (
     <TourRunner
+      beats={decision.beats}
       snap={snap}
       currentTrackKey={currentTrackKey}
       selectedCode={selectedCode}
@@ -59,16 +64,45 @@ export function TourHost({
 }
 
 interface TourRunnerProps extends TourHostProps {
+  beats: TeachBeat[];
   onDone: () => void;
 }
 
 function TourRunner({
+  beats,
   snap,
   currentTrackKey,
   selectedCode,
   onDone,
 }: TourRunnerProps) {
-  const [state, dispatch] = useReducer(tourReducer, initialTourState());
+  const [state, dispatch] = useReducer(tourReducer, beats, initialTourState);
+  const beat = currentBeat(state);
+  const setTourActive = useStore(tourBridge, (s) => s.setTourActive);
+
+  // Count this appearance once, at show time, so the two-appearance cap holds
+  // even if the user leaves mid-tour. Captured before any learning is folded in.
+  const [baseRecord] = useState(() => recordShown(readRecord()));
+
+  // Flag the tour on screen so the commentary hint waits: a capped final
+  // appearance marks the record concluded while the tour is still up. Declared
+  // before the persistence write below so tourActive is true when the write
+  // notifies the hint.
+  useEffect(() => {
+    setTourActive(true);
+    return () => setTourActive(false);
+  }, [setTourActive]);
+
+  // Persist the run's progress on every transition: the beats performed become
+  // learned, and an X latches dismissed. Folding into baseRecord (which already
+  // counted this show) means a mid-tour close keeps what was learned.
+  useEffect(() => {
+    writeRecord(
+      recordLearned(baseRecord, {
+        learned: learnedSoFar(state),
+        dismissedByX: state.dismissed,
+      }),
+    );
+  }, [state, baseRecord]);
 
   // Beat 1: hide the demo hand the instant the user grabs the globe (a flick is
   // starting), not when it settles seconds later. The hand is a "do this" cue;
@@ -77,7 +111,7 @@ function TourRunner({
   // doesn't strand them with no hint and no Next.
   const [engaged, setEngaged] = useState(false);
   useEffect(() => {
-    if (state.beat !== "gesture") return;
+    if (beat !== "gesture") return;
     const onDown = (e: PointerEvent) => {
       const target = e.target as HTMLElement | null;
       // Engage on a globe grab, not on the other interactive surfaces in view:
@@ -96,7 +130,7 @@ function TourRunner({
     });
     return () =>
       window.removeEventListener("pointerdown", onDown, { capture: true });
-  }, [state.beat]);
+  }, [beat]);
 
   // A settle ends the spin: if it changed the country the gesture beat advances
   // (the hand is already gone); if not, re-arm the hand. Ref-gated so the mount
@@ -114,11 +148,11 @@ function TourRunner({
   // mid-slide drags the glow up with it. Gate on the sheet's transform
   // transitionend (with a timeout fallback if it never fires) so the glow only
   // appears once the row is at rest.
-  // Starts false and only ever flips true (below); the tour is linear, so audio
-  // is entered exactly once and never needs resetting back to false.
+  // Starts false and only ever flips true (below); audio is entered at most once
+  // per run and never needs resetting back to false.
   const [sheetSettled, setSheetSettled] = useState(false);
   useEffect(() => {
-    if (state.beat !== "audio") return;
+    if (beat !== "audio") return;
     let done = false;
     const finish = () => {
       if (done) return;
@@ -140,7 +174,7 @@ function TourRunner({
       window.removeEventListener("transitionend", onEnd, true);
       window.clearTimeout(fallback);
     };
-  }, [state.beat]);
+  }, [beat]);
 
   // The user's first selection (a flick, or a pick from the a11y list) advances
   // the gesture beat: doing the gesture is the advance. On the first render we
@@ -149,7 +183,7 @@ function TourRunner({
   const prevCodeRef = useRef(selectedCode);
   const tryArmedRef = useRef(false);
   useEffect(() => {
-    if (state.beat !== "gesture") return;
+    if (beat !== "gesture") return;
     if (!tryArmedRef.current) {
       tryArmedRef.current = true;
       prevCodeRef.current = selectedCode;
@@ -163,15 +197,15 @@ function TourRunner({
       if (globeChartStore.getState().lastSettleViaTap) return;
       dispatch({ type: "USER_SELECTED" });
     }
-  }, [selectedCode, state.beat]);
+  }, [selectedCode, beat]);
 
   // Beat 2 advances when the user pulls the sheet to full; beat 3 when a track
   // starts. Both observe, never drive. Show, don't tell.
   useEffect(() => {
-    if (state.beat === "sheet" && snap === "full") {
+    if (beat === "sheet" && snap === "full") {
       dispatch({ type: "SHEET_OPENED" });
     }
-  }, [snap, state.beat]);
+  }, [snap, beat]);
 
   // Beat 3 baselines whatever is already previewing when it opens, so a track
   // played earlier (even an accidental tap during beats 1-2) never auto-skips
@@ -180,7 +214,7 @@ function TourRunner({
   const audioBaselineRef = useRef<string | null>(null);
   const audioArmedRef = useRef(false);
   useEffect(() => {
-    if (state.beat !== "audio") return;
+    if (beat !== "audio") return;
     if (!audioArmedRef.current) {
       audioArmedRef.current = true;
       audioBaselineRef.current = currentTrackKey;
@@ -192,9 +226,9 @@ function TourRunner({
     ) {
       dispatch({ type: "TRACK_PREVIEWED" });
     }
-  }, [currentTrackKey, state.beat]);
+  }, [currentTrackKey, beat]);
 
-  // ESC dismisses from any beat (counts as seen). Window-level, like the Space
+  // ESC dismisses from any beat (latches dismissed). Window-level, like the Space
   // play/pause handler in chart-screen.tsx.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -205,10 +239,9 @@ function TourRunner({
   }, []);
 
   useEffect(() => {
-    if (state.beat === "done") onDone();
-  }, [state.beat, onDone]);
+    if (beat === "done") onDone();
+  }, [beat, onDone]);
 
-  const beat = state.beat;
   // Beat 2 frames the whole sheet; beat 3 frames the first track row (the thing
   // to tap), selected by its rank attribute so it needs no id of its own.
   const targetSelector =

--- a/src/components/tour/tour-record-store.test.ts
+++ b/src/components/tour/tour-record-store.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { emptyRecord, type TourRecord } from "./tour-record";
+import { readRecord, subscribeRecord, writeRecord } from "./tour-record-store";
+
+const KEY = "sounds-abroad:tour:v2";
+
+function fakeStorage(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+  };
+}
+
+describe("readRecord", () => {
+  test("is the empty record when nothing is stored (a fresh v2 key)", () => {
+    expect(readRecord(fakeStorage())).toEqual(emptyRecord);
+  });
+
+  test("round-trips a written record", () => {
+    const record: TourRecord = {
+      learned: ["gesture", "sheet"],
+      shows: 1,
+      dismissed: false,
+    };
+    const storage = fakeStorage();
+
+    writeRecord(record, storage);
+
+    expect(readRecord(storage)).toEqual(record);
+  });
+
+  test("falls back to the empty record on corrupt JSON rather than throwing", () => {
+    expect(readRecord(fakeStorage({ [KEY]: "{not json" }))).toEqual(
+      emptyRecord,
+    );
+  });
+
+  test("drops unknown values from learned so a stale key can't inject junk beats", () => {
+    const stored = JSON.stringify({
+      learned: ["gesture", "skip", "bogus"],
+      shows: 1,
+      dismissed: false,
+    });
+
+    expect(readRecord(fakeStorage({ [KEY]: stored })).learned).toEqual([
+      "gesture",
+    ]);
+  });
+
+  test("returns the empty record instead of throwing when reading throws", () => {
+    const hostile = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: vi.fn(),
+    };
+
+    expect(readRecord(hostile)).toEqual(emptyRecord);
+  });
+});
+
+describe("writeRecord", () => {
+  test("swallows a failing write rather than throwing", () => {
+    const hostile = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+
+    expect(() => writeRecord(emptyRecord, hostile)).not.toThrow();
+  });
+});
+
+describe("subscribeRecord", () => {
+  test("notifies a subscriber when the record is written", () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeRecord(onChange);
+
+    writeRecord(emptyRecord, fakeStorage());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("stops notifying after unsubscribe", () => {
+    const onChange = vi.fn();
+
+    subscribeRecord(onChange)();
+    writeRecord(emptyRecord, fakeStorage());
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("falls back to the in-memory mirror when localStorage throws", () => {
+  test("round-trips through the mirror when access throws (private mode)", () => {
+    const getSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const setSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    try {
+      const record: TourRecord = {
+        learned: ["audio"],
+        shows: 2,
+        dismissed: true,
+      };
+      expect(readRecord()).toEqual(emptyRecord);
+
+      writeRecord(record);
+
+      expect(readRecord()).toEqual(record);
+    } finally {
+      getSpy.mockRestore();
+      setSpy.mockRestore();
+    }
+  });
+});
+
+describe("through the real localStorage", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test("persists under the v2 key", () => {
+    const record: TourRecord = {
+      learned: ["gesture"],
+      shows: 1,
+      dismissed: false,
+    };
+
+    writeRecord(record);
+
+    expect(localStorage.getItem(KEY)).toBe(JSON.stringify(record));
+  });
+});

--- a/src/components/tour/tour-record-store.ts
+++ b/src/components/tour/tour-record-store.ts
@@ -1,0 +1,66 @@
+import {
+  createMirroredStorage,
+  type MirroredStorage,
+} from "@/lib/mirrored-storage";
+
+import { emptyRecord, type TourRecord } from "./tour-record";
+import { TEACH_ORDER, type TeachBeat } from "./tour-step";
+
+// Persists the tour record across sessions. A fresh key from the boolean flag's
+// `:v1`, so every existing user starts on the empty record and re-sees the
+// finished tour once. Private-mode resilience (the in-memory mirror) comes from
+// the shared createMirroredStorage, the same one the seen-flags use.
+const KEY = "sounds-abroad:tour:v2";
+
+const store = createMirroredStorage();
+const listeners = new Set<() => void>();
+
+const TEACHABLE = new Set<string>(TEACH_ORDER);
+
+// Reads tolerantly: any malformed or partial value degrades to the empty record
+// (the tour re-teaches) rather than throwing. Unknown `learned` entries are
+// dropped so a stale or hand-edited key can't inject beats the machine can't run.
+function parseRecord(raw: string): TourRecord {
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null) return emptyRecord;
+  const value = parsed as Record<string, unknown>;
+  const learned = Array.isArray(value.learned)
+    ? (value.learned.filter(
+        (beat): beat is TeachBeat =>
+          typeof beat === "string" && TEACHABLE.has(beat),
+      ) as TeachBeat[])
+    : [];
+  return {
+    learned,
+    shows: typeof value.shows === "number" ? value.shows : 0,
+    dismissed: value.dismissed === true,
+  };
+}
+
+export function readRecord(storage: MirroredStorage = store): TourRecord {
+  try {
+    const raw = storage.getItem(KEY);
+    return raw ? parseRecord(raw) : emptyRecord;
+  } catch {
+    return emptyRecord;
+  }
+}
+
+export function writeRecord(
+  record: TourRecord,
+  storage: MirroredStorage = store,
+): void {
+  try {
+    storage.setItem(KEY, JSON.stringify(record));
+  } catch {
+    // An injected storage may throw; the default's mirror already recorded it.
+  }
+  for (const listener of listeners) listener();
+}
+
+// Same-session subscription, so the commentary hint notices the tour concluding
+// mid-session (a localStorage write fires no storage event in the writing tab).
+export function subscribeRecord(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => listeners.delete(onChange);
+}

--- a/src/components/tour/tour-record.test.ts
+++ b/src/components/tour/tour-record.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  decideShow,
+  emptyRecord,
+  hasConcluded,
+  recordLearned,
+  recordShown,
+  type TourRecord,
+} from "./tour-record";
+
+describe("decideShow", () => {
+  test("a first-run (empty) record shows all three teachable beats in order", () => {
+    expect(decideShow(emptyRecord)).toEqual({
+      show: true,
+      beats: ["gesture", "sheet", "audio"],
+    });
+  });
+
+  test("shows only the beats the user has not yet learned", () => {
+    const record: TourRecord = {
+      learned: ["gesture", "audio"],
+      shows: 1,
+      dismissed: false,
+    };
+
+    expect(decideShow(record)).toEqual({ show: true, beats: ["sheet"] });
+  });
+
+  test("a fully-learned user is shown nothing", () => {
+    const record: TourRecord = {
+      learned: ["gesture", "sheet", "audio"],
+      shows: 1,
+      dismissed: false,
+    };
+
+    expect(decideShow(record)).toEqual({ show: false, beats: [] });
+  });
+
+  test("a dismissed record never shows again, even with un-learned beats", () => {
+    const record: TourRecord = {
+      learned: ["gesture"],
+      shows: 1,
+      dismissed: true,
+    };
+
+    expect(decideShow(record)).toEqual({ show: false, beats: [] });
+  });
+
+  test("the tour is capped at two appearances", () => {
+    const record: TourRecord = {
+      learned: ["gesture"],
+      shows: 2,
+      dismissed: false,
+    };
+
+    expect(decideShow(record)).toEqual({ show: false, beats: [] });
+  });
+});
+
+describe("recordShown", () => {
+  test("counts an appearance so the cap can be reached, without touching learned or dismissed", () => {
+    expect(recordShown(emptyRecord)).toEqual({
+      learned: [],
+      shows: 1,
+      dismissed: false,
+    });
+  });
+
+  test("increments from a prior count", () => {
+    const record: TourRecord = {
+      learned: ["gesture"],
+      shows: 1,
+      dismissed: false,
+    };
+
+    expect(recordShown(record).shows).toBe(2);
+  });
+});
+
+describe("recordLearned", () => {
+  test("unions the run's performed gestures into learned without duplicating", () => {
+    const record: TourRecord = {
+      learned: ["gesture"],
+      shows: 1,
+      dismissed: false,
+    };
+
+    const next = recordLearned(record, {
+      learned: ["gesture", "sheet"],
+      dismissedByX: false,
+    });
+
+    expect(next.learned).toEqual(["gesture", "sheet"]);
+  });
+
+  test("latches dismissed on an X dismissal", () => {
+    const next = recordLearned(emptyRecord, {
+      learned: [],
+      dismissedByX: true,
+    });
+
+    expect(next.dismissed).toBe(true);
+  });
+
+  test("keeps dismissed once latched, even on a later non-X outcome", () => {
+    const record: TourRecord = {
+      learned: [],
+      shows: 1,
+      dismissed: true,
+    };
+
+    const next = recordLearned(record, {
+      learned: ["gesture"],
+      dismissedByX: false,
+    });
+
+    expect(next.dismissed).toBe(true);
+  });
+
+  test("does not change the shows count (that is recordShown's job)", () => {
+    const next = recordLearned(emptyRecord, {
+      learned: ["gesture"],
+      dismissedByX: false,
+    });
+
+    expect(next.shows).toBe(0);
+  });
+});
+
+describe("hasConcluded", () => {
+  test("a first-run record has not concluded (the tour will still show)", () => {
+    expect(hasConcluded(emptyRecord)).toBe(false);
+  });
+
+  test("concludes once dismissed", () => {
+    expect(hasConcluded({ learned: [], shows: 1, dismissed: true })).toBe(true);
+  });
+
+  test("concludes once every gesture is learned", () => {
+    expect(
+      hasConcluded({
+        learned: ["gesture", "sheet", "audio"],
+        shows: 1,
+        dismissed: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("concludes once the appearance cap is reached", () => {
+    expect(
+      hasConcluded({ learned: ["gesture"], shows: 2, dismissed: false }),
+    ).toBe(true);
+  });
+});

--- a/src/components/tour/tour-record.ts
+++ b/src/components/tour/tour-record.ts
@@ -1,0 +1,63 @@
+// The tour's memory of what a user has actually learned, so a later launch
+// re-teaches only the gestures they haven't performed and never nags. Pure: the
+// host reads the persisted record, asks decideShow what to run, and folds the
+// run's outcome back in. Only the three linear beats are teachable here; the
+// double-tap skip lives in its own contextual hint with its own flag.
+
+import type { TeachBeat } from "./tour-step";
+import { TEACH_ORDER } from "./tour-step";
+
+export interface TourRecord {
+  learned: TeachBeat[];
+  shows: number;
+  dismissed: boolean;
+}
+
+export const emptyRecord: TourRecord = {
+  learned: [],
+  shows: 0,
+  dismissed: false,
+};
+
+// A dismissal is permanent and the tour appears at most twice, so a user who
+// keeps ignoring gestures still isn't nagged past the cap.
+const MAX_SHOWS = 2;
+
+// Whether to run the tour this launch, and which beats: the teachable order
+// minus what's already learned. An empty beat list means nothing left to teach.
+export function decideShow(record: TourRecord): {
+  show: boolean;
+  beats: TeachBeat[];
+} {
+  if (record.dismissed || record.shows >= MAX_SHOWS) {
+    return { show: false, beats: [] };
+  }
+  const beats = TEACH_ORDER.filter((beat) => !record.learned.includes(beat));
+  return { show: beats.length > 0, beats };
+}
+
+// Count this appearance. Persisted at show time, not at the end, so the cap
+// holds even if the user closes the app mid-tour.
+export function recordShown(record: TourRecord): TourRecord {
+  return { ...record, shows: record.shows + 1 };
+}
+
+// Fold a finished run back in: union the gestures the user actually performed
+// into learned, and latch dismissed if they closed the tour with the X. Leaves
+// shows untouched (recordShown owns that).
+export function recordLearned(
+  record: TourRecord,
+  outcome: { learned: TeachBeat[]; dismissedByX: boolean },
+): TourRecord {
+  return {
+    ...record,
+    learned: [...new Set([...record.learned, ...outcome.learned])],
+    dismissed: record.dismissed || outcome.dismissedByX,
+  };
+}
+
+// The tour will never show again: dismissed, capped, or everything learned. The
+// commentary hint arms off this, so it waits only while the tour still might run.
+export function hasConcluded(record: TourRecord): boolean {
+  return !decideShow(record).show;
+}

--- a/src/components/tour/tour-step.test.ts
+++ b/src/components/tour/tour-step.test.ts
@@ -1,63 +1,81 @@
 import { describe, expect, test } from "vitest";
 
-import { initialTourState, tourReducer, type TourState } from "./tour-step";
-
-const onGesture: TourState = { beat: "gesture" };
-const onSheet: TourState = { beat: "sheet" };
-const onAudio: TourState = { beat: "audio" };
+import {
+  currentBeat,
+  initialTourState,
+  learnedSoFar,
+  tourReducer,
+} from "./tour-step";
 
 describe("initialTourState", () => {
-  test("opens on the gesture beat", () => {
-    expect(initialTourState()).toEqual({ beat: "gesture" });
+  test("runs all three teachable beats by default, opening on the gesture beat", () => {
+    const state = initialTourState();
+
+    expect(currentBeat(state)).toBe("gesture");
+    expect(learnedSoFar(state)).toEqual([]);
+  });
+
+  test("runs only the given subset, opening on its first beat", () => {
+    const state = initialTourState(["sheet", "audio"]);
+
+    expect(currentBeat(state)).toBe("sheet");
+  });
+
+  test("an empty subset is already done", () => {
+    expect(currentBeat(initialTourState([]))).toBe("done");
   });
 });
 
-describe("tourReducer gesture beat", () => {
-  test("performing the gesture advances to the sheet beat", () => {
-    const next = tourReducer(onGesture, { type: "USER_SELECTED" });
+describe("tourReducer beat progression", () => {
+  test("performing a beat's gesture advances to the next beat and records it learned", () => {
+    const next = tourReducer(initialTourState(), { type: "USER_SELECTED" });
 
-    expect(next.beat).toBe("sheet");
+    expect(currentBeat(next)).toBe("sheet");
+    expect(learnedSoFar(next)).toEqual(["gesture"]);
   });
 
-  test("an unrelated event leaves the gesture beat unchanged", () => {
-    const next = tourReducer(onGesture, { type: "SHEET_OPENED" });
+  test("a beat completes only on its own event; a stray event is ignored", () => {
+    const state = initialTourState();
 
-    expect(next).toEqual(onGesture);
-  });
-});
-
-describe("tourReducer later beats", () => {
-  test("opening the sheet advances to the audio beat", () => {
-    const next = tourReducer(onSheet, { type: "SHEET_OPENED" });
-
-    expect(next.beat).toBe("audio");
+    expect(tourReducer(state, { type: "SHEET_OPENED" })).toEqual(state);
   });
 
-  test("a stray selection during the sheet beat does not skip it", () => {
-    const next = tourReducer(onSheet, { type: "USER_SELECTED" });
+  test("walks the full sequence to done, learning each beat performed", () => {
+    let state = initialTourState();
+    state = tourReducer(state, { type: "USER_SELECTED" });
+    state = tourReducer(state, { type: "SHEET_OPENED" });
+    state = tourReducer(state, { type: "TRACK_PREVIEWED" });
 
-    expect(next.beat).toBe("sheet");
+    expect(currentBeat(state)).toBe("done");
+    expect(learnedSoFar(state)).toEqual(["gesture", "sheet", "audio"]);
   });
 
-  test("previewing a track finishes the tour", () => {
-    const next = tourReducer(onAudio, { type: "TRACK_PREVIEWED" });
+  test("a subset advances through only its beats", () => {
+    const next = tourReducer(initialTourState(["sheet"]), {
+      type: "SHEET_OPENED",
+    });
 
-    expect(next.beat).toBe("done");
+    expect(currentBeat(next)).toBe("done");
+    expect(learnedSoFar(next)).toEqual(["sheet"]);
   });
 });
 
 describe("tourReducer exit", () => {
-  test("Skip ends the tour from any beat", () => {
-    expect(tourReducer(onGesture, { type: "SKIP" }).beat).toBe("done");
-    expect(tourReducer(onSheet, { type: "SKIP" }).beat).toBe("done");
-    expect(tourReducer(onAudio, { type: "SKIP" }).beat).toBe("done");
+  test("Skip dismisses from any beat and learns only what was performed first", () => {
+    const performed = tourReducer(initialTourState(), {
+      type: "USER_SELECTED",
+    });
+    const dismissed = tourReducer(performed, { type: "SKIP" });
+
+    expect(currentBeat(dismissed)).toBe("done");
+    expect(dismissed.dismissed).toBe(true);
+    // Only the gesture was performed before the X; the rest stay un-learned.
+    expect(learnedSoFar(dismissed)).toEqual(["gesture"]);
   });
 
   test("done is terminal", () => {
-    const done: TourState = { beat: "done" };
+    const done = initialTourState([]);
 
-    const next = tourReducer(done, { type: "USER_SELECTED" });
-
-    expect(next).toEqual(done);
+    expect(tourReducer(done, { type: "USER_SELECTED" })).toEqual(done);
   });
 });

--- a/src/components/tour/tour-step.ts
+++ b/src/components/tour/tour-step.ts
@@ -5,8 +5,19 @@
 
 export type Beat = "gesture" | "sheet" | "audio" | "done";
 
+// The teachable beats, in the order the tour runs them. "done" is the terminal
+// state, not a beat to teach.
+export type TeachBeat = Exclude<Beat, "done">;
+export const TEACH_ORDER: TeachBeat[] = ["gesture", "sheet", "audio"];
+
+// The tour runs an ordered subset of the teachable beats (only the un-learned
+// ones, decided by the record). `index` is how many of `beats` are complete, so
+// `beats[index]` is the current one and `beats.slice(0, index)` is what the user
+// performed this run. `dismissed` (the X) ends the run without learning the rest.
 export interface TourState {
-  beat: Beat;
+  beats: TeachBeat[];
+  index: number;
+  dismissed: boolean;
 }
 
 export type TourEvent =
@@ -15,30 +26,40 @@ export type TourEvent =
   | { type: "TRACK_PREVIEWED" } // the user tapped a track to preview it
   | { type: "SKIP" }; // dismiss (the X) or Escape
 
-// No auto-demo: the gesture beat opens inviting the user to flick the globe
-// themselves, so the tour never moves the globe or changes the selection on the
-// user's behalf. A hint, not a scripted motion, teaches the gesture.
-export function initialTourState(): TourState {
-  return { beat: "gesture" };
+// The event that completes each beat. A beat advances only when the user
+// performs its real gesture on the live target; there is no tap-to-skip a step.
+const EVENT_FOR: Record<TeachBeat, TourEvent["type"]> = {
+  gesture: "USER_SELECTED",
+  sheet: "SHEET_OPENED",
+  audio: "TRACK_PREVIEWED",
+};
+
+// No auto-demo: each beat opens inviting the user to perform the gesture
+// themselves, so the tour never drives the globe, sheet, or selection. A hint,
+// not a scripted motion, teaches it. Defaults to the full sequence.
+export function initialTourState(beats: TeachBeat[] = TEACH_ORDER): TourState {
+  return { beats, index: 0, dismissed: false };
+}
+
+// The beat to render, or "done" once dismissed or past the last beat.
+export function currentBeat(state: TourState): Beat {
+  if (state.dismissed || state.index >= state.beats.length) return "done";
+  return state.beats[state.index];
+}
+
+// The beats the user actually performed this run, to fold into the record as
+// learned. A dismissal doesn't retroactively learn the beats it skipped.
+export function learnedSoFar(state: TourState): TeachBeat[] {
+  return state.beats.slice(0, state.index);
 }
 
 export function tourReducer(state: TourState, event: TourEvent): TourState {
-  // Skip ends the tour from any beat; dismissing counts as seen.
-  if (event.type === "SKIP") return { beat: "done" };
-  if (state.beat === "done") return state;
-
-  switch (state.beat) {
-    case "gesture":
-      // Each beat advances only when the user performs its real gesture on the
-      // live target under the pass-through dim; there is no tap-to-skip a step.
-      // The single exit is the X (SKIP), so the dim never competes with the
-      // gesture for the same tap.
-      return event.type === "USER_SELECTED" ? { beat: "sheet" } : state;
-    case "sheet":
-      return event.type === "SHEET_OPENED" ? { beat: "audio" } : state;
-    case "audio":
-      return event.type === "TRACK_PREVIEWED" ? { beat: "done" } : state;
-    default:
-      return state;
-  }
+  if (currentBeat(state) === "done") return state;
+  // The single exit is the X (SKIP), so the dim never competes with the gesture
+  // for the same tap.
+  if (event.type === "SKIP") return { ...state, dismissed: true };
+  const beat = state.beats[state.index];
+  return event.type === EVENT_FOR[beat]
+    ? { ...state, index: state.index + 1 }
+    : state;
 }

--- a/src/lib/create-seen-flag.ts
+++ b/src/lib/create-seen-flag.ts
@@ -1,15 +1,11 @@
 // A one-time "seen" flag persisted in localStorage: the shared machinery behind
-// the tour, commentary-hint, and edge-tap cues, each of which gates a cue that
-// should fire once and stay dismissed across sessions. One call per flag, keyed
-// by its storage key; bump the key's :v1 suffix to re-trigger everyone with no
-// migration code.
-//
-// Each flag closes over an in-memory mirror so a same-tab handoff survives a
-// localStorage that's unavailable or throwing (private mode, blocked cookies,
-// quota): the write records to the mirror even when it can't persist, and reads
-// fall back to it. Injected storages (tests) never touch the mirror, staying
-// isolated. This mirror lived only in the tour flag before; folding it into the
-// factory gives all three flags the same private-mode resilience.
+// the commentary-hint and edge-tap cues, each of which gates a cue that should
+// fire once and stay dismissed across sessions. One call per flag, keyed by its
+// storage key; bump the key's :v1 suffix to re-trigger everyone with no migration
+// code. Private-mode resilience (the in-memory mirror) comes from the shared
+// createMirroredStorage; injected storages (tests) bypass it, staying isolated.
+
+import { createMirroredStorage } from "./mirrored-storage";
 
 // The slice of Storage a flag touches; lets tests inject a fake.
 type FlagStorage = Pick<Storage, "getItem" | "setItem">;
@@ -28,36 +24,10 @@ export interface SeenFlag {
 }
 
 export function createSeenFlag(key: string): SeenFlag {
-  const memory = new Map<string, string>();
+  const store = createMirroredStorage();
   const listeners = new Set<() => void>();
 
-  function defaultStorage(): FlagStorage {
-    return {
-      getItem(k) {
-        try {
-          // Accessible localStorage is authoritative, even when it returns null
-          // (a real "not set"), so clearing it isn't shadowed by the mirror.
-          if (typeof localStorage !== "undefined")
-            return localStorage.getItem(k);
-        } catch {
-          // Touching localStorage can throw outright (sandboxed iframe,
-          // hard-blocked cookies); only then fall back to the in-memory mirror.
-        }
-        return memory.get(k) ?? null;
-      },
-      setItem(k, value) {
-        memory.set(k, value);
-        try {
-          if (typeof localStorage !== "undefined")
-            localStorage.setItem(k, value);
-        } catch {
-          // Best-effort persistence; the in-memory mirror already holds it.
-        }
-      },
-    };
-  }
-
-  function hasSeen(storage: FlagStorage = defaultStorage()): boolean {
+  function hasSeen(storage: FlagStorage = store): boolean {
     try {
       return storage.getItem(key) === "1";
     } catch {
@@ -65,7 +35,7 @@ export function createSeenFlag(key: string): SeenFlag {
     }
   }
 
-  function markSeen(storage: FlagStorage = defaultStorage()): void {
+  function markSeen(storage: FlagStorage = store): void {
     try {
       storage.setItem(key, "1");
     } catch {

--- a/src/lib/mirrored-storage.test.ts
+++ b/src/lib/mirrored-storage.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createMirroredStorage } from "./mirrored-storage";
+
+const KEY = "sounds-abroad:mirror-test";
+
+describe("createMirroredStorage", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test("round-trips through the real localStorage when available", () => {
+    const storage = createMirroredStorage();
+
+    storage.setItem(KEY, "value");
+
+    expect(storage.getItem(KEY)).toBe("value");
+    expect(localStorage.getItem(KEY)).toBe("value");
+  });
+
+  test("is null for an unset key", () => {
+    expect(createMirroredStorage().getItem(KEY)).toBeNull();
+  });
+
+  test("falls back to the in-memory mirror when access throws (private mode)", () => {
+    const getSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const setSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    try {
+      const storage = createMirroredStorage();
+      expect(storage.getItem(KEY)).toBeNull();
+
+      storage.setItem(KEY, "value");
+
+      expect(storage.getItem(KEY)).toBe("value");
+    } finally {
+      getSpy.mockRestore();
+      setSpy.mockRestore();
+    }
+  });
+});

--- a/src/lib/mirrored-storage.ts
+++ b/src/lib/mirrored-storage.ts
@@ -1,0 +1,35 @@
+// localStorage that degrades to an in-memory mirror when access throws (private
+// mode, blocked cookies, quota): every write also records to the mirror, and
+// reads fall back to it only when localStorage itself throws, so a same-session
+// handoff survives even where persistence can't. Each call gets its own mirror,
+// so a per-instance flag and a module-singleton store stay isolated. The one
+// place this resilience lives, shared by the persisted flags and the tour record.
+
+export type MirroredStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function createMirroredStorage(): MirroredStorage {
+  const memory = new Map<string, string>();
+  return {
+    getItem(key) {
+      try {
+        // Accessible localStorage is authoritative, even when it returns null (a
+        // real "not set"), so clearing it isn't shadowed by the mirror.
+        if (typeof localStorage !== "undefined")
+          return localStorage.getItem(key);
+      } catch {
+        // Touching localStorage can throw outright (sandboxed iframe,
+        // hard-blocked cookies); only then fall back to the in-memory mirror.
+      }
+      return memory.get(key) ?? null;
+    },
+    setItem(key, value) {
+      memory.set(key, value);
+      try {
+        if (typeof localStorage !== "undefined")
+          localStorage.setItem(key, value);
+      } catch {
+        // Best-effort persistence; the in-memory mirror already holds it.
+      }
+    },
+  };
+}

--- a/src/lib/tour-bridge.ts
+++ b/src/lib/tour-bridge.ts
@@ -5,12 +5,19 @@ export interface TourBridgeState {
   // the globe is on screen.
   globeReady: boolean;
   setGlobeReady: (ready: boolean) => void;
+  // The tour is on screen right now. The commentary hint waits on this as well as
+  // the record: a capped final appearance marks the record concluded while the
+  // tour is still up, and the hint must not arm under it.
+  tourActive: boolean;
+  setTourActive: (active: boolean) => void;
 }
 
 export function createTourBridge() {
   return createStore<TourBridgeState>()((set) => ({
     globeReady: false,
     setGlobeReady: (ready) => set({ globeReady: ready }),
+    tourActive: false,
+    setTourActive: (active) => set({ tourActive: active }),
   }));
 }
 


### PR DESCRIPTION
## What & why

The last v2.3.0 tour slice. The onboarding tour gains a memory of what the user actually learned, so a later launch re-teaches only the un-learned gestures, never the ones they've performed. It appears at most twice, and an X or Escape dismissal is permanent. The storage key is bumped `tour-seen:v1` → `tour:v2`, so every existing user re-sees the finished tour once.

## Changes

- Pure policy module `tour-record.ts` (`decideShow` / `recordShown` / `recordLearned` / `hasConcluded`) over a persisted `TourRecord { learned, shows, dismissed }`.
- `tour-record-store.ts` persists it as JSON under the v2 key.
- The step machine (`tour-step.ts`) now walks an ordered un-learned subset (`{ beats, index, dismissed }`) instead of a fixed sequence.
- The commentary hint keeps its "tour done" gate, now derived from the record (`tour-concluded.ts`) and held off by a `tourActive` flag while a capped final appearance is still on screen, so its pulse isn't spent under the tour dim.
- The localStorage memory-mirror is extracted to `mirrored-storage.ts` and shared by the seen-flags and the record, so the private-mode resilience lives in one place.

## Deliberate reads of the spec (agreed in issue comments, not the stale sketch)

- No dim-tap exit: the tour is X-only + gesture-advances (settled in #211), so AC1's dim-tap clause is moot.
- The learnable set is the three linear beats only; the double-tap skip is a contextual hint (#212) with its own flag, out of `TourRecord`.
- `shows` is counted at show time (not at outcome), so the two-appearance cap holds even if the app is closed mid-tour; `recordOutcome` is split into `recordShown` + `recordLearned`.

## Test plan

- Local CI green: typecheck, lint, build, **639 tests** (policy module 15, store 10, reducer 9, host 16, mirror 3, plus the existing suite).
- Two-axis `/code-review`: Spec 6/6 ACs met, no defects; Standards surfaced 3 judgement calls, 2 applied (extract the shared mirror; rename `tourSeen` → `tourConcluded` for honesty), 1 deferred with reason (a one-caller param shape).

Closes #213
