### PR TITLE
fix(globe): arbitrate pointers and resume settles interrupted by a skip

### DIFF
--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -130,14 +130,19 @@ export function SpinSnapControls({
   const sim = useRef(
     (() => {
       const start = COUNTRY_BY_CODE.get(initialCode);
+      const startAz = start ? start.lon * DEG : 0;
+      const startEl = start ? start.lat * DEG : 0;
+      // Seed the settle targets to the resting position so "az/el are at the
+      // settle targets" reads true from the first frame. The skip-during-settle
+      // resume relies on that invariant to tell a stranded glide from rest.
       return {
-        az: start ? start.lon * DEG : 0,
-        el: start ? start.lat * DEG : 0,
+        az: startAz,
+        el: startEl,
         vAz: 0,
         vEl: 0,
         mode: "idle" as "idle" | "drag" | "fling" | "settle",
-        settleAz: 0,
-        settleEl: 0,
+        settleAz: startAz,
+        settleEl: startEl,
         settledCode: initialCode,
       };
     })(),
@@ -217,11 +222,18 @@ export function SpinSnapControls({
       vx: 0,
       vy: 0,
       dragging: false,
+      // The one pointer that owns the active gesture. touchAction:"none" routes
+      // every touch here, so a second finger's move/up must not steer or end the
+      // first finger's drag.
+      activePointerId: null as number | null,
     };
 
     const onDown = (e: PointerEvent) => {
       // Read mode covers the globe; ignore presses so reading never grabs it.
       if (cfg.current.readMode) return;
+      // A gesture already owns a pointer: ignore a second finger rather than let
+      // it reset the drag anchor and hurl the globe on the next move.
+      if (g.dragging) return;
       // Cancel a deferred edge-tap select so it can't fire mid-gesture; the
       // armed window survives this press so a second tap can still skip.
       clearPendingSelect();
@@ -230,6 +242,7 @@ export function SpinSnapControls({
       s.vAz = 0;
       s.vEl = 0;
       g.dragging = true;
+      g.activePointerId = e.pointerId;
       g.downX = e.clientX;
       g.downY = e.clientY;
       g.lastX = e.clientX;
@@ -241,7 +254,10 @@ export function SpinSnapControls({
     };
 
     const onMove = (e: PointerEvent) => {
-      if (!g.dragging) return;
+      if (!g.dragging || e.pointerId !== g.activePointerId) return;
+      // Read mode can flip on mid-drag; onMove writes az directly, bypassing the
+      // useFrame suspend, so bail here too or the globe drifts under the sheet.
+      if (cfg.current.readMode) return;
       const s = sim.current;
       const dx = e.clientX - g.lastX;
       const dy = e.clientY - g.lastY;
@@ -260,8 +276,9 @@ export function SpinSnapControls({
     };
 
     const onUp = (e: PointerEvent) => {
-      if (!g.dragging) return;
+      if (!g.dragging || e.pointerId !== g.activePointerId) return;
       g.dragging = false;
+      g.activePointerId = null;
       el.releasePointerCapture?.(e.pointerId);
       const s = sim.current;
 
@@ -315,9 +332,14 @@ export function SpinSnapControls({
           // pending select and skip instead.
           clearPendingSelect();
           lastEdgeTapAt.current = null;
-          // A skip moves no globe, so return the machine to rest instead of
-          // leaving it at "drag" from the press.
-          s.mode = "idle";
+          // A skip moves no globe. If the press that started this tap froze a
+          // settle in flight, resume it — its targets still hold the intended
+          // landing — so the globe never strands mid-glide, possibly on ocean.
+          // At rest az/el already sit on the targets, so return to idle instead.
+          const atTarget =
+            Math.abs(shortestAngle(s.settleAz - s.az)) < 0.002 &&
+            Math.abs(s.settleEl - s.el) < 0.002;
+          s.mode = atTarget ? "idle" : "settle";
           // Raise a skip-intent; the chart runs the skip and flashes on a real
           // change. The globe emits data and learns no outcome.
           globeChartStore.getState().signalSkip(action.dir);
@@ -352,8 +374,9 @@ export function SpinSnapControls({
     // not pointerup. Without this the drag never ends and the globe freezes.
     // Snap to the nearest country so it still never rests on open ocean.
     const onCancel = (e: PointerEvent) => {
-      if (!g.dragging) return;
+      if (!g.dragging || e.pointerId !== g.activePointerId) return;
       g.dragging = false;
+      g.activePointerId = null;
       el.releasePointerCapture?.(e.pointerId);
       // An abandoned gesture ends any armed double-tap window too.
       clearPendingSelect();

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -32,6 +32,9 @@ const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap withi
 // DOUBLE_TAP_MS) so main-thread jank can't fire the select before a second
 // tap's pointerup and misclassify a skip as a select.
 const SELECT_DEFER_MS = 360;
+// Angular tolerance (rad) for "the camera sits on the settle target": ends a
+// settle, and tells a skip whether a settle was interrupted mid-glide.
+const SETTLE_EPS = 0.002;
 
 const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
 
@@ -256,8 +259,14 @@ export function SpinSnapControls({
     const onMove = (e: PointerEvent) => {
       if (!g.dragging || e.pointerId !== g.activePointerId) return;
       // Read mode can flip on mid-drag; onMove writes az directly, bypassing the
-      // useFrame suspend, so bail here too or the globe drifts under the sheet.
-      if (cfg.current.readMode) return;
+      // useFrame suspend, so don't rotate. Keep the pointer baseline current so
+      // a flip back off doesn't read the whole gap as one jump.
+      if (cfg.current.readMode) {
+        g.lastX = e.clientX;
+        g.lastY = e.clientY;
+        g.lastT = e.timeStamp;
+        return;
+      }
       const s = sim.current;
       const dx = e.clientX - g.lastX;
       const dy = e.clientY - g.lastY;
@@ -333,12 +342,12 @@ export function SpinSnapControls({
           clearPendingSelect();
           lastEdgeTapAt.current = null;
           // A skip moves no globe. If the press that started this tap froze a
-          // settle in flight, resume it — its targets still hold the intended
-          // landing — so the globe never strands mid-glide, possibly on ocean.
+          // settle in flight, resume it: its targets still hold the intended
+          // landing, so the globe never strands mid-glide, possibly on ocean.
           // At rest az/el already sit on the targets, so return to idle instead.
           const atTarget =
-            Math.abs(shortestAngle(s.settleAz - s.az)) < 0.002 &&
-            Math.abs(s.settleEl - s.el) < 0.002;
+            Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
+            Math.abs(s.settleEl - s.el) < SETTLE_EPS;
           s.mode = atTarget ? "idle" : "settle";
           // Raise a skip-intent; the chart runs the skip and flashes on a real
           // change. The globe emits data and learns no outcome.
@@ -452,8 +461,8 @@ export function SpinSnapControls({
       s.az += s.vAz * dtc;
       s.el += s.vEl * dtc;
       if (
-        Math.abs(shortestAngle(s.settleAz - s.az)) < 0.002 &&
-        Math.abs(s.settleEl - s.el) < 0.002 &&
+        Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
+        Math.abs(s.settleEl - s.el) < SETTLE_EPS &&
         Math.hypot(s.vAz, s.vEl) < 0.02
       ) {
         s.az = s.settleAz;


### PR DESCRIPTION
> **Draft: needs on-device verification before merge.** `spin-snap-controls.tsx` has no tests and these are touch/interruption paths that can't be driven off-device. Static checks (typecheck/lint/build, 650 tests) pass, but the gesture behavior itself is unverified.

## Why

Two interruption bugs in the spin-snap gesture handlers, from the 2026-07-09 audit. These are the two point-fixes; the recommended R2 reducer refactor is intentionally **not** done here (that's the taste/feel judgment call the `ready-for-human` label protects).

## What

**Bug 1 — pointer arbitration.** A second finger reset the shared drag anchor and either finger's release ended the drag, so multi-touch could hurl the globe and poison fling velocity. The gesture now binds to one `activePointerId` and ignores the rest. `onMove` also bails in read mode, so a finger already down when the sheet opens can't drag the globe under it.

**Bug 2 — resume interrupted settle.** An edge double-tap landing during an in-flight settle left the machine idle mid-glide while the chart already claimed the target, resting the camera between countries and sometimes on ocean. The skip branch now resumes the settle whose targets still hold. Seeding those targets to the start position (they were `0,0` while `az/el` start at the initial country) keeps the resume from firing before the first settle.

## Test plan

- [x] typecheck / lint / build / 650 unit tests
- [x] **Device:** two-finger drag doesn't hurl the globe; second finger ignored
- [ ] **Device:** finger down, then open sheet to full → globe doesn't drift
- [x] **Device:** edge double-tap during an in-flight settle → globe lands on a country, never strands mid-ocean
- [ ] **Device:** first-ever gesture is an edge double-tap → globe doesn't glide to null-island

Refs #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch gesture handling to prevent unintended interference from simultaneous touches.
  * Fixed camera settling and skip behavior during interrupted glide animations.
  * Improved consistency when detecting when the camera has reached its final position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->