### PR TITLE
perf(chart): defer off-screen track rows with content-visibility

### DIFF
--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -61,7 +61,11 @@ export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
       data-disabled={!hasPreview || undefined}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex flex-col rounded-[14px] px-3 py-2.5 transition-colors duration-200 data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
+      // content-visibility:auto skips layout/paint for rows scrolled out of view
+      // (most of the list). contain-intrinsic-size seeds an off-screen row at a
+      // collapsed single-line height (~68px) and, via `auto`, reuses its real
+      // height once rendered, reducing data-rank scroll drift for taller rows.
+      className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex flex-col rounded-[14px] px-3 py-2.5 transition-colors duration-200 [contain-intrinsic-size:auto_68px] [content-visibility:auto] data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
     >
       <div className="flex items-center gap-[14px]">
         <button


### PR DESCRIPTION
Closes #83

Uses `contain-intrinsic-size: auto 68px` (the `auto` keyword) rather than the issue's literal `0 68px`. The `auto` keyword reuses each row's real rendered height once painted, so it softens the scroll-drift caveat the issue flags for `data-rank` targeting. The `68px` seed is a collapsed single-line row estimate used only before first paint.

On-device verification still recommended per the issue's caveats: scroll-into-view by `data-rank`, and `useOverflowMarquee` measuring off-screen rows.
