### PR TITLE
chore: release v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounds-abroad",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## v2.3.0 — Wordless onboarding + learned-aware re-show

### Onboarding tour, rebuilt wordless
- Text callout cards give way to a dim-to-settle spotlight and a breathing nudge badge; the three gestures (flick, pull, tap) are shown, not told (#221).
- The double-tap-edge skip cue is reskinned to the same wordless language: aurora edge rails, a double-tap hand, and a synced left-edge ripple echo (#223).
- The tour now remembers what you learned. On a later launch it re-teaches only the un-done gestures, appears at most twice, and an X or Escape dismissal is permanent (#224).

### Pipeline reliability (crawl + commentary)
- Stop publishing iTunes lookup outages and carried-forward staleness as a healthy chart (#215).
- Give every retry its own throttle slot so a burst stays within the rate budget (#214).
- Salvage the valid commentary entries when one entry fails the schema, instead of dropping the batch (#217).
- Write the previous-chart snapshot the movement triggers diff against (#216).
- The gem card surfaces preview-failure feedback instead of silently reverting (#218).
- ADR: record the draft-time guard that replaced ADR-0009's clause-splitting (#219).

### Accessibility
- Free keyboard focus from the chart sheet on every load, dropping the Radix Dialog focus trap (#220).

### Under the hood
- Route end-of-track auto-advance through `step()`, make the globe→chart skip seam data-only, and extract `createSeenFlag(key)` for the one-time hint flags (#197, #198, #199).
- Migrate the vendored Pocock skills to v1.1 (#222).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 2.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->