### PR TITLE
chore(ci): bump actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node and pnpm via mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/cron-crawl.yml
+++ b/.github/workflows/cron-crawl.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node and pnpm via mise
         uses: jdx/mise-action@v4


### PR DESCRIPTION
## What

Bumps `actions/checkout` from `v6` to `v7` in `ci.yml` and `cron-crawl.yml`, the current stable major (published 2026-06-18).

## Why

Aligns both workflows with the new react-doctor workflow (#229) and the repo's Node 24 runtime — v7 ships the ESM / Node 24 action runtime.

## Safety

v7's one breaking change blocks fork-PR checkout under `pull_request_target` and `workflow_run`. Neither workflow uses those triggers (ci: `pull_request` + `push` + `workflow_dispatch`; cron-crawl: `schedule` + `workflow_dispatch`), so it doesn't apply.

## Test plan

- [ ] CI workflow runs green on this PR with checkout@v7.