### PR TITLE
chore(player): drop unused MediaMetadata artwork hints

### DIFF
--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -38,7 +38,7 @@ export function setNowPlaying(
   mediaSession.metadata = new metadataCtor({
     title: track.name,
     artist: track.artist,
-    artwork: [{ src: track.artworkUrl, sizes: "600x600", type: "image/jpeg" }],
+    artwork: [{ src: track.artworkUrl }],
   });
 }
 


### PR DESCRIPTION
Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for now-playing artwork metadata by simplifying the artwork information provided to supported media controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->