### PR TITLE
fix(commentary): recede the gem and receded rows while a card is focused

### DIFF
--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -638,6 +638,21 @@ describe("ChartSheet commentary focus", () => {
     ).not.toBeNull();
   });
 
+  test("dimmed siblings and the gem card recede and go inert", () => {
+    const { container } = renderSheet("full");
+    fireEvent.click(firstTeaser(container)!);
+
+    const sibling = container.querySelector(
+      "li[data-rank]:not([data-commentary-card])",
+    );
+    expect(sibling?.hasAttribute("inert")).toBe(true);
+
+    // The gem card is the one ranked-list <li> without a data-rank.
+    const gemLi = container.querySelector("ol > li:not([data-rank])");
+    expect(gemLi?.className).toContain("opacity-40");
+    expect(gemLi?.hasAttribute("inert")).toBe(true);
+  });
+
   test("Escape closes the focused card without collapsing the sheet", () => {
     const { container, onSnapChange } = renderSheet("full");
     fireEvent.click(firstTeaser(container)!);

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -640,7 +640,17 @@ export function ChartSheet({
         className="min-h-0 flex-1 touch-none overflow-y-auto overscroll-y-contain px-4 pb-12 transition-[max-height] duration-300 ease-out [-ms-overflow-style:none] [scrollbar-width:none] group-data-[snap=full]:touch-pan-y data-[peek]:max-h-[calc(35dvh-62px)] [&::-webkit-scrollbar]:hidden"
       >
         {gemSelection ? (
-          <li>
+          <li
+            // Recede with the rest of the list while a track's card is focused,
+            // and go inert so its play / commentary can't fire (or, being outside
+            // the card, collapse it) mid-read.
+            className={
+              focusedRank !== null
+                ? "pointer-events-none opacity-40 transition-opacity duration-[240ms] ease-[var(--ease-out)] motion-reduce:transition-none"
+                : undefined
+            }
+            inert={focusedRank !== null}
+          >
             <GemCard
               track={gemSelection.gem}
               tier={gemSelection.tier}

--- a/src/components/chart-sheet/track-commentary.tsx
+++ b/src/components/chart-sheet/track-commentary.tsx
@@ -140,22 +140,20 @@ export function TrackCommentary({
     return (
       <div className="border-fg-1/10 mt-2.5 border-t pt-2.5">
         {active ? (
-          // Open: the badge sits on its own top row (a flex row, so extra tags
-          // would wrap if the schema ever carries more than one) with the
-          // collapse cue, above a full-width lead. The whole button toggles
-          // closed (tap the card again), so there's no separate close control.
+          // Open: the badge sits on its own top row with the collapse cue, above
+          // a full-width lead. The whole button toggles closed (tap the card
+          // again), so there's no separate close control.
           <button
             type="button"
             onClick={onClose}
             aria-expanded
+            aria-controls={panelId}
             aria-label="Collapse commentary"
             className="focus-visible:outline-aurora block w-full text-left focus-visible:outline-2 focus-visible:outline-offset-2"
           >
             <div className="flex items-center gap-2">
-              <div className="flex flex-1 flex-wrap items-center gap-2">
-                <TagPill tag={commentary.tag} />
-              </div>
-              <MinimizeIcon className="text-fg-3 h-4 w-4 shrink-0" />
+              <TagPill tag={commentary.tag} />
+              <MinimizeIcon className="text-fg-3 ml-auto h-4 w-4 shrink-0" />
             </div>
             <p className="text-fg-2 text-small mt-2 leading-relaxed">
               {commentary.lead}
@@ -169,6 +167,7 @@ export function TrackCommentary({
             onClick={onOpen}
             data-commentary-teaser
             aria-expanded={false}
+            aria-controls={panelId}
             className="focus-visible:outline-aurora flex w-full items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
           >
             <TagPill tag={commentary.tag} />
@@ -181,6 +180,7 @@ export function TrackCommentary({
           </button>
         )}
         <div
+          id={panelId}
           className="commentary-reveal"
           data-open={active || undefined}
           inert={!active}

--- a/src/components/chart-sheet/track-row.test.tsx
+++ b/src/components/chart-sheet/track-row.test.tsx
@@ -387,5 +387,6 @@ describe("TrackRow commentary focus card", () => {
     const li = container.querySelector("li");
     expect(li?.className).toContain("opacity-40");
     expect(li?.className).toContain("pointer-events-none");
+    expect(li?.hasAttribute("inert")).toBe(true);
   });
 });

--- a/src/components/chart-sheet/track-row.tsx
+++ b/src/components/chart-sheet/track-row.tsx
@@ -91,6 +91,10 @@ export function TrackRow({
       data-state={state}
       data-disabled={!hasPreview || undefined}
       data-commentary-card={focused || undefined}
+      // A dimmed sibling is inert as well as pointer-dead, so keyboard and
+      // screen-reader users can't tab into a receded row and fire its controls
+      // when a mouse user can't.
+      inert={dimmed}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       className={`${baseClass} ${stateClass}`}


### PR DESCRIPTION
## What & why

Follow-up to #228 (the commentary focus card), from a fresh two-axis `/code-review` of the merged feature.

The main finding: while a track's commentary card is focused, **the gem card didn't recede**. It stayed bright and interactive, so tapping its play button both played the gem and collapsed the card (the dimmed track siblings are deliberately close-only, but the gem had no dim path). The gem now dims and goes inert with the rest of the list.

## Changes

- The gem card `<li>` dims (`opacity-40`) and goes `inert` while any track card is focused, matching the dimmed siblings.
- Dimmed track rows also gain `inert`, not just `pointer-events-none`: a keyboard or screen-reader user could otherwise tab into a receded row and fire its controls when a mouse user can't.
- The focus toggle buttons link to their reveal via `aria-controls` (the inline accordion already did; the focus card had only `aria-expanded`).
- Drop a speculative multi-tag `flex-wrap` (the schema carries a single `tag`).

## Test plan

- Local CI green: typecheck, lint, **650 tests** (new: gem dim + inert, dimmed-sibling inert), build.

## Notes

- Deferred (judgement call from the review): the teaser markup is duplicated across the accordion and focus paths; the `commentary-rise` stagger wrappers make a shared sub-component awkward, so left as-is.
- The review flagged the expand/minimize glyph as "two-corner" vs a "four-corner" design note; the two-corner maximize is the icon that was rendered and approved on device, so no change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Focused commentary cards now correctly expose their associated reveal panels to assistive technologies.
  * Dimmed chart rows and gem cards are no longer interactive while a commentary card is open.
  * Keyboard and screen-reader focus is prevented from reaching inactive chart elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->