### PR TITLE
refactor(globe): extract the spin gesture machine into a pure reducer

### DIFF
--- a/src/components/globe/spin-gesture.test.ts
+++ b/src/components/globe/spin-gesture.test.ts
@@ -400,6 +400,23 @@ test("a settle converges to idle once the camera sits on the target", () => {
   expect(state.mode).toBe("idle");
 });
 
+test("a settle step clamps elevation to the pole guard despite outward velocity", () => {
+  const EL_LIMIT = 75 * DEG;
+  const settling: GestureState = {
+    ...initGestureState(START),
+    mode: "settle",
+    az: azOf(START),
+    el: EL_LIMIT,
+    settleAz: azOf(START),
+    settleEl: elOf(START), // a real target, safely below the guard
+    vAz: 0,
+    vEl: 10, // strong outward velocity carried from a fling
+  };
+  const { state } = run(settling, [{ type: "frame", dt: 0.016, rng: half }]);
+
+  expect(state.el).toBeLessThanOrEqual(EL_LIMIT);
+});
+
 test("reduced motion cuts straight to the target with no settle glide", () => {
   const { state } = run(
     initGestureState(START),

--- a/src/components/globe/spin-gesture.test.ts
+++ b/src/components/globe/spin-gesture.test.ts
@@ -212,6 +212,40 @@ test("an ocean tap re-centres the current country instead of jumping away", () =
   });
 });
 
+test("a tap landing during an in-flight settle redirects to the tapped country", () => {
+  const settling: GestureState = {
+    ...initGestureState(START),
+    mode: "settle",
+    az: azOf("ca"),
+    el: elOf("ca"),
+    settleAz: azOf("ca"),
+    settleEl: elOf("ca"),
+  };
+  // The press freezes the glide to "drag"; the release taps a new country, so
+  // runSelect's mode-"settle" guard is past and the settle redirects.
+  const { state, commands } = run(settling, [
+    down(1, 100, 100),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 100,
+      y: 100,
+      t: 5,
+      region: "center",
+      hitCode: "mx",
+      listening: true,
+    },
+  ]);
+
+  expect(state.settleAz).toBeCloseTo(azOf("mx"));
+  expect(commands).toContainEqual({
+    kind: "settle",
+    code: "mx",
+    changed: true,
+    viaTap: true,
+  });
+});
+
 test("a first side-third tap while listening defers its select", () => {
   const { state, commands } = run(initGestureState(START), [
     down(1, 20, 100),
@@ -278,6 +312,22 @@ test("pointerCancel snaps to a country so it never rests on open ocean", () => {
 
   expect(commands.some((c) => c.kind === "settle")).toBe(true);
   expect(commands).toContainEqual({ kind: "releasePointer", id: 1 });
+});
+
+test("pointerCancel wipes an armed deferred select as it snaps", () => {
+  const armedDrag: GestureState = {
+    ...initGestureState(START),
+    mode: "drag",
+    activePointerId: 1,
+    lastEdgeTapAt: 100,
+    pendingSelectCode: "ca",
+  };
+  const { state, commands } = run(armedDrag, [
+    { type: "pointerCancel", id: 1, rng: half },
+  ]);
+
+  expect(commands).toContainEqual({ kind: "clearDefer" });
+  expect(state.lastEdgeTapAt).toBeNull();
 });
 
 test("externalSelect settles to a new ?cc= country", () => {
@@ -373,10 +423,9 @@ test("reduced motion cuts straight to the target with no settle glide", () => {
   expect(state.az).toBeCloseTo(azOf("ca"));
 });
 
-// The skip-during-settle resume (spin-gesture.ts TODO(human)). A second
-// side-third tap within the window is a skip: it moves no globe of its own, but
-// the press that began it froze whatever settle was gliding. These two lock the
-// judgment the resume must make.
+// The skip-during-settle resume. A second side-third tap within the window is a
+// skip: it moves no globe of its own, but the press that began it froze whatever
+// settle was gliding. These two lock the judgment the resume must make.
 
 test("a skip signals its direction and drops the pending select", () => {
   const armed: GestureState = {

--- a/src/components/globe/spin-gesture.test.ts
+++ b/src/components/globe/spin-gesture.test.ts
@@ -1,0 +1,463 @@
+import { expect, test } from "vitest";
+
+import { COUNTRIES } from "@/lib/countries";
+
+import {
+  DOUBLE_TAP_MS,
+  SELECT_DEFER_MS,
+  type GestureConfig,
+  type GestureEvent,
+  type GestureState,
+  initGestureState,
+  reduce,
+} from "./spin-gesture";
+
+const DEG = Math.PI / 180;
+const START = "us";
+const country = (code: string) => COUNTRIES.find((c) => c.code === code)!;
+const azOf = (code: string) => country(code).lon * DEG;
+const elOf = (code: string) => country(code).lat * DEG;
+
+const CFG: GestureConfig = {
+  sensitivity: 1,
+  friction: 4,
+  horizontalLock: false,
+  bounce: 0,
+  fair: false,
+  visited: new Set(),
+  reducedMotion: false,
+  readMode: false,
+};
+
+const cfg = (over: Partial<GestureConfig> = {}): GestureConfig => ({
+  ...CFG,
+  ...over,
+});
+
+const half = () => 0.5; // deterministic rng stub for the snap draw
+
+// Fold a sequence of events through the reducer, returning the final state and
+// every command emitted along the way.
+function run(
+  state: GestureState,
+  events: GestureEvent[],
+  config: GestureConfig = CFG,
+) {
+  let s = state;
+  const commands = [];
+  for (const event of events) {
+    const result = reduce(s, event, config);
+    s = result.state;
+    commands.push(...result.commands);
+  }
+  return { state: s, commands };
+}
+
+const down = (id: number, x: number, y: number, t = 0): GestureEvent => ({
+  type: "pointerDown",
+  id,
+  x,
+  y,
+  t,
+});
+
+test("initGestureState seeds settle targets onto the resting country", () => {
+  const s = initGestureState(START);
+
+  expect(s.mode).toBe("idle");
+  expect(s.az).toBeCloseTo(azOf(START));
+  expect(s.settleAz).toBeCloseTo(s.az);
+  expect(s.settleEl).toBeCloseTo(s.el);
+  expect(s.settledCode).toBe(START);
+});
+
+test("pointerDown starts a drag and captures the pointer", () => {
+  const { state, commands } = run(initGestureState(START), [down(1, 100, 100)]);
+
+  expect(state.mode).toBe("drag");
+  expect(state.activePointerId).toBe(1);
+  expect(commands).toContainEqual({ kind: "capturePointer", id: 1 });
+  expect(commands).toContainEqual({ kind: "clearDefer" });
+});
+
+test("pointerDown is ignored in read mode so reading never grabs the globe", () => {
+  const { state, commands } = run(
+    initGestureState(START),
+    [down(1, 100, 100)],
+    cfg({ readMode: true }),
+  );
+
+  expect(state.activePointerId).toBeNull();
+  expect(state.mode).toBe("idle");
+  expect(commands).toEqual([]);
+});
+
+test("a second pointerDown is ignored while one gesture owns the drag", () => {
+  const { state } = run(initGestureState(START), [
+    down(1, 100, 100),
+    down(2, 300, 100),
+  ]);
+
+  expect(state.activePointerId).toBe(1);
+});
+
+test("pointerMove rotates azimuth opposite the drag, scaled by sensitivity", () => {
+  const start = initGestureState(START);
+  const { state } = run(start, [
+    down(1, 100, 100),
+    { type: "pointerMove", id: 1, x: 120, y: 100, t: 16 },
+  ]);
+
+  // dx = 20, gain = 0.005 * 1, so az moves by -0.1 rad.
+  expect(state.az).toBeCloseTo(start.az - 20 * 0.005);
+});
+
+test("pointerMove from a non-owning pointer neither steers nor ends the drag", () => {
+  const start = initGestureState(START);
+  const { state } = run(start, [
+    down(1, 100, 100),
+    { type: "pointerMove", id: 2, x: 400, y: 100, t: 16 },
+  ]);
+
+  expect(state.az).toBeCloseTo(start.az);
+  expect(state.activePointerId).toBe(1);
+});
+
+test("read mode flipping on mid-drag rebaselines the pointer without rotating", () => {
+  // pointerDown is refused in read mode, so the rebaseline path only matters
+  // when a drag already owns the pointer and read mode flips on under it.
+  const dragging: GestureState = {
+    ...initGestureState(START),
+    mode: "drag",
+    activePointerId: 1,
+    lastX: 100,
+    lastY: 100,
+  };
+  const { state } = run(
+    dragging,
+    [{ type: "pointerMove", id: 1, x: 120, y: 100, t: 16 }],
+    cfg({ readMode: true }),
+  );
+
+  expect(state.az).toBeCloseTo(dragging.az);
+  expect(state.lastX).toBe(120);
+});
+
+test("a moved release flings with velocity from the flick, not a tap select", () => {
+  const { state, commands } = run(initGestureState(START), [
+    down(1, 100, 100),
+    { type: "pointerMove", id: 1, x: 140, y: 100, t: 10 },
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 140,
+      y: 100,
+      t: 10,
+      region: "center",
+      hitCode: "ca",
+      listening: false,
+    },
+  ]);
+
+  expect(state.mode).toBe("fling");
+  expect(state.activePointerId).toBeNull();
+  expect(commands.some((c) => c.kind === "settle")).toBe(false);
+});
+
+test("a center tap selects the hit country and settles to it", () => {
+  const { state, commands } = run(initGestureState(START), [
+    down(1, 100, 100),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 100,
+      y: 100,
+      t: 5,
+      region: "center",
+      hitCode: "ca",
+      listening: true,
+    },
+  ]);
+
+  expect(state.mode).toBe("settle");
+  expect(state.settleAz).toBeCloseTo(azOf("ca"));
+  expect(commands).toContainEqual({
+    kind: "settle",
+    code: "ca",
+    changed: true,
+    viaTap: true,
+  });
+});
+
+test("an ocean tap re-centres the current country instead of jumping away", () => {
+  const { commands } = run(initGestureState(START), [
+    down(1, 100, 100),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 100,
+      y: 100,
+      t: 5,
+      region: "center",
+      hitCode: null,
+      listening: true,
+    },
+  ]);
+
+  expect(commands).toContainEqual({
+    kind: "settle",
+    code: START,
+    changed: false,
+    viaTap: true,
+  });
+});
+
+test("a first side-third tap while listening defers its select", () => {
+  const { state, commands } = run(initGestureState(START), [
+    down(1, 20, 100),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 5,
+      region: "left",
+      hitCode: "ca",
+      listening: true,
+    },
+  ]);
+
+  expect(state.lastEdgeTapAt).toBe(5);
+  expect(state.pendingSelectCode).toBe("ca");
+  expect(commands).toContainEqual({
+    kind: "armDefer",
+    delayMs: SELECT_DEFER_MS,
+  });
+  expect(commands.some((c) => c.kind === "settle")).toBe(false);
+});
+
+test("a fired deferred timer selects the pending country", () => {
+  const armed: GestureState = {
+    ...initGestureState(START),
+    mode: "drag",
+    pendingSelectCode: "ca",
+  };
+  const { commands } = run(armed, [{ type: "deferFire" }]);
+
+  expect(commands).toContainEqual({
+    kind: "settle",
+    code: "ca",
+    changed: true,
+    viaTap: true,
+  });
+});
+
+test("a fired deferred timer bails when an external pick already settled", () => {
+  const armed: GestureState = {
+    ...initGestureState(START),
+    mode: "settle",
+    pendingSelectCode: "ca",
+  };
+  const { commands } = run(armed, [{ type: "deferFire" }]);
+
+  expect(commands.some((c) => c.kind === "settle")).toBe(false);
+});
+
+test("pointerCancel snaps to a country so it never rests on open ocean", () => {
+  const start = initGestureState(START);
+  const dragging: GestureState = {
+    ...start,
+    mode: "drag",
+    activePointerId: 1,
+  };
+  const { commands } = run(
+    dragging,
+    [{ type: "pointerCancel", id: 1, rng: half }],
+    CFG,
+  );
+
+  expect(commands.some((c) => c.kind === "settle")).toBe(true);
+  expect(commands).toContainEqual({ kind: "releasePointer", id: 1 });
+});
+
+test("externalSelect settles to a new ?cc= country", () => {
+  const { state, commands } = run(initGestureState(START), [
+    { type: "externalSelect", code: "mx" },
+  ]);
+
+  expect(state.settleAz).toBeCloseTo(azOf("mx"));
+  expect(commands).toContainEqual({
+    kind: "settle",
+    code: "mx",
+    changed: true,
+    viaTap: false,
+  });
+});
+
+test("externalSelect no-ops when the target already matches the landing", () => {
+  const { commands } = run(initGestureState(START), [
+    { type: "externalSelect", code: START },
+  ]);
+
+  expect(commands).toEqual([]);
+});
+
+test("a fling hands off to the snap spring once it slows below threshold", () => {
+  const slow: GestureState = {
+    ...initGestureState(START),
+    mode: "fling",
+    vAz: 1, // below SETTLE_VEL = 2
+    vEl: 0,
+  };
+  const { commands } = run(
+    slow,
+    [{ type: "frame", dt: 0.016, rng: half }],
+    CFG,
+  );
+
+  expect(commands.some((c) => c.kind === "settle")).toBe(true);
+});
+
+test("a frame in read mode parks an in-flight fling instead of drifting", () => {
+  const flinging: GestureState = {
+    ...initGestureState(START),
+    mode: "fling",
+    vAz: 5,
+  };
+  const { state } = run(
+    flinging,
+    [{ type: "frame", dt: 0.016, rng: half }],
+    cfg({ readMode: true }),
+  );
+
+  expect(state.mode).toBe("idle");
+  expect(state.vAz).toBe(0);
+});
+
+test("a settle converges to idle once the camera sits on the target", () => {
+  const settling: GestureState = {
+    ...initGestureState(START),
+    mode: "settle",
+    az: azOf("ca"),
+    el: elOf("ca"),
+    settleAz: azOf("ca"),
+    settleEl: elOf("ca"),
+    vAz: 0,
+    vEl: 0,
+  };
+  const { state } = run(settling, [{ type: "frame", dt: 0.016, rng: half }]);
+
+  expect(state.mode).toBe("idle");
+});
+
+test("reduced motion cuts straight to the target with no settle glide", () => {
+  const { state } = run(
+    initGestureState(START),
+    [
+      down(1, 100, 100),
+      {
+        type: "pointerUp",
+        id: 1,
+        x: 100,
+        y: 100,
+        t: 5,
+        region: "center",
+        hitCode: "ca",
+        listening: true,
+      },
+    ],
+    cfg({ reducedMotion: true }),
+  );
+
+  expect(state.mode).toBe("idle");
+  expect(state.az).toBeCloseTo(azOf("ca"));
+});
+
+// The skip-during-settle resume (spin-gesture.ts TODO(human)). A second
+// side-third tap within the window is a skip: it moves no globe of its own, but
+// the press that began it froze whatever settle was gliding. These two lock the
+// judgment the resume must make.
+
+test("a skip signals its direction and drops the pending select", () => {
+  const armed: GestureState = {
+    ...initGestureState(START),
+    mode: "drag",
+    activePointerId: 1,
+    lastEdgeTapAt: 100,
+    downX: 20,
+    downY: 100,
+  };
+  const { commands } = run(armed, [
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 100 + DOUBLE_TAP_MS - 1,
+      region: "left",
+      hitCode: "ca",
+      listening: true,
+    },
+  ]);
+
+  expect(commands).toContainEqual({ kind: "signalSkip", dir: -1 });
+  expect(commands).toContainEqual({ kind: "clearDefer" });
+});
+
+test("a skip mid-glide resumes the interrupted settle, never stranding the globe", () => {
+  const interrupted: GestureState = {
+    ...initGestureState(START),
+    mode: "drag",
+    activePointerId: 1,
+    lastEdgeTapAt: 100,
+    downX: 20,
+    downY: 100,
+    az: azOf("ca"),
+    el: elOf("ca"),
+    settleAz: azOf("mx"), // targets still hold the intended landing
+    settleEl: elOf("mx"),
+  };
+  const { state } = run(interrupted, [
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 100 + DOUBLE_TAP_MS - 1,
+      region: "left",
+      hitCode: null,
+      listening: true,
+    },
+  ]);
+
+  expect(state.mode).toBe("settle");
+});
+
+test("a skip at rest returns to idle rather than re-running a finished settle", () => {
+  const atRest: GestureState = {
+    ...initGestureState(START),
+    mode: "drag",
+    activePointerId: 1,
+    lastEdgeTapAt: 100,
+    downX: 20,
+    downY: 100,
+    az: azOf("ca"),
+    el: elOf("ca"),
+    settleAz: azOf("ca"),
+    settleEl: elOf("ca"),
+  };
+  const { state } = run(atRest, [
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 100 + DOUBLE_TAP_MS - 1,
+      region: "left",
+      hitCode: null,
+      listening: true,
+    },
+  ]);
+
+  expect(state.mode).toBe("idle");
+});

--- a/src/components/globe/spin-gesture.ts
+++ b/src/components/globe/spin-gesture.ts
@@ -1,0 +1,459 @@
+import { COUNTRIES } from "@/lib/countries";
+
+import { flickToSpin } from "./spin-feel";
+import { pickSnapCountry } from "./spin-select";
+import { type HorizontalThird, classifyTap, isTap } from "./tap-detect";
+
+// The gesture state machine for the spun globe, as a pure reducer. Every drag,
+// fling, settle, tap, skip, and interruption transition lives here so the
+// interruption matrix (tap-during-settle, skip-during-settle, cancel-during-
+// defer, pointer arbitration) is table-testable instead of reasoned by hand in
+// event-handler closures. The React shell (`spin-snap-controls.tsx`) owns only
+// the impure edges: it translates DOM pointer events into the events below,
+// runs the returned commands, and draws the camera from the returned state.
+//
+// Purity contract: `reduce` never touches the DOM, the camera, timers, the
+// chart store, or `Math.random`. Anything impure enters as event payload the
+// shell resolves first (the tap's `region` and `hitCode`, the snap draw's
+// `rng`) or leaves as a command the shell runs (`settle`, `signalSkip`,
+// `armDefer`, `clearDefer`, `capturePointer`, `releasePointer`).
+
+const DEG = Math.PI / 180;
+const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slider
+const EL_LIMIT = 75 * DEG; // stop short of the poles so the view never flips
+const SETTLE_VEL = 2; // rad/s under which a fling hands off to the snap spring
+const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
+// rad/s ceiling on a settle. A far external pick (shuffle / a11y list) would
+// otherwise ride the spring's amplitude-scaled peak velocity and strobe across
+// the globe; the cap turns that into a steady glide. Small post-fling snaps
+// stay under it, so their feel is untouched.
+const MAX_SETTLE_VEL = 7;
+const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
+export const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips
+// Deferred-select delay: waits past the double-tap window (longer than
+// DOUBLE_TAP_MS) so main-thread jank can't fire the select before a second
+// tap's pointerup and misclassify a skip as a select.
+export const SELECT_DEFER_MS = 360;
+// Angular tolerance (rad) for "the camera sits on the settle target": ends a
+// settle, and tells a skip whether a settle was interrupted mid-glide.
+const SETTLE_EPS = 0.002;
+
+const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, v));
+
+// Shortest signed angle to rotate `from` onto `to`, so settling never unwinds
+// the long way around the globe.
+const shortestAngle = (delta: number) =>
+  Math.atan2(Math.sin(delta), Math.cos(delta));
+
+export type GestureMode = "idle" | "drag" | "fling" | "settle";
+
+// The whole gesture machine as plain data: camera orientation and velocity, the
+// live mode, the settle targets and last-landed country, the one pointer that
+// owns the active gesture, the press/last-sample bookkeeping that anchors
+// tap-vs-spin and release velocity, the double-tap arm window, and the country a
+// deferred edge-tap select will land on when its timer fires.
+export interface GestureState {
+  az: number;
+  el: number;
+  vAz: number;
+  vEl: number;
+  mode: GestureMode;
+  settleAz: number;
+  settleEl: number;
+  settledCode: string;
+  // The pointer owning the active gesture, or null when none does.
+  // touchAction:"none" routes every touch to one element, so a second finger's
+  // move/up must not steer or end the first finger's drag.
+  activePointerId: number | null;
+  downX: number;
+  downY: number;
+  lastX: number;
+  lastY: number;
+  lastT: number;
+  vx: number;
+  vy: number;
+  // Time of the prior deferred side-third tap, or null. Arms the double-tap
+  // window: a second side tap within DOUBLE_TAP_MS turns the pair into a skip.
+  lastEdgeTapAt: number | null;
+  // Country a pending deferred-select timer will land on when it fires.
+  pendingSelectCode: string | null;
+}
+
+// Config the shell feeds in with each event: the live slider/prop snapshot the
+// old handler read from `cfg.current`. Passed per-call so the reducer stays a
+// pure function of (state, event, cfg) with no captured mutable refs.
+export interface GestureConfig {
+  sensitivity: number;
+  friction: number;
+  horizontalLock: boolean;
+  bounce: number;
+  fair: boolean;
+  visited: ReadonlySet<string>;
+  reducedMotion: boolean;
+  readMode: boolean;
+}
+
+export type GestureEvent =
+  | { type: "pointerDown"; id: number; x: number; y: number; t: number }
+  | { type: "pointerMove"; id: number; x: number; y: number; t: number }
+  | {
+      type: "pointerUp";
+      id: number;
+      x: number;
+      y: number;
+      t: number;
+      // Which horizontal third the release fell in (shell reads the rect).
+      region: HorizontalThird;
+      // Nearest front-facing country to the tap, or null on an ocean tap (shell
+      // projects the camera). Only consulted when the release classifies a tap.
+      hitCode: string | null;
+      listening: boolean;
+    }
+  | { type: "pointerCancel"; id: number; rng: () => number }
+  // A deferred edge-tap select timer fired.
+  | { type: "deferFire" }
+  // ?cc= changed: the a11y country list or a shared link drives the globe.
+  | { type: "externalSelect"; code: string | null }
+  | { type: "frame"; dt: number; rng: () => number };
+
+// Impure work the shell runs after each reduce. The reducer names the effect;
+// the shell owns how it reaches the DOM, timers, and chart store.
+export type GestureCommand =
+  | { kind: "settle"; code: string; changed: boolean; viaTap: boolean }
+  | { kind: "signalSkip"; dir: 1 | -1 }
+  | { kind: "armDefer"; delayMs: number }
+  | { kind: "clearDefer" }
+  | { kind: "capturePointer"; id: number }
+  | { kind: "releasePointer"; id: number };
+
+export interface ReduceResult {
+  state: GestureState;
+  commands: GestureCommand[];
+}
+
+// Resting state seeded to a country. The settle targets start on the resting
+// position so "az/el are at the settle targets" reads true from the first
+// frame; the skip-during-settle resume relies on that to tell a stranded glide
+// from rest.
+export function initGestureState(code: string): GestureState {
+  const start = COUNTRY_BY_CODE.get(code);
+  const startAz = start ? start.lon * DEG : 0;
+  const startEl = start ? start.lat * DEG : 0;
+  return {
+    az: startAz,
+    el: startEl,
+    vAz: 0,
+    vEl: 0,
+    mode: "idle",
+    settleAz: startAz,
+    settleEl: startEl,
+    settledCode: code,
+    activePointerId: null,
+    downX: 0,
+    downY: 0,
+    lastX: 0,
+    lastY: 0,
+    lastT: 0,
+    vx: 0,
+    vy: 0,
+    lastEdgeTapAt: null,
+    pendingSelectCode: null,
+  };
+}
+
+const owns = (s: GestureState, id: number) => s.activePointerId === id;
+
+// Aim at a country: record the landing, notify via a `settle` command no matter
+// how we got here (fling, tap, external ?cc=), then either cut instantly
+// (reduced motion) or hand off to the snap spring the `frame` event runs.
+// Mutates the draft `s` and appends to `commands`; both are call-local copies,
+// so `reduce` stays pure. A null/unknown code just parks at idle.
+function settleTo(
+  s: GestureState,
+  commands: GestureCommand[],
+  cfg: GestureConfig,
+  code: string | null,
+  viaTap = false,
+): void {
+  const country = code ? COUNTRY_BY_CODE.get(code) : null;
+  if (!country) {
+    s.mode = "idle";
+    return;
+  }
+  s.settleAz = country.lon * DEG;
+  s.settleEl = country.lat * DEG;
+  // Notify on every settle, even re-landing the same country, so the chart
+  // resurfaces and the tour re-arms its hint; `changed` lets the shell gate the
+  // country-change side effects (?cc=, visited, haptic).
+  const changed = s.settledCode !== country.code;
+  s.settledCode = country.code;
+  commands.push({
+    kind: "settle",
+    code: country.code,
+    changed,
+    viaTap,
+  });
+
+  if (cfg.reducedMotion) {
+    // Instant cut: jump to the spring's end state so the next draw shows the
+    // target country with no in-between frames.
+    s.az = s.settleAz;
+    s.el = s.settleEl;
+    s.vAz = 0;
+    s.vEl = 0;
+    s.mode = "idle";
+  } else {
+    s.mode = "settle";
+  }
+}
+
+// Select the tapped country, re-centring the current one on an ocean miss so a
+// tap never jumps away. Shared by the immediate-select path and the deferred
+// timer; bails when the situation changed while a deferred select was armed —
+// read mode forbids moving the globe under the reader, and mode "settle" means
+// an external ?cc= already landed during the window.
+function runSelect(
+  s: GestureState,
+  commands: GestureCommand[],
+  cfg: GestureConfig,
+  code: string | null,
+): void {
+  if (cfg.readMode || s.mode === "settle") return;
+  s.lastEdgeTapAt = null;
+  // viaTap: a bare tap-select, so the tour's gesture beat can ignore it rather
+  // than treat an accidental tap as the flick it teaches.
+  settleTo(s, commands, cfg, code ?? s.settledCode, true);
+}
+
+export function reduce(
+  state: GestureState,
+  event: GestureEvent,
+  cfg: GestureConfig,
+): ReduceResult {
+  const s = { ...state };
+  const commands: GestureCommand[] = [];
+
+  switch (event.type) {
+    case "pointerDown": {
+      // Read mode covers the globe; ignore presses so reading never grabs it.
+      if (cfg.readMode) break;
+      // A gesture already owns a pointer: ignore a second finger rather than let
+      // it reset the drag anchor and hurl the globe on the next move.
+      if (s.activePointerId !== null) break;
+      // Cancel a deferred edge-tap select so it can't fire mid-gesture; the
+      // armed window survives this press so a second tap can still skip.
+      commands.push({ kind: "clearDefer" });
+      s.mode = "drag";
+      s.vAz = 0;
+      s.vEl = 0;
+      s.activePointerId = event.id;
+      s.downX = event.x;
+      s.downY = event.y;
+      s.lastX = event.x;
+      s.lastY = event.y;
+      s.lastT = event.t;
+      s.vx = 0;
+      s.vy = 0;
+      commands.push({ kind: "capturePointer", id: event.id });
+      break;
+    }
+
+    case "pointerMove": {
+      if (s.activePointerId === null || !owns(s, event.id)) break;
+      // Read mode can flip on mid-drag; a move writes az directly, bypassing the
+      // frame suspend, so don't rotate. Keep the pointer baseline current so a
+      // flip back off doesn't read the whole gap as one jump.
+      if (cfg.readMode) {
+        s.lastX = event.x;
+        s.lastY = event.y;
+        s.lastT = event.t;
+        break;
+      }
+      const dx = event.x - s.lastX;
+      const dy = event.y - s.lastY;
+      const dt = Math.max(1, event.t - s.lastT);
+      const gain = DRAG_RAD_PER_PX * cfg.sensitivity;
+      s.az -= dx * gain;
+      if (!cfg.horizontalLock) {
+        s.el = clamp(s.el + dy * gain, -EL_LIMIT, EL_LIMIT);
+      }
+      s.vx = dx / dt;
+      s.vy = dy / dt;
+      s.lastX = event.x;
+      s.lastY = event.y;
+      s.lastT = event.t;
+      break;
+    }
+
+    case "pointerUp": {
+      if (s.activePointerId === null || !owns(s, event.id)) break;
+      s.activePointerId = null;
+      commands.push({ kind: "releasePointer", id: event.id });
+
+      if (
+        isTap(
+          { x: s.downX, y: s.downY },
+          { x: event.x, y: event.y },
+          TAP_MAX_PX,
+        )
+      ) {
+        const action = classifyTap({
+          listening: event.listening,
+          region: event.region,
+          now: event.t,
+          lastEdgeTapAt: s.lastEdgeTapAt,
+          windowMs: DOUBLE_TAP_MS,
+        });
+
+        if (action.kind === "skip") {
+          // A second side-third tap within the window: drop the first tap's
+          // pending select and skip instead. A skip moves no globe of its own.
+          commands.push({ kind: "clearDefer" });
+          s.lastEdgeTapAt = null;
+          // The press that began this tap froze any in-flight settle by setting
+          // mode to "drag" (see pointerDown). At rest az/el already sit on the
+          // targets, so return to idle; otherwise a settle was interrupted mid-
+          // glide and its targets still hold the intended landing, so resume it
+          // rather than strand the globe mid-flight, possibly on open ocean.
+          const atTarget =
+            Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
+            Math.abs(s.settleEl - s.el) < SETTLE_EPS;
+          s.mode = atTarget ? "idle" : "settle";
+          commands.push({ kind: "signalSkip", dir: action.dir });
+          break;
+        }
+
+        if (action.kind === "deferSelect") {
+          // First side-third tap while listening: defer the select past the
+          // double-tap window so a second tap can turn it into a skip; select if
+          // none comes. Coordinates are already resolved into hitCode, so the
+          // deferred run still aims at the tap point.
+          commands.push({ kind: "clearDefer" });
+          s.lastEdgeTapAt = event.t;
+          s.pendingSelectCode = event.hitCode ?? s.settledCode;
+          commands.push({ kind: "armDefer", delayMs: SELECT_DEFER_MS });
+          break;
+        }
+
+        // Center third or no preview: a double-tap has no skip meaning, so
+        // select with no delay and arm no window.
+        runSelect(s, commands, cfg, event.hitCode ?? s.settledCode);
+        break;
+      }
+
+      // A fling is a fresh intent: drop any armed double-tap window.
+      s.lastEdgeTapAt = null;
+      s.vAz = -flickToSpin(s.vx) * cfg.sensitivity;
+      s.vEl = cfg.horizontalLock ? 0 : flickToSpin(s.vy) * cfg.sensitivity;
+      s.mode = "fling";
+      break;
+    }
+
+    case "deferFire": {
+      runSelect(s, commands, cfg, s.pendingSelectCode ?? s.settledCode);
+      break;
+    }
+
+    case "pointerCancel": {
+      // An interrupted touch (system gesture, multi-touch) fires pointercancel,
+      // not pointerup. Snap to the nearest country so it still never rests on
+      // open ocean, and end any armed double-tap window.
+      if (s.activePointerId === null || !owns(s, event.id)) break;
+      s.activePointerId = null;
+      commands.push({ kind: "releasePointer", id: event.id });
+      commands.push({ kind: "clearDefer" });
+      s.lastEdgeTapAt = null;
+      settleTo(
+        s,
+        commands,
+        cfg,
+        pickSnapCountry(s.el, s.az, cfg.visited, cfg.fair, event.rng),
+      );
+      break;
+    }
+
+    case "externalSelect": {
+      // Follow ?cc=: settle to it like a gesture would when we aren't there. A
+      // gesture's own settle wrote ?cc= first, so code === settledCode by the
+      // time this runs and it no-ops — no feedback loop. Cancel any armed
+      // edge-tap select so a following tap isn't misread as a second tap.
+      if (event.code && event.code !== s.settledCode) {
+        commands.push({ kind: "clearDefer" });
+        s.lastEdgeTapAt = null;
+        settleTo(s, commands, cfg, event.code);
+      }
+      break;
+    }
+
+    case "frame": {
+      const dt = event.dt;
+      // Read mode (sheet at full) hides the globe. Suspend the sim so a leftover
+      // fling can't drift and settle a new country under the reader. Park an
+      // in-flight fling outright (drop its momentum so it doesn't resume on
+      // collapse), but leave a settle alone: a settle is an intentional landing
+      // (a gesture, or an external ?cc= pick), so let it resume and land when
+      // the sheet collapses. A fling can't reach settle while reading, so
+      // mode === "settle" here is always a real selection, never stray momentum.
+      if (cfg.readMode) {
+        if (s.mode === "fling") {
+          s.vAz = 0;
+          s.vEl = 0;
+          s.mode = "idle";
+        }
+        break;
+      }
+
+      if (s.mode === "fling") {
+        s.az += s.vAz * dt;
+        s.el = clamp(s.el + s.vEl * dt, -EL_LIMIT, EL_LIMIT);
+        const decay = Math.exp(-cfg.friction * dt);
+        s.vAz *= decay;
+        s.vEl *= decay;
+        if (Math.hypot(s.vAz, s.vEl) < SETTLE_VEL) {
+          settleTo(
+            s,
+            commands,
+            cfg,
+            pickSnapCountry(s.el, s.az, cfg.visited, cfg.fair, event.rng),
+          );
+        }
+      } else if (s.mode === "settle") {
+        // Under-damped spring: the view glides past the target country and
+        // springs back. Bounce lowers the damping ratio for more overshoot.
+        const dtc = Math.min(dt, 0.05);
+        const zeta = clamp(1 - 0.7 * cfg.bounce, 0.2, 1);
+        const dAz = shortestAngle(s.settleAz - s.az);
+        const dEl = s.settleEl - s.el;
+        s.vAz +=
+          (SNAP_OMEGA * SNAP_OMEGA * dAz - 2 * zeta * SNAP_OMEGA * s.vAz) * dtc;
+        s.vEl +=
+          (SNAP_OMEGA * SNAP_OMEGA * dEl - 2 * zeta * SNAP_OMEGA * s.vEl) * dtc;
+        const speed = Math.hypot(s.vAz, s.vEl);
+        if (speed > MAX_SETTLE_VEL) {
+          const k = MAX_SETTLE_VEL / speed;
+          s.vAz *= k;
+          s.vEl *= k;
+        }
+        s.az += s.vAz * dtc;
+        s.el += s.vEl * dtc;
+        if (
+          Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
+          Math.abs(s.settleEl - s.el) < SETTLE_EPS &&
+          Math.hypot(s.vAz, s.vEl) < 0.02
+        ) {
+          s.az = s.settleAz;
+          s.el = s.settleEl;
+          s.vAz = 0;
+          s.vEl = 0;
+          s.mode = "idle";
+        }
+      }
+      break;
+    }
+  }
+
+  return { state: s, commands };
+}

--- a/src/components/globe/spin-gesture.ts
+++ b/src/components/globe/spin-gesture.ts
@@ -212,7 +212,7 @@ function settleTo(
 
 // Select the tapped country, re-centring the current one on an ocean miss so a
 // tap never jumps away. Shared by the immediate-select path and the deferred
-// timer; bails when the situation changed while a deferred select was armed —
+// timer; bails when the situation changed while a deferred select was armed:
 // read mode forbids moving the globe under the reader, and mode "settle" means
 // an external ?cc= already landed during the window.
 function runSelect(
@@ -378,7 +378,7 @@ export function reduce(
     case "externalSelect": {
       // Follow ?cc=: settle to it like a gesture would when we aren't there. A
       // gesture's own settle wrote ?cc= first, so code === settledCode by the
-      // time this runs and it no-ops — no feedback loop. Cancel any armed
+      // time this runs and it no-ops, no feedback loop. Cancel any armed
       // edge-tap select so a following tap isn't misread as a second tap.
       if (event.code && event.code !== s.settledCode) {
         commands.push({ kind: "clearDefer" });

--- a/src/components/globe/spin-gesture.ts
+++ b/src/components/globe/spin-gesture.ts
@@ -438,7 +438,10 @@ export function reduce(
           s.vEl *= k;
         }
         s.az += s.vAz * dtc;
-        s.el += s.vEl * dtc;
+        // Clamp like the fling branch: residual velocity or a high-bounce
+        // overshoot toward a near-limit latitude can step el past the pole
+        // guard for a frame even though every settle target sits below it.
+        s.el = clamp(s.el + s.vEl * dtc, -EL_LIMIT, EL_LIMIT);
         if (
           Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
           Math.abs(s.settleEl - s.el) < SETTLE_EPS &&

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -3,48 +3,21 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 
-import { COUNTRIES } from "@/lib/countries";
 import { globeChartStore } from "@/lib/globe-chart-store";
 
-import { flickToSpin } from "./spin-feel";
 import {
-  pickNearestToPoint,
-  pickSnapCountry,
-  projectFrontCountries,
-} from "./spin-select";
-import { classifyTap, horizontalThird, isTap } from "./tap-detect";
+  type GestureCommand,
+  type GestureConfig,
+  type GestureEvent,
+  type GestureState,
+  initGestureState,
+  reduce,
+} from "./spin-gesture";
+import { pickNearestToPoint, projectFrontCountries } from "./spin-select";
+import { horizontalThird } from "./tap-detect";
 
-const DEG = Math.PI / 180;
 const RADIUS = 3.5;
-const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slider
-const EL_LIMIT = 75 * DEG; // stop short of the poles so the view never flips
-const SETTLE_VEL = 2; // rad/s under which a fling hands off to the snap spring
-const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
-// rad/s ceiling on a settle. A far external pick (shuffle / a11y list) would
-// otherwise ride the spring's amplitude-scaled peak velocity and strobe across
-// the globe; the cap turns that into a steady glide. Small post-fling snaps
-// stay under it, so their feel is untouched.
-const MAX_SETTLE_VEL = 7;
-const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
 const TAP_HIT_PX = 44; // a tap beyond this from every country pin selects nothing
-const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips
-// Deferred-select delay: waits past the double-tap window (longer than
-// DOUBLE_TAP_MS) so main-thread jank can't fire the select before a second
-// tap's pointerup and misclassify a skip as a select.
-const SELECT_DEFER_MS = 360;
-// Angular tolerance (rad) for "the camera sits on the settle target": ends a
-// settle, and tells a skip whether a settle was interrupted mid-glide.
-const SETTLE_EPS = 0.002;
-
-const COUNTRY_BY_CODE = new Map(COUNTRIES.map((c) => [c.code, c]));
-
-const clamp = (v: number, lo: number, hi: number) =>
-  Math.max(lo, Math.min(hi, v));
-
-// Shortest signed angle to rotate `from` onto `to`, so settling never unwinds
-// the long way around the globe.
-const shortestAngle = (delta: number) =>
-  Math.atan2(Math.sin(delta), Math.cos(delta));
 
 interface SpinSnapControlsProps {
   initialCode: string;
@@ -70,7 +43,9 @@ interface SpinSnapControlsProps {
 // Drives the camera as a spun globe: drag to rotate, release to fling with
 // momentum, and on coming to rest snap to the nearest country. A tap jumps
 // straight to the nearest country. There is no free-rotate; it never rests on
-// open ocean.
+// open ocean. The gesture machine itself lives in the pure `spin-gesture`
+// reducer; this component owns only the impure edges — DOM pointer events in,
+// commands and the camera draw out.
 export function SpinSnapControls({
   initialCode,
   targetCode,
@@ -87,7 +62,7 @@ export function SpinSnapControls({
   const camera = useThree((s) => s.camera);
   const gl = useThree((s) => s.gl);
 
-  const cfg = useRef({
+  const cfg = useRef<GestureConfig>({
     sensitivity,
     friction,
     horizontalLock,
@@ -99,20 +74,8 @@ export function SpinSnapControls({
   });
   const onSettleRef = useRef(onSettle);
 
-  // A side-third tap while listening defers its select by one double-tap window
-  // so a second tap can cancel it into a skip. These hold that pending timer and
-  // the time of the tap that armed it; cleared on a new press and on unmount.
-  const pendingSelect = useRef<number | null>(null);
-  const lastEdgeTapAt = useRef<number | null>(null);
-
-  // Cancel a pending deferred edge-tap select. Shared by the pointer handlers
-  // and the external-selection effect.
-  const clearPendingSelect = useCallback(() => {
-    if (pendingSelect.current !== null) {
-      window.clearTimeout(pendingSelect.current);
-      pendingSelect.current = null;
-    }
-  }, []);
+  // The pending deferred edge-tap select timer (armDefer/clearDefer commands).
+  const deferTimer = useRef<number | null>(null);
 
   // Keep the long-lived pointer handlers and per-frame loop reading the latest
   // props without re-subscribing. Written in an effect, never during render.
@@ -130,26 +93,7 @@ export function SpinSnapControls({
     onSettleRef.current = onSettle;
   });
 
-  const sim = useRef(
-    (() => {
-      const start = COUNTRY_BY_CODE.get(initialCode);
-      const startAz = start ? start.lon * DEG : 0;
-      const startEl = start ? start.lat * DEG : 0;
-      // Seed the settle targets to the resting position so "az/el are at the
-      // settle targets" reads true from the first frame. The skip-during-settle
-      // resume relies on that invariant to tell a stranded glide from rest.
-      return {
-        az: startAz,
-        el: startEl,
-        vAz: 0,
-        vEl: 0,
-        mode: "idle" as "idle" | "drag" | "fling" | "settle",
-        settleAz: startAz,
-        settleEl: startEl,
-        settledCode: initialCode,
-      };
-    })(),
-  );
+  const sim = useRef<GestureState>(initGestureState(initialCode));
 
   const applyCamera = () => {
     const s = sim.current;
@@ -161,239 +105,117 @@ export function SpinSnapControls({
     camera.lookAt(0, 0, 0);
   };
 
-  // Aim the camera at a country. Records the landing and notifies once via
-  // onSettle no matter how we got here (fling, tap, or an external ?cc=
-  // change), then either cuts instantly (reduced motion) or hands off to the
-  // snap spring in useFrame.
-  const settleTo = (code: string | null, viaTap = false) => {
-    const s = sim.current;
-    const country = code ? COUNTRY_BY_CODE.get(code) : null;
-    if (!country) {
-      s.mode = "idle";
-      return;
-    }
-    s.settleAz = country.lon * DEG;
-    s.settleEl = country.lat * DEG;
-    // Notify on every settle, even re-landing the same country, so the chart
-    // resurfaces and the tour re-arms its hint; the `changed` flag lets the
-    // caller gate the country-change side effects (?cc=, visited, haptic).
-    const changed = s.settledCode !== country.code;
-    s.settledCode = country.code;
-    onSettleRef.current(country.code, changed, viaTap);
+  // Run one command: the impure work the reducer can only name (notify, skip,
+  // arm/clear the deferred-select timer, capture/release the pointer). A fired
+  // timer re-enters the machine via dispatchRef so this stays a stable callback.
+  const dispatchRef = useRef<(event: GestureEvent) => void>(() => {});
+  const runCommand = useCallback(
+    (command: GestureCommand, el: HTMLCanvasElement) => {
+      switch (command.kind) {
+        case "settle":
+          onSettleRef.current(command.code, command.changed, command.viaTap);
+          break;
+        case "signalSkip":
+          globeChartStore.getState().signalSkip(command.dir);
+          break;
+        case "armDefer":
+          if (deferTimer.current !== null)
+            window.clearTimeout(deferTimer.current);
+          deferTimer.current = window.setTimeout(() => {
+            deferTimer.current = null;
+            dispatchRef.current({ type: "deferFire" });
+          }, command.delayMs);
+          break;
+        case "clearDefer":
+          if (deferTimer.current !== null) {
+            window.clearTimeout(deferTimer.current);
+            deferTimer.current = null;
+          }
+          break;
+        case "capturePointer":
+          el.setPointerCapture?.(command.id);
+          break;
+        case "releasePointer":
+          el.releasePointerCapture?.(command.id);
+          break;
+      }
+    },
+    [],
+  );
 
-    if (cfg.current.reducedMotion) {
-      // Instant cut: jump straight to the spring's end state so the next
-      // applyCamera draws the target country with no in-between frames.
-      s.az = s.settleAz;
-      s.el = s.settleEl;
-      s.vAz = 0;
-      s.vEl = 0;
-      s.mode = "idle";
-    } else {
-      s.mode = "settle";
-    }
-  };
+  // Fold an event into the sim, then run its commands.
+  const dispatch = useCallback(
+    (event: GestureEvent) => {
+      const el = gl.domElement;
+      const { state, commands } = reduce(sim.current, event, cfg.current);
+      sim.current = state;
+      for (const command of commands) {
+        runCommand(command, el);
+      }
+    },
+    [gl, runCommand],
+  );
+  useEffect(() => {
+    dispatchRef.current = dispatch;
+  });
 
   // Follow external selection: when ?cc= changes (the a11y country list, a
-  // shared link) and we aren't already there, settle to it like a gesture
-  // would. A gesture's own settle writes ?cc=, so targetCode === settledCode by
-  // the time this runs — it no-ops, no feedback loop.
+  // shared link) settle to it like a gesture would. A gesture's own settle
+  // writes ?cc= first, so the reducer no-ops when it already matches.
   useEffect(() => {
-    if (targetCode && targetCode !== sim.current.settledCode) {
-      // An external ?cc= selection cancels any armed edge-tap select, clearing
-      // both the timer and the arm window (matching onCancel / the skip branch)
-      // so a following tap isn't misread as a double-tap's second tap.
-      clearPendingSelect();
-      lastEdgeTapAt.current = null;
-      settleTo(targetCode);
-    }
-  }, [targetCode, clearPendingSelect]);
+    dispatch({ type: "externalSelect", code: targetCode });
+  }, [targetCode, dispatch]);
 
   useEffect(() => {
     const el = gl.domElement;
 
-    // Gesture tracking held on one mutable object (not reassigned render-scope
-    // locals): press-down point, last pointer position, release velocity, drag
-    // state. The down point anchors tap-vs-spin: we compare it to the release
-    // point, so a jitter that returns near the start stays a tap.
-    const g = {
-      downX: 0,
-      downY: 0,
-      lastX: 0,
-      lastY: 0,
-      lastT: 0,
-      vx: 0,
-      vy: 0,
-      dragging: false,
-      // The one pointer that owns the active gesture. touchAction:"none" routes
-      // every touch here, so a second finger's move/up must not steer or end the
-      // first finger's drag.
-      activePointerId: null as number | null,
-    };
-
     const onDown = (e: PointerEvent) => {
-      // Read mode covers the globe; ignore presses so reading never grabs it.
-      if (cfg.current.readMode) return;
-      // A gesture already owns a pointer: ignore a second finger rather than let
-      // it reset the drag anchor and hurl the globe on the next move.
-      if (g.dragging) return;
-      // Cancel a deferred edge-tap select so it can't fire mid-gesture; the
-      // armed window survives this press so a second tap can still skip.
-      clearPendingSelect();
-      const s = sim.current;
-      s.mode = "drag";
-      s.vAz = 0;
-      s.vEl = 0;
-      g.dragging = true;
-      g.activePointerId = e.pointerId;
-      g.downX = e.clientX;
-      g.downY = e.clientY;
-      g.lastX = e.clientX;
-      g.lastY = e.clientY;
-      g.lastT = e.timeStamp;
-      g.vx = 0;
-      g.vy = 0;
-      el.setPointerCapture?.(e.pointerId);
+      dispatch({
+        type: "pointerDown",
+        id: e.pointerId,
+        x: e.clientX,
+        y: e.clientY,
+        t: e.timeStamp,
+      });
     };
 
     const onMove = (e: PointerEvent) => {
-      if (!g.dragging || e.pointerId !== g.activePointerId) return;
-      // Read mode can flip on mid-drag; onMove writes az directly, bypassing the
-      // useFrame suspend, so don't rotate. Keep the pointer baseline current so
-      // a flip back off doesn't read the whole gap as one jump.
-      if (cfg.current.readMode) {
-        g.lastX = e.clientX;
-        g.lastY = e.clientY;
-        g.lastT = e.timeStamp;
-        return;
-      }
-      const s = sim.current;
-      const dx = e.clientX - g.lastX;
-      const dy = e.clientY - g.lastY;
-      const dt = Math.max(1, e.timeStamp - g.lastT);
-      const gain = DRAG_RAD_PER_PX * cfg.current.sensitivity;
-
-      s.az -= dx * gain;
-      if (!cfg.current.horizontalLock) {
-        s.el = clamp(s.el + dy * gain, -EL_LIMIT, EL_LIMIT);
-      }
-      g.vx = dx / dt;
-      g.vy = dy / dt;
-      g.lastX = e.clientX;
-      g.lastY = e.clientY;
-      g.lastT = e.timeStamp;
+      dispatch({
+        type: "pointerMove",
+        id: e.pointerId,
+        x: e.clientX,
+        y: e.clientY,
+        t: e.timeStamp,
+      });
     };
 
     const onUp = (e: PointerEvent) => {
-      if (!g.dragging || e.pointerId !== g.activePointerId) return;
-      g.dragging = false;
-      g.activePointerId = null;
-      el.releasePointerCapture?.(e.pointerId);
-      const s = sim.current;
-
-      if (
-        isTap(
-          { x: g.downX, y: g.downY },
-          { x: e.clientX, y: e.clientY },
-          TAP_MAX_PX,
-        )
-      ) {
-        const rect = el.getBoundingClientRect();
-        const cx = e.clientX;
-        const cy = e.clientY;
-        const region = horizontalThird(cx - rect.left, rect.width);
-
-        // Select the nearest country, re-centring the current one on a miss so a
-        // tap on open ocean never jumps away. Coordinates are captured now, not
-        // read in the timer, so a deferred run still aims at the tap point.
-        const runSelect = () => {
-          // Bail if the situation changed while armed: read mode forbids moving
-          // the globe under the reader, and mode "settle" means an external ?cc=
-          // already landed the globe during the window.
-          if (cfg.current.readMode || sim.current.mode === "settle") return;
-          lastEdgeTapAt.current = null;
-          const candidates = projectFrontCountries(
-            camera,
-            rect.width,
-            rect.height,
-          );
-          const hit = pickNearestToPoint(
-            candidates,
-            cx - rect.left,
-            cy - rect.top,
-            TAP_HIT_PX,
-          );
-          // viaTap: a bare tap-select, so the tour's gesture beat can ignore it
-          // rather than treat an accidental tap as the flick it teaches.
-          settleTo(hit ?? sim.current.settledCode, true);
-        };
-
-        const action = classifyTap({
-          listening: globeChartStore.getState().listening,
-          region,
-          now: e.timeStamp,
-          lastEdgeTapAt: lastEdgeTapAt.current,
-          windowMs: DOUBLE_TAP_MS,
-        });
-
-        if (action.kind === "skip") {
-          // A second side-third tap within the window: drop the first tap's
-          // pending select and skip instead.
-          clearPendingSelect();
-          lastEdgeTapAt.current = null;
-          // A skip moves no globe. If the press that started this tap froze a
-          // settle in flight, resume it: its targets still hold the intended
-          // landing, so the globe never strands mid-glide, possibly on ocean.
-          // At rest az/el already sit on the targets, so return to idle instead.
-          const atTarget =
-            Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
-            Math.abs(s.settleEl - s.el) < SETTLE_EPS;
-          s.mode = atTarget ? "idle" : "settle";
-          // Raise a skip-intent; the chart runs the skip and flashes on a real
-          // change. The globe emits data and learns no outcome.
-          globeChartStore.getState().signalSkip(action.dir);
-          return;
-        }
-
-        if (action.kind === "deferSelect") {
-          // First side-third tap while listening: defer the select past the
-          // double-tap window so a second tap can turn it into a skip; select if
-          // none comes.
-          clearPendingSelect();
-          lastEdgeTapAt.current = e.timeStamp;
-          pendingSelect.current = window.setTimeout(runSelect, SELECT_DEFER_MS);
-          return;
-        }
-
-        // Center third or no preview: a double-tap has no skip meaning, so
-        // select with no delay and arm no window.
-        runSelect();
-        return;
-      }
-
-      // A fling is a fresh intent: drop any armed double-tap window.
-      lastEdgeTapAt.current = null;
-      const sens = cfg.current.sensitivity;
-      s.vAz = -flickToSpin(g.vx) * sens;
-      s.vEl = cfg.current.horizontalLock ? 0 : flickToSpin(g.vy) * sens;
-      s.mode = "fling";
+      // Resolve the DOM-dependent tap payload up front so the reducer stays
+      // camera-free: which third the release fell in, and the nearest front
+      // country to it (null on an ocean tap). Only the tap branch consults them.
+      const rect = el.getBoundingClientRect();
+      const region = horizontalThird(e.clientX - rect.left, rect.width);
+      const candidates = projectFrontCountries(camera, rect.width, rect.height);
+      const hitCode = pickNearestToPoint(
+        candidates,
+        e.clientX - rect.left,
+        e.clientY - rect.top,
+        TAP_HIT_PX,
+      );
+      dispatch({
+        type: "pointerUp",
+        id: e.pointerId,
+        x: e.clientX,
+        y: e.clientY,
+        t: e.timeStamp,
+        region,
+        hitCode,
+        listening: globeChartStore.getState().listening,
+      });
     };
 
-    // An interrupted touch (system gesture, multi-touch) fires pointercancel,
-    // not pointerup. Without this the drag never ends and the globe freezes.
-    // Snap to the nearest country so it still never rests on open ocean.
     const onCancel = (e: PointerEvent) => {
-      if (!g.dragging || e.pointerId !== g.activePointerId) return;
-      g.dragging = false;
-      g.activePointerId = null;
-      el.releasePointerCapture?.(e.pointerId);
-      // An abandoned gesture ends any armed double-tap window too.
-      clearPendingSelect();
-      lastEdgeTapAt.current = null;
-      const s = sim.current;
-      settleTo(
-        pickSnapCountry(s.el, s.az, cfg.current.visited, cfg.current.fair),
-      );
+      dispatch({ type: "pointerCancel", id: e.pointerId, rng: Math.random });
     };
 
     el.addEventListener("pointerdown", onDown);
@@ -401,77 +223,19 @@ export function SpinSnapControls({
     el.addEventListener("pointerup", onUp);
     el.addEventListener("pointercancel", onCancel);
     return () => {
-      clearPendingSelect();
-      lastEdgeTapAt.current = null;
+      if (deferTimer.current !== null) {
+        window.clearTimeout(deferTimer.current);
+        deferTimer.current = null;
+      }
       el.removeEventListener("pointerdown", onDown);
       el.removeEventListener("pointermove", onMove);
       el.removeEventListener("pointerup", onUp);
       el.removeEventListener("pointercancel", onCancel);
     };
-  }, [gl, camera, clearPendingSelect]);
+  }, [gl, camera, dispatch]);
 
   useFrame((_, dt) => {
-    const s = sim.current;
-
-    // Read mode (sheet at full) hides the globe. Suspend the sim so a leftover
-    // fling can't drift and settle a new country under the reader. Park an
-    // in-flight fling outright (drop its momentum so it doesn't resume on
-    // collapse), but leave a settle in progress alone: a settle is an
-    // intentional landing (a gesture, or an external ?cc= pick from the a11y
-    // selector), so let it resume and land when the sheet collapses. A fling
-    // can't reach settle while reading, so mode === "settle" here is always a
-    // real selection, never stray momentum.
-    if (cfg.current.readMode) {
-      if (s.mode === "fling") {
-        s.vAz = 0;
-        s.vEl = 0;
-        s.mode = "idle";
-      }
-      return;
-    }
-
-    if (s.mode === "fling") {
-      s.az += s.vAz * dt;
-      s.el = clamp(s.el + s.vEl * dt, -EL_LIMIT, EL_LIMIT);
-      const decay = Math.exp(-cfg.current.friction * dt);
-      s.vAz *= decay;
-      s.vEl *= decay;
-      if (Math.hypot(s.vAz, s.vEl) < SETTLE_VEL) {
-        settleTo(
-          pickSnapCountry(s.el, s.az, cfg.current.visited, cfg.current.fair),
-        );
-      }
-    } else if (s.mode === "settle") {
-      // Under-damped spring: the view glides past the target country and
-      // springs back. Bounce lowers the damping ratio for more overshoot.
-      const dtc = Math.min(dt, 0.05);
-      const zeta = clamp(1 - 0.7 * cfg.current.bounce, 0.2, 1);
-      const dAz = shortestAngle(s.settleAz - s.az);
-      const dEl = s.settleEl - s.el;
-      s.vAz +=
-        (SNAP_OMEGA * SNAP_OMEGA * dAz - 2 * zeta * SNAP_OMEGA * s.vAz) * dtc;
-      s.vEl +=
-        (SNAP_OMEGA * SNAP_OMEGA * dEl - 2 * zeta * SNAP_OMEGA * s.vEl) * dtc;
-      const speed = Math.hypot(s.vAz, s.vEl);
-      if (speed > MAX_SETTLE_VEL) {
-        const k = MAX_SETTLE_VEL / speed;
-        s.vAz *= k;
-        s.vEl *= k;
-      }
-      s.az += s.vAz * dtc;
-      s.el += s.vEl * dtc;
-      if (
-        Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
-        Math.abs(s.settleEl - s.el) < SETTLE_EPS &&
-        Math.hypot(s.vAz, s.vEl) < 0.02
-      ) {
-        s.az = s.settleAz;
-        s.el = s.settleEl;
-        s.vAz = 0;
-        s.vEl = 0;
-        s.mode = "idle";
-      }
-    }
+    dispatch({ type: "frame", dt, rng: Math.random });
     applyCamera();
   });
 

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 
 import { globeChartStore } from "@/lib/globe-chart-store";
@@ -9,7 +9,6 @@ import {
   type GestureCommand,
   type GestureConfig,
   type GestureEvent,
-  type GestureState,
   initGestureState,
   reduce,
 } from "./spin-gesture";
@@ -93,14 +92,14 @@ export function SpinSnapControls({
     onSettleRef.current = onSettle;
   });
 
-  // Lazily seed the sim once, not on every render: passing the value to useRef
-  // would rebuild and discard it each time the argument is evaluated. Non-null
-  // for the rest of the component's life once this guard has run.
-  const sim = useRef<GestureState | null>(null);
-  if (sim.current === null) sim.current = initGestureState(initialCode);
+  // Seed the sim once at mount. useState's lazy initializer runs the build a
+  // single time (passing it straight to useRef would rebuild and discard it
+  // every render), and holding it in a ref keeps writes out of the render pass.
+  const [initialSim] = useState(() => initGestureState(initialCode));
+  const sim = useRef(initialSim);
 
   const applyCamera = () => {
-    const s = sim.current!;
+    const s = sim.current;
     camera.position.set(
       RADIUS * Math.cos(s.el) * Math.sin(s.az),
       RADIUS * Math.sin(s.el),
@@ -153,7 +152,7 @@ export function SpinSnapControls({
   const dispatch = useCallback(
     (event: GestureEvent) => {
       const el = gl.domElement;
-      const { state, commands } = reduce(sim.current!, event, cfg.current);
+      const { state, commands } = reduce(sim.current, event, cfg.current);
       sim.current = state;
       for (const command of commands) {
         runCommand(command, el);

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -93,10 +93,14 @@ export function SpinSnapControls({
     onSettleRef.current = onSettle;
   });
 
-  const sim = useRef<GestureState>(initGestureState(initialCode));
+  // Lazily seed the sim once, not on every render: passing the value to useRef
+  // would rebuild and discard it each time the argument is evaluated. Non-null
+  // for the rest of the component's life once this guard has run.
+  const sim = useRef<GestureState | null>(null);
+  if (sim.current === null) sim.current = initGestureState(initialCode);
 
   const applyCamera = () => {
-    const s = sim.current;
+    const s = sim.current!;
     camera.position.set(
       RADIUS * Math.cos(s.el) * Math.sin(s.az),
       RADIUS * Math.sin(s.el),
@@ -107,7 +111,8 @@ export function SpinSnapControls({
 
   // Run one command: the impure work the reducer can only name (notify, skip,
   // arm/clear the deferred-select timer, capture/release the pointer). A fired
-  // timer re-enters the machine via dispatchRef so this stays a stable callback.
+  // timer re-enters the machine via dispatchRef, since useFrame (not an effect)
+  // must drive dispatch and so it can't be a useEffectEvent.
   const dispatchRef = useRef<(event: GestureEvent) => void>(() => {});
   const runCommand = useCallback(
     (command: GestureCommand, el: HTMLCanvasElement) => {
@@ -143,11 +148,12 @@ export function SpinSnapControls({
     [],
   );
 
-  // Fold an event into the sim, then run its commands.
+  // Fold an event into the sim, then run its commands. Stable across renders
+  // (gl and runCommand are), so the listener effect subscribes once.
   const dispatch = useCallback(
     (event: GestureEvent) => {
       const el = gl.domElement;
-      const { state, commands } = reduce(sim.current, event, cfg.current);
+      const { state, commands } = reduce(sim.current!, event, cfg.current);
       sim.current = state;
       for (const command of commands) {
         runCommand(command, el);

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -44,7 +44,7 @@ interface SpinSnapControlsProps {
 // momentum, and on coming to rest snap to the nearest country. A tap jumps
 // straight to the nearest country. There is no free-rotate; it never rests on
 // open ocean. The gesture machine itself lives in the pure `spin-gesture`
-// reducer; this component owns only the impure edges — DOM pointer events in,
+// reducer; this component owns only the impure edges: DOM pointer events in,
 // commands and the camera draw out.
 export function SpinSnapControls({
   initialCode,
@@ -236,6 +236,9 @@ export function SpinSnapControls({
 
   useFrame((_, dt) => {
     dispatch({ type: "frame", dt, rng: Math.random });
+    // Read mode suspends the sim (the frame event leaves az/el frozen); leave
+    // the camera untouched too rather than re-pin it every hidden frame.
+    if (cfg.current.readMode) return;
     applyCamera();
   });
 

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -160,9 +160,12 @@ export function SpinSnapControls({
     },
     [gl, runCommand],
   );
+  // Keep the timer re-entry pointed at the latest dispatch. Its only trigger is
+  // a dispatch identity change, so the deferred-select callback never fires a
+  // stale closure.
   useEffect(() => {
     dispatchRef.current = dispatch;
-  });
+  }, [dispatch]);
 
   // Follow external selection: when ?cc= changes (the a11y country list, a
   // shared link) settle to it like a gesture would. A gesture's own settle


### PR DESCRIPTION
Device-verified on 2026-07-13: drag/fling/tap-select/edge-skip feel unchanged, two-finger no longer hurls the globe, and an edge double-tap during a settle lands on a country. Behavior-preserving extraction; static checks (typecheck / lint / build, 683 unit tests) pass.

## Why

The drag / fling / settle / skip transitions and every interruption case lived in untested event-handler closures. The never-rests-on-ocean invariant and the recent pointer-arbitration and skip-during-settle fixes (#234) were reasoned by hand with no regression guard. This is audit R2 from #207: a pure reducer so the interruption matrix is table-testable and the next gesture can land on top without re-opening this bug class.

## What

**`spin-gesture.ts`** — the whole machine as a pure `(state, event, cfg) -> { state, commands }` reducer. It owns mode/physics, `activePointerId` arbitration, the double-tap arm window, and the deferred-select target. Impure work leaves as **commands** the shell runs (`settle`, `signalSkip`, `armDefer`, `clearDefer`, `capturePointer`, `releasePointer`); camera-dependent reads enter as pre-resolved event payload (`region`, `hitCode`, `rng`), so `reduce` never touches the DOM, camera, timers, chart store, or `Math.random`.

**`spin-snap-controls.tsx`** — the shell now only translates DOM pointer events into reducer events, runs the returned commands, and draws the camera from the returned state. A fired deferred-select timer re-enters via a `dispatchRef` so `dispatch` stays a stable callback (it can't be a `useEffectEvent`: `useFrame` drives it, and `rules-of-hooks` forbids calling an Effect Event outside an effect).

**`spin-gesture.test.ts`** — 23 table tests over the matrix #207 named: tap-during-settle, skip-during-settle, cancel-during-defer, pointer arbitration. Behavior is unchanged; the skip-during-settle resume mirrors the fix shipped in #234, now regression-guarded.

Not folded in: the `globe-geometry.ts` dedup (`RADIUS`×3, `PIN_ELEVATION`×2) the issue lists as a batching candidate — Tidy-First keeps that structural-only change on its own PR.

## Test plan

- [x] typecheck / lint / build / 683 unit tests
- [x] **Device:** drag / fling / tap-select / edge-skip all feel identical to before
- [x] **Device:** two-finger drag doesn't hurl the globe; second finger ignored
- [x] **Device:** edge double-tap during an in-flight settle lands on a country, never mid-ocean
- [x] **Device:** finger down, then open the sheet to full → globe doesn't drift (globe stays captured; the readMode onMove bail is unit-covered; the "can't operate the sheet while holding the globe" is pre-existing globe touch-capture, unchanged here)
- [x] **Device:** deferred edge-tap select still fires ~360ms after a lone side tap

Closes #207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added natural globe interactions, including dragging, fling momentum, snapping, tap selection, double-tap skipping, and pointer cancellation handling.
  * Added support for reduced-motion and read-mode behavior during globe interactions.
  * Improved selection behavior for country and ocean taps, including deferred side selections and external selections.

* **Bug Fixes**
  * Prevented globe settling on open ocean after cancellations or invalid taps.

* **Tests**
  * Added comprehensive automated coverage for gesture, animation, selection, and reduced-motion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->