### PR TITLE
feat(commentary): open a track's "why it's here" into a focused reader card

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -257,6 +257,42 @@
   }
 }
 
+/* Commentary focus card open/close: the detail + sources grow and shrink on a
+   grid-rows track (height on ease-out so it never jiggles) while the content
+   rises in with a slight spring; the sources trail by a beat. Both directions
+   animate off the single data-open toggle. */
+.commentary-reveal {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 300ms var(--ease-out);
+}
+.commentary-reveal[data-open] {
+  grid-template-rows: 1fr;
+}
+.commentary-reveal-inner {
+  overflow: hidden;
+}
+.commentary-rise {
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    opacity 300ms var(--ease-out),
+    transform 300ms var(--ease-spring);
+}
+.commentary-reveal[data-open] .commentary-rise {
+  opacity: 1;
+  transform: translateY(0);
+}
+.commentary-reveal[data-open] .commentary-rise-late {
+  transition-delay: 80ms;
+}
+@media (prefers-reduced-motion: reduce) {
+  .commentary-reveal,
+  .commentary-rise {
+    transition: none;
+  }
+}
+
 /* Shared plain fade-in, used by the edge-tap hint (and any other one-shot cue). */
 @keyframes tour-fade {
   from {

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -638,14 +638,27 @@ describe("ChartSheet commentary focus", () => {
     ).not.toBeNull();
   });
 
-  test("Escape closes the focused card", () => {
-    const { container } = renderSheet("full");
+  test("Escape closes the focused card without collapsing the sheet", () => {
+    const { container, onSnapChange } = renderSheet("full");
     fireEvent.click(firstTeaser(container)!);
     expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
 
     fireEvent.keyDown(window, { key: "Escape" });
 
     expect(container.querySelector("[data-commentary-card]")).toBeNull();
+    // The card owns the first Escape; the sheet-collapse handler stands down.
+    expect(onSnapChange).not.toHaveBeenCalled();
+  });
+
+  test("a second Escape, after the card closes, collapses the sheet", () => {
+    const { container, onSnapChange } = renderSheet("full");
+    fireEvent.click(firstTeaser(container)!);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onSnapChange).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onSnapChange).toHaveBeenCalledWith("closed");
   });
 
   test("a pointer outside the card closes it", () => {

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -617,11 +617,11 @@ describe("ChartSheet", () => {
 });
 
 describe("ChartSheet commentary focus", () => {
-  // The focus-mode teasers carry aria-haspopup="dialog"; the gem card's accordion
+  // The focus-mode teasers carry data-commentary-teaser; the gem card's accordion
   // does not, so this selects a ranked row's commentary teaser.
   function firstTeaser(container: HTMLElement) {
     return container.querySelector<HTMLButtonElement>(
-      'button[aria-haspopup="dialog"]',
+      "[data-commentary-teaser]",
     );
   }
 
@@ -654,6 +654,28 @@ describe("ChartSheet commentary focus", () => {
     expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
 
     fireEvent.pointerDown(document.body);
+
+    expect(container.querySelector("[data-commentary-card]")).toBeNull();
+  });
+
+  test("switching country closes the card and does not restore it on return", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    const view = (cc: string) => (
+      <AudioStoreContext.Provider value={store}>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode={cc}
+          snap="full"
+          onSnapChange={vi.fn()}
+        />
+      </AudioStoreContext.Provider>
+    );
+    const { container, rerender } = render(view("kr"));
+    fireEvent.click(firstTeaser(container)!);
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+
+    rerender(view("us"));
+    rerender(view("kr"));
 
     expect(container.querySelector("[data-commentary-card]")).toBeNull();
   });

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -661,14 +661,29 @@ describe("ChartSheet commentary focus", () => {
     expect(onSnapChange).toHaveBeenCalledWith("closed");
   });
 
-  test("a pointer outside the card closes it", () => {
+  test("a click on the sheet outside the card (a dimmed sibling) closes it", () => {
     const { container } = renderSheet("full");
     fireEvent.click(firstTeaser(container)!);
     expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
 
-    fireEvent.pointerDown(document.body);
+    const sibling = container.querySelector(
+      "li[data-rank]:not([data-commentary-card])",
+    );
+    fireEvent.click(sibling!);
 
     expect(container.querySelector("[data-commentary-card]")).toBeNull();
+  });
+
+  test("a click outside the sheet (persistent chrome) keeps the card open", () => {
+    const { container } = renderSheet("full");
+    fireEvent.click(firstTeaser(container)!);
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+
+    // The mini-player and other chrome live outside the sheet element; clicking
+    // them must not collapse the card.
+    fireEvent.click(document.body);
+
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
   });
 
   test("switching country closes the card and does not restore it on return", () => {

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -615,3 +615,46 @@ describe("ChartSheet", () => {
     expect(onSnapChange).not.toHaveBeenCalled();
   });
 });
+
+describe("ChartSheet commentary focus", () => {
+  // The focus-mode teasers carry aria-haspopup="dialog"; the gem card's accordion
+  // does not, so this selects a ranked row's commentary teaser.
+  function firstTeaser(container: HTMLElement) {
+    return container.querySelector<HTMLButtonElement>(
+      'button[aria-haspopup="dialog"]',
+    );
+  }
+
+  test("opening a teaser focuses its card and dims the other rows", () => {
+    const { container } = renderSheet("full");
+    const teaser = firstTeaser(container);
+    expect(teaser).not.toBeNull();
+
+    fireEvent.click(teaser!);
+
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+    expect(
+      container.querySelector("li[class*='pointer-events-none']"),
+    ).not.toBeNull();
+  });
+
+  test("Escape closes the focused card", () => {
+    const { container } = renderSheet("full");
+    fireEvent.click(firstTeaser(container)!);
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(container.querySelector("[data-commentary-card]")).toBeNull();
+  });
+
+  test("a pointer outside the card closes it", () => {
+    const { container } = renderSheet("full");
+    fireEvent.click(firstTeaser(container)!);
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(container.querySelector("[data-commentary-card]")).toBeNull();
+  });
+});

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -150,6 +150,35 @@ export function ChartSheet({
   // dragged; only toggled at gesture start/end, never per frame.
   const [isDragging, setIsDragging] = useState(false);
 
+  // A commentary track opened into its focused reader card. Scoped to the country
+  // it opened in, so `focusedRank` derives to null when the country changes
+  // (no reset effect); one at a time.
+  const [focused, setFocused] = useState<{ cc: string; rank: number } | null>(
+    null,
+  );
+  const focusedRank = focused?.cc === countryCode ? focused.rank : null;
+
+  // While a card is focused, dismiss on Escape or a pointer outside it (a dimmed
+  // sibling, the sheet chrome). The opening teaser and the card's own controls
+  // sit inside the card, so this never fights them; capture-phase so a dimmed
+  // sibling's own (pointer-events-none) handlers can't swallow it first.
+  useEffect(() => {
+    if (focusedRank === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFocused(null);
+    };
+    const onDown = (e: PointerEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target?.closest("[data-commentary-card]")) setFocused(null);
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", onDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", onDown, true);
+    };
+  }, [focusedRank]);
+
   // Mount-time snap, captured once. React writes this transform for SSR/first
   // paint and never reconciles it (it never changes across renders), so the
   // gesture and settle code own the transform imperatively from then on. Do not
@@ -578,6 +607,12 @@ export function ChartSheet({
             track={track}
             countryCode={countryCode}
             isHintTarget={track.rank === hintRank}
+            focused={track.rank === focusedRank}
+            dimmed={focusedRank !== null && track.rank !== focusedRank}
+            onOpenCommentary={() =>
+              setFocused({ cc: countryCode, rank: track.rank })
+            }
+            onCloseCommentary={() => setFocused(null)}
           />
         ))}
       </ol>

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -162,24 +162,31 @@ export function ChartSheet({
     setFocusedRank(null);
   }
 
-  // While a card is focused, dismiss on Escape or a pointer outside it (a dimmed
-  // sibling, the sheet chrome). The opening teaser and the card's own controls
-  // sit inside the card, so this never fights them; capture-phase so a dimmed
-  // sibling's own (pointer-events-none) handlers can't swallow it first.
+  // While a card is focused, dismiss on Escape or a click outside it (a dimmed
+  // sibling, the sheet chrome). Dismiss on click, not pointerdown: closing
+  // un-dims the siblings, so a pointerdown-close would restore a sibling's
+  // pointer-events before its click landed and play that track. A dimmed
+  // sibling stays pointer-events-none through the whole click, so the click
+  // targets the list behind it (never the row's play button) and only closes.
   useEffect(() => {
     if (focusedRank === null) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setFocusedRank(null);
     };
-    const onDown = (e: PointerEvent) => {
+    const onClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
-      if (!target?.closest("[data-commentary-card]")) setFocusedRank(null);
+      // Keep the card open for clicks on the card itself, and for anything
+      // outside the sheet (the mini-player and other persistent chrome): only a
+      // click on the sheet's own dimmed area collapses it.
+      if (target?.closest("[data-commentary-card]")) return;
+      if (!sheetRef.current?.contains(target)) return;
+      setFocusedRank(null);
     };
     window.addEventListener("keydown", onKey);
-    window.addEventListener("pointerdown", onDown, true);
+    window.addEventListener("click", onClick, true);
     return () => {
       window.removeEventListener("keydown", onKey);
-      window.removeEventListener("pointerdown", onDown, true);
+      window.removeEventListener("click", onClick, true);
     };
   }, [focusedRank]);
 
@@ -190,6 +197,30 @@ export function ChartSheet({
   const focusedRankRef = useRef(focusedRank);
   useEffect(() => {
     focusedRankRef.current = focusedRank;
+  }, [focusedRank]);
+
+  // When a card opens, its grown height can push its own top above the list
+  // viewport; nudge it into view so the read starts at the top, not mid-card.
+  // Only when clipped (so an already-visible card never yanks); rAF so the grown
+  // card is measured, not the pre-open row.
+  useEffect(() => {
+    if (focusedRank === null) return;
+    const id = requestAnimationFrame(() => {
+      const ol = olRef.current;
+      const row = ol?.querySelector<HTMLElement>(
+        `[data-rank="${focusedRank}"]`,
+      );
+      if (!ol || !row) return;
+      // Leave a small margin above the card so its top outline clears the
+      // viewport edge instead of sitting flush against it (clipped on mobile).
+      const MARGIN_PX = 12;
+      const delta =
+        row.getBoundingClientRect().top -
+        ol.getBoundingClientRect().top -
+        MARGIN_PX;
+      if (delta < 0) ol.scrollBy({ top: delta, behavior: "smooth" });
+    });
+    return () => cancelAnimationFrame(id);
   }, [focusedRank]);
 
   // Mount-time snap, captured once. React writes this transform for SSR/first

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -150,13 +150,17 @@ export function ChartSheet({
   // dragged; only toggled at gesture start/end, never per frame.
   const [isDragging, setIsDragging] = useState(false);
 
-  // A commentary track opened into its focused reader card. Scoped to the country
-  // it opened in, so `focusedRank` derives to null when the country changes
-  // (no reset effect); one at a time.
-  const [focused, setFocused] = useState<{ cc: string; rank: number } | null>(
-    null,
-  );
-  const focusedRank = focused?.cc === countryCode ? focused.rank : null;
+  // A commentary track opened into its focused reader card, by rank; one at a
+  // time. A focus is scoped to the country it opened in: reset it when the
+  // country changes by adjusting state during render, not in an effect (which
+  // would flag a cascading setState, and would leave the focus latent to re-open
+  // on return to that country).
+  const [focusedRank, setFocusedRank] = useState<number | null>(null);
+  const [focusCountry, setFocusCountry] = useState(countryCode);
+  if (focusCountry !== countryCode) {
+    setFocusCountry(countryCode);
+    setFocusedRank(null);
+  }
 
   // While a card is focused, dismiss on Escape or a pointer outside it (a dimmed
   // sibling, the sheet chrome). The opening teaser and the card's own controls
@@ -165,11 +169,11 @@ export function ChartSheet({
   useEffect(() => {
     if (focusedRank === null) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setFocused(null);
+      if (e.key === "Escape") setFocusedRank(null);
     };
     const onDown = (e: PointerEvent) => {
       const target = e.target as HTMLElement | null;
-      if (!target?.closest("[data-commentary-card]")) setFocused(null);
+      if (!target?.closest("[data-commentary-card]")) setFocusedRank(null);
     };
     window.addEventListener("keydown", onKey);
     window.addEventListener("pointerdown", onDown, true);
@@ -609,10 +613,8 @@ export function ChartSheet({
             isHintTarget={track.rank === hintRank}
             focused={track.rank === focusedRank}
             dimmed={focusedRank !== null && track.rank !== focusedRank}
-            onOpenCommentary={() =>
-              setFocused({ cc: countryCode, rank: track.rank })
-            }
-            onCloseCommentary={() => setFocused(null)}
+            onOpenCommentary={() => setFocusedRank(track.rank)}
+            onCloseCommentary={() => setFocusedRank(null)}
           />
         ))}
       </ol>

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -183,6 +183,15 @@ export function ChartSheet({
     };
   }, [focusedRank]);
 
+  // The sheet's own long-lived Escape-collapse listener reads focus via this ref
+  // (the file's ref-for-listeners pattern), so an Escape that closes a focused
+  // card doesn't also collapse the sheet: the card takes the first Escape, a
+  // second collapses.
+  const focusedRankRef = useRef(focusedRank);
+  useEffect(() => {
+    focusedRankRef.current = focusedRank;
+  }, [focusedRank]);
+
   // Mount-time snap, captured once. React writes this transform for SSR/first
   // paint and never reconciles it (it never changes across renders), so the
   // gesture and settle code own the transform imperatively from then on. Do not
@@ -499,6 +508,9 @@ export function ChartSheet({
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      // A focused commentary card owns Escape first; only once it's closed does
+      // Escape collapse the sheet.
+      if (focusedRankRef.current !== null) return;
       // Already collapsed or off-screen: nothing to close, so skip the write.
       const currentSnap = snapRef.current;
       if (currentSnap === "closed" || currentSnap === "hidden") return;

--- a/src/components/chart-sheet/track-commentary.tsx
+++ b/src/components/chart-sheet/track-commentary.tsx
@@ -101,7 +101,7 @@ export interface TrackCommentaryProps {
   // focused reader card (the lead un-clamps, detail/sources show, a close control
   // appears) instead of expanding inline; the gem card omits it and keeps the
   // inline accordion.
-  focus?: {
+  focusCard?: {
     active: boolean;
     onOpen: () => void;
     onClose: () => void;
@@ -109,27 +109,27 @@ export interface TrackCommentaryProps {
 }
 
 // The tag/lead teaser plus its depth. Two shells over one body:
-// - gem card (no `focus`): an inline accordion that expands the detail in place.
-// - chart row (`focus`): a teaser that opens the row's focused reader card, so
-//   the "why it's here" reads with room instead of fighting the cramped row.
+// - gem card (no `focusCard`): an inline accordion that expands the detail here.
+// - chart row (`focusCard`): a teaser that opens the row's focused reader card,
+//   so the "why it's here" reads with room instead of fighting the cramped row.
 export function TrackCommentary({
   commentary,
   isHintTarget,
-  focus,
+  focusCard,
 }: TrackCommentaryProps) {
   const [expanded, setExpanded] = useState(false);
   const panelId = useId();
 
   const Glyph = isHintTarget ? HintedGlyph : PlainGlyph;
 
-  if (focus) {
-    const { active, onOpen, onClose } = focus;
+  if (focusCard) {
+    const { active, onOpen, onClose } = focusCard;
     return (
       <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
         <button
           type="button"
           onClick={active ? onClose : onOpen}
-          aria-haspopup="dialog"
+          data-commentary-teaser
           aria-expanded={active}
           className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
         >

--- a/src/components/chart-sheet/track-commentary.tsx
+++ b/src/components/chart-sheet/track-commentary.tsx
@@ -4,6 +4,7 @@ import { Fragment, useId, useState } from "react";
 
 import { ChevronDownIcon } from "@/components/icons/chevron-down";
 import { ExpandIcon } from "@/components/icons/expand";
+import { MinimizeIcon } from "@/components/icons/minimize";
 import type { Commentary } from "@/lib/chart-schema";
 
 import { useCommentaryHintPulse } from "./use-commentary-hint-pulse";
@@ -18,35 +19,45 @@ function sourceLabel(url: string): string {
   }
 }
 
-// The detail paragraph plus cited sources, shared by the accordion (gem card)
-// and the focused card (chart row) so both render identical commentary depth.
+// The detail paragraph and the cited sources, split so the focused card can rise
+// them in as two staggered beats; the gem accordion composes them via
+// CommentaryDetail. Both surfaces render identical commentary depth.
+function CommentaryText({ commentary }: { commentary: Commentary }) {
+  if (!commentary.detail) return null;
+  return (
+    <p className="text-fg-2 text-small leading-relaxed">{commentary.detail}</p>
+  );
+}
+
+function CommentarySources({ commentary }: { commentary: Commentary }) {
+  return (
+    <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
+      {commentary.sources.map((url, i) => (
+        <Fragment key={`${url}-${i}`}>
+          {i > 0 ? (
+            <span aria-hidden className="text-fg-4 mx-2">
+              ·
+            </span>
+          ) : null}
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
+          >
+            {sourceLabel(url)}
+          </a>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
 function CommentaryDetail({ commentary }: { commentary: Commentary }) {
   return (
     <div className="flex flex-col gap-2 pt-2">
-      {commentary.detail ? (
-        <p className="text-fg-2 text-small leading-relaxed">
-          {commentary.detail}
-        </p>
-      ) : null}
-      <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
-        {commentary.sources.map((url, i) => (
-          <Fragment key={`${url}-${i}`}>
-            {i > 0 ? (
-              <span aria-hidden className="text-fg-4 mx-2">
-                ·
-              </span>
-            ) : null}
-            <a
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
-            >
-              {sourceLabel(url)}
-            </a>
-          </Fragment>
-        ))}
-      </div>
+      <CommentaryText commentary={commentary} />
+      <CommentarySources commentary={commentary} />
     </div>
   );
 }
@@ -124,30 +135,69 @@ export function TrackCommentary({
 
   if (focusCard) {
     const { active, onOpen, onClose } = focusCard;
+    // The detail + sources live in an always-mounted reveal so opening AND
+    // closing animate (grid-rows height + a springy rise); inert while closed.
     return (
       <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
-        <button
-          type="button"
-          onClick={active ? onClose : onOpen}
-          data-commentary-teaser
-          aria-expanded={active}
-          className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
-        >
-          <TagPill tag={commentary.tag} />
-          <span
-            className={`text-fg-2 text-small min-w-0 flex-1 ${active ? "" : "line-clamp-2"}`}
+        {active ? (
+          // Open: the badge sits on its own top row (a flex row, so extra tags
+          // would wrap if the schema ever carries more than one) with the
+          // collapse cue, above a full-width lead. The whole button toggles
+          // closed (tap the card again), so there's no separate close control.
+          <button
+            type="button"
+            onClick={onClose}
+            aria-expanded
+            aria-label="Collapse commentary"
+            className="focus-visible:outline-aurora block w-full text-left focus-visible:outline-2 focus-visible:outline-offset-2"
           >
-            {commentary.lead}
-          </span>
-          <Glyph>
-            {active ? (
-              <ChevronGlyph expanded />
-            ) : (
+            <div className="flex items-center gap-2">
+              <div className="flex flex-1 flex-wrap items-center gap-2">
+                <TagPill tag={commentary.tag} />
+              </div>
+              <MinimizeIcon className="text-fg-3 h-4 w-4 shrink-0" />
+            </div>
+            <p className="text-fg-2 text-small mt-2 leading-relaxed">
+              {commentary.lead}
+            </p>
+          </button>
+        ) : (
+          // Teaser: the compact hook. Pill + clamped lead + an "open into a
+          // larger view" icon (a chevron would imply an in-place fold).
+          <button
+            type="button"
+            onClick={onOpen}
+            data-commentary-teaser
+            aria-expanded={false}
+            className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
+          >
+            <TagPill tag={commentary.tag} />
+            <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
+              {commentary.lead}
+            </span>
+            <Glyph>
               <ExpandIcon className="text-fg-3 h-4 w-4" />
-            )}
-          </Glyph>
-        </button>
-        {active ? <CommentaryDetail commentary={commentary} /> : null}
+            </Glyph>
+          </button>
+        )}
+        <div
+          className="commentary-reveal"
+          data-open={active || undefined}
+          inert={!active}
+        >
+          <div className="commentary-reveal-inner">
+            <div className="flex flex-col gap-2 pt-2">
+              {commentary.detail ? (
+                <div className="commentary-rise">
+                  <CommentaryText commentary={commentary} />
+                </div>
+              ) : null}
+              <div className="commentary-rise commentary-rise-late">
+                <CommentarySources commentary={commentary} />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/chart-sheet/track-commentary.tsx
+++ b/src/components/chart-sheet/track-commentary.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useId, useState } from "react";
 
 import { ChevronDownIcon } from "@/components/icons/chevron-down";
+import { ExpandIcon } from "@/components/icons/expand";
 import type { Commentary } from "@/lib/chart-schema";
 
 import { useCommentaryHintPulse } from "./use-commentary-hint-pulse";
@@ -17,6 +18,47 @@ function sourceLabel(url: string): string {
   }
 }
 
+// The detail paragraph plus cited sources, shared by the accordion (gem card)
+// and the focused card (chart row) so both render identical commentary depth.
+function CommentaryDetail({ commentary }: { commentary: Commentary }) {
+  return (
+    <div className="flex flex-col gap-2 pt-2">
+      {commentary.detail ? (
+        <p className="text-fg-2 text-small leading-relaxed">
+          {commentary.detail}
+        </p>
+      ) : null}
+      <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
+        {commentary.sources.map((url, i) => (
+          <Fragment key={`${url}-${i}`}>
+            {i > 0 ? (
+              <span aria-hidden className="text-fg-4 mx-2">
+                ·
+              </span>
+            ) : null}
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              {sourceLabel(url)}
+            </a>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TagPill({ tag }: { tag: string }) {
+  return (
+    <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
+      {tag}
+    </span>
+  );
+}
+
 function ChevronGlyph({ expanded }: { expanded: boolean }) {
   return (
     <ChevronDownIcon
@@ -28,7 +70,7 @@ function ChevronGlyph({ expanded }: { expanded: boolean }) {
 
 // Only mounted on the single hint-target row, so its store reads and observer
 // are paid once. The pulse animates this wrapper, not the SVG inside it.
-function HintedChevron({ expanded }: { expanded: boolean }) {
+function HintedGlyph({ children }: { children: React.ReactNode }) {
   const { chevronRef, pulsing } = useCommentaryHintPulse();
   return (
     <span
@@ -36,7 +78,15 @@ function HintedChevron({ expanded }: { expanded: boolean }) {
       data-commentary-hint={pulsing || undefined}
       className="inline-flex shrink-0 items-center justify-center"
     >
-      <ChevronGlyph expanded={expanded} />
+      {children}
+    </span>
+  );
+}
+
+function PlainGlyph({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex shrink-0 items-center justify-center">
+      {children}
     </span>
   );
 }
@@ -47,17 +97,60 @@ export interface TrackCommentaryProps {
   // first-commentary-rank.ts). Callers outside the ranked list, like the gem
   // card, never pass this.
   isHintTarget?: boolean;
+  // Present only for the chart-row usage. When given, the teaser opens the row's
+  // focused reader card (the lead un-clamps, detail/sources show, a close control
+  // appears) instead of expanding inline; the gem card omits it and keeps the
+  // inline accordion.
+  focus?: {
+    active: boolean;
+    onOpen: () => void;
+    onClose: () => void;
+  };
 }
 
-// The expandable tag/lead/detail/sources panel, shared by TrackRow and the gem
-// card so both surfaces reuse identical commentary markup rather than each
-// carrying its own copy.
+// The tag/lead teaser plus its depth. Two shells over one body:
+// - gem card (no `focus`): an inline accordion that expands the detail in place.
+// - chart row (`focus`): a teaser that opens the row's focused reader card, so
+//   the "why it's here" reads with room instead of fighting the cramped row.
 export function TrackCommentary({
   commentary,
   isHintTarget,
+  focus,
 }: TrackCommentaryProps) {
   const [expanded, setExpanded] = useState(false);
   const panelId = useId();
+
+  const Glyph = isHintTarget ? HintedGlyph : PlainGlyph;
+
+  if (focus) {
+    const { active, onOpen, onClose } = focus;
+    return (
+      <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
+        <button
+          type="button"
+          onClick={active ? onClose : onOpen}
+          aria-haspopup="dialog"
+          aria-expanded={active}
+          className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          <TagPill tag={commentary.tag} />
+          <span
+            className={`text-fg-2 text-small min-w-0 flex-1 ${active ? "" : "line-clamp-2"}`}
+          >
+            {commentary.lead}
+          </span>
+          <Glyph>
+            {active ? (
+              <ChevronGlyph expanded />
+            ) : (
+              <ExpandIcon className="text-fg-3 h-4 w-4" />
+            )}
+          </Glyph>
+        </button>
+        {active ? <CommentaryDetail commentary={commentary} /> : null}
+      </div>
+    );
+  }
 
   return (
     <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
@@ -68,19 +161,13 @@ export function TrackCommentary({
         aria-controls={panelId}
         className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
       >
-        <span className="bg-fg-1/5 text-fg-3 text-micro rounded-pill shrink-0 px-2 py-0.5">
-          {commentary.tag}
-        </span>
+        <TagPill tag={commentary.tag} />
         <span className="text-fg-2 text-small line-clamp-2 min-w-0 flex-1">
           {commentary.lead}
         </span>
-        {isHintTarget ? (
-          <HintedChevron expanded={expanded} />
-        ) : (
-          <span className="inline-flex shrink-0 items-center justify-center">
-            <ChevronGlyph expanded={expanded} />
-          </span>
-        )}
+        <Glyph>
+          <ChevronGlyph expanded={expanded} />
+        </Glyph>
       </button>
       <div
         id={panelId}
@@ -88,32 +175,7 @@ export function TrackCommentary({
         data-expanded={expanded || undefined}
         className="max-h-0 overflow-hidden transition-[max-height] duration-300 ease-[var(--ease-out)] data-[expanded]:max-h-96 motion-reduce:transition-none"
       >
-        <div className="flex flex-col gap-2 pt-2">
-          {commentary.detail ? (
-            <p className="text-fg-2 text-small leading-relaxed">
-              {commentary.detail}
-            </p>
-          ) : null}
-          <div className="text-fg-3 text-micro flex flex-wrap items-center gap-y-1">
-            {commentary.sources.map((url, i) => (
-              <Fragment key={`${url}-${i}`}>
-                {i > 0 ? (
-                  <span aria-hidden className="text-fg-4 mx-2">
-                    ·
-                  </span>
-                ) : null}
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-fg-1 focus-visible:outline-aurora underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
-                >
-                  {sourceLabel(url)}
-                </a>
-              </Fragment>
-            ))}
-          </div>
-        </div>
+        <CommentaryDetail commentary={commentary} />
       </div>
     </div>
   );

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -318,3 +318,72 @@ describe("TrackRow commentary card", () => {
     expect(screen.getByRole("link", { name: "npr.org" })).toBeDefined();
   });
 });
+
+describe("TrackRow commentary focus card", () => {
+  const COMMENTARY = {
+    lead: "A drill-inflected breakout dominating the charts for three weeks.",
+    detail: "It crossed over from underground clubs after a viral challenge.",
+    tag: "why it's here",
+    claim: "why-charting",
+    sources: ["https://www.billboard.com/charts"],
+    generatedAt: "2026-04-25T03:00:00Z",
+  } satisfies Commentary;
+
+  function renderFocusRow(over: { focused?: boolean; dimmed?: boolean } = {}) {
+    const store = createAudioStore(() => makeMockAudio());
+    const onOpenCommentary = vi.fn();
+    const onCloseCommentary = vi.fn();
+    const utils = render(
+      <AudioStoreContext.Provider value={store}>
+        <ul>
+          <TrackRow
+            track={makeTrack({ commentary: COMMENTARY })}
+            countryCode="kr"
+            focused={over.focused ?? false}
+            dimmed={over.dimmed ?? false}
+            onOpenCommentary={onOpenCommentary}
+            onCloseCommentary={onCloseCommentary}
+          />
+        </ul>
+      </AudioStoreContext.Provider>,
+    );
+    return { ...utils, onOpenCommentary, onCloseCommentary };
+  }
+
+  test("closed: the teaser opens the card rather than expanding detail inline", () => {
+    const { onOpenCommentary } = renderFocusRow({ focused: false });
+
+    const teaser = screen.getByRole("button", { expanded: false });
+    expect(teaser.textContent).toContain(COMMENTARY.lead);
+    expect(screen.queryByText(COMMENTARY.detail)).toBeNull();
+
+    fireEvent.click(teaser);
+
+    expect(onOpenCommentary).toHaveBeenCalledTimes(1);
+  });
+
+  test("focused: shows the detail and sources, and the teaser closes it", () => {
+    const { onCloseCommentary } = renderFocusRow({ focused: true });
+
+    expect(screen.getByText(COMMENTARY.detail)).toBeDefined();
+    expect(screen.getByRole("link", { name: "billboard.com" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { expanded: true }));
+
+    expect(onCloseCommentary).toHaveBeenCalledTimes(1);
+  });
+
+  test("focused: the row is tagged as the commentary card for outside-click", () => {
+    const { container } = renderFocusRow({ focused: true });
+
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+  });
+
+  test("dimmed: the row recedes and is inert to pointers", () => {
+    const { container } = renderFocusRow({ dimmed: true });
+
+    const li = container.querySelector("li");
+    expect(li?.className).toContain("opacity-40");
+    expect(li?.className).toContain("pointer-events-none");
+  });
+});

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -350,12 +350,14 @@ describe("TrackRow commentary focus card", () => {
     return { ...utils, onOpenCommentary, onCloseCommentary };
   }
 
-  test("closed: the teaser opens the card rather than expanding detail inline", () => {
-    const { onOpenCommentary } = renderFocusRow({ focused: false });
+  test("closed: the teaser opens the card; the reveal stays collapsed", () => {
+    const { container, onOpenCommentary } = renderFocusRow({ focused: false });
 
     const teaser = screen.getByRole("button", { expanded: false });
     expect(teaser.textContent).toContain(COMMENTARY.lead);
-    expect(screen.queryByText(COMMENTARY.detail)).toBeNull();
+    // The reveal is always mounted (so it can animate closed too), but is not
+    // opened while the teaser is closed.
+    expect(container.querySelector(".commentary-reveal[data-open]")).toBeNull();
 
     fireEvent.click(teaser);
 

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -74,13 +74,16 @@ export function TrackRow({
   // contain-intrinsic-size seeds an off-screen row at a collapsed single-line
   // height (~68px) and, via `auto`, reuses its real height once rendered,
   // reducing data-rank scroll drift for taller rows.
+  // The chrome transition (background, ring/shadow, opacity) lives on the base so
+  // the card fades its surface in and the siblings dim/undim both when opening
+  // and when closing, off the same class change.
   const baseClass =
-    "flex flex-col rounded-[14px] px-3 py-2.5 data-[disabled]:opacity-40";
+    "flex flex-col rounded-[14px] px-3 py-2.5 transition-[background-color,box-shadow,opacity] duration-[240ms] ease-[var(--ease-out)] data-[disabled]:opacity-40 motion-reduce:transition-none";
   const stateClass = focused
     ? "bg-atmos ring-aurora/25 relative z-10 shadow-sheet ring-1"
     : dimmed
-      ? "pointer-events-none opacity-40 transition-opacity duration-200 motion-reduce:transition-none"
-      : "hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] transition-colors duration-200 [contain-intrinsic-size:auto_68px] [content-visibility:auto] data-[disabled]:hover:bg-transparent";
+      ? "pointer-events-none opacity-40"
+      : "hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] [contain-intrinsic-size:auto_68px] [content-visibility:auto] data-[disabled]:hover:bg-transparent";
 
   return (
     <li

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -181,7 +181,7 @@ export function TrackRow({
         <TrackCommentary
           commentary={commentary}
           isHintTarget={isHintTarget}
-          focus={
+          focusCard={
             onOpenCommentary && onCloseCommentary
               ? {
                   active: focused,

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -18,9 +18,24 @@ export interface TrackRowProps {
   // True on the first commentary-bearing row of the current country: the one
   // row eligible for the one-time discovery pulse.
   isHintTarget?: boolean;
+  // Commentary focus state, owned by the sheet. `focused` makes this row the
+  // reader card; `dimmed` recedes it while a sibling is focused. Absent for rows
+  // without commentary and for the gem card.
+  focused?: boolean;
+  dimmed?: boolean;
+  onOpenCommentary?: () => void;
+  onCloseCommentary?: () => void;
 }
 
-export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
+export function TrackRow({
+  track,
+  countryCode,
+  isHintTarget,
+  focused = false,
+  dimmed = false,
+  onOpenCommentary,
+  onCloseCommentary,
+}: TrackRowProps) {
   const isCurrent = useAudioStore(
     (s) =>
       s.currentTrack?.previewUrl === track.previewUrl &&
@@ -54,18 +69,28 @@ export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
 
   const commentary = track.commentary ?? null;
 
+  // content-visibility:auto skips layout/paint for rows scrolled out of view
+  // (most of the list); the focused card must fully render, so it opts out.
+  // contain-intrinsic-size seeds an off-screen row at a collapsed single-line
+  // height (~68px) and, via `auto`, reuses its real height once rendered,
+  // reducing data-rank scroll drift for taller rows.
+  const baseClass =
+    "flex flex-col rounded-[14px] px-3 py-2.5 data-[disabled]:opacity-40";
+  const stateClass = focused
+    ? "bg-atmos ring-aurora/25 relative z-10 shadow-sheet ring-1"
+    : dimmed
+      ? "pointer-events-none opacity-40 transition-opacity duration-200 motion-reduce:transition-none"
+      : "hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] transition-colors duration-200 [contain-intrinsic-size:auto_68px] [content-visibility:auto] data-[disabled]:hover:bg-transparent";
+
   return (
     <li
       data-rank={track.rank}
       data-state={state}
       data-disabled={!hasPreview || undefined}
+      data-commentary-card={focused || undefined}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      // content-visibility:auto skips layout/paint for rows scrolled out of view
-      // (most of the list). contain-intrinsic-size seeds an off-screen row at a
-      // collapsed single-line height (~68px) and, via `auto`, reuses its real
-      // height once rendered, reducing data-rank scroll drift for taller rows.
-      className="hover:bg-atmos data-[state]:bg-sunrise/[0.08] data-[state]:hover:bg-sunrise/[0.15] flex flex-col rounded-[14px] px-3 py-2.5 transition-colors duration-200 [contain-intrinsic-size:auto_68px] [content-visibility:auto] data-[disabled]:opacity-40 data-[disabled]:hover:bg-transparent"
+      className={`${baseClass} ${stateClass}`}
     >
       <div className="flex items-center gap-[14px]">
         <button
@@ -153,7 +178,19 @@ export function TrackRow({ track, countryCode, isHintTarget }: TrackRowProps) {
         </div>
       </div>
       {commentary ? (
-        <TrackCommentary commentary={commentary} isHintTarget={isHintTarget} />
+        <TrackCommentary
+          commentary={commentary}
+          isHintTarget={isHintTarget}
+          focus={
+            onOpenCommentary && onCloseCommentary
+              ? {
+                  active: focused,
+                  onOpen: onOpenCommentary,
+                  onClose: onCloseCommentary,
+                }
+              : undefined
+          }
+        />
       ) : null}
     </li>
   );

--- a/src/components/icons/expand.tsx
+++ b/src/components/icons/expand.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from "react";
+
+// Two corner arrows pushing outward: signals "open into a larger view", not the
+// in-place fold a chevron implies.
+export function ExpandIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M15 3h6v6" />
+      <path d="M9 21H3v-6" />
+      <path d="m21 3-7 7" />
+      <path d="m3 21 7-7" />
+    </svg>
+  );
+}

--- a/src/components/icons/minimize.tsx
+++ b/src/components/icons/minimize.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from "react";
+
+// Four corner arrows pulling inward: the counterpart to ExpandIcon, so an open
+// commentary card cues "shrink back" the way the teaser cues "open larger".
+export function MinimizeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M4 14h6v6" />
+      <path d="M20 10h-6V4" />
+      <path d="m14 10 7-7" />
+      <path d="m3 21 7-7" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What & why

A chart row's AI commentary teaser was clamped to two lines in a cramped row, so the "why it's here" was truncated and unread. Tapping the teaser now grows that row into a focused reader card (full lead + detail + sources) and dims the rest of the list, so the commentary reads with room. Dismiss via the teaser, Escape, or a tap outside the card. The gem card keeps its inline accordion.

Design chosen by eye from a visual compare of six treatments (inline / modal / detail-sheet / focused-row / story-card / full-snap); focused-row won for keeping one surface and one metaphor while giving the read real space.

## Changes

- `track-commentary.tsx`: extract a shared `CommentaryDetail`; add a `focus` mode (teaser opens the row's card; active shows the full body and a collapse control) alongside the accordion default that the gem card still uses.
- `icons/expand.tsx`: a new "open into a larger view" glyph for the teaser (a chevron would imply an in-place fold).
- `track-row.tsx`: `focused` / `dimmed` / `onOpenCommentary` / `onCloseCommentary` props; card vs dimmed styling; opts out of `content-visibility` when focused.
- `sheet.tsx`: the focused commentary is `{ cc, rank }` state with a derived `focusedRank` (country-scoped, so switching countries collapses it with no reset effect); Escape and an outside pointerdown (capture phase) dismiss. No hard focus trap (respects the ADR-0004 / #200 a11y fix): the same teaser button toggles open/close, so focus stays put.

## Test plan

- Local CI green: typecheck, lint, **646 tests** (7 new: 4 in `track-row`, 3 in `sheet` covering open → focused + dimmed siblings, Escape close, outside-pointer close), build.
- ⚠️ **On-device feel not yet verified**: the grow + dim on a real phone, whether the focused card should scroll into a better position when the tapped row sits near the sheet bottom, and how the dim reads at the peek snap vs full. Worth a device pass before merge.

No linked issue (UX enhancement surfaced in session).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added focused commentary cards for chart rows with expanded detail and source links.
  * Clicking commentary teasers now opens a dialog-style focus card with open/close controls.
  * Selected rows are visually emphasized while other rows are dimmed/inert.

* **Bug Fixes**
  * Escape no longer collapses the sheet while a commentary card is focused (card consumes Escape first).
  * Dismissal behavior is refined so outside-page clicks keep the card open; changing countries closes the card.

* **Tests**
  * Expanded interaction coverage for focus/open/close, Escape behavior, dimmed-row dismissal, and state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->