### PR TITLE
enhance(globe): gate edge-skip on empty-globe taps, not screen thirds

### DIFF
--- a/src/components/globe/spin-gesture.test.ts
+++ b/src/components/globe/spin-gesture.test.ts
@@ -4,7 +4,6 @@ import { COUNTRIES } from "@/lib/countries";
 
 import {
   DOUBLE_TAP_MS,
-  SELECT_DEFER_MS,
   type GestureConfig,
   type GestureEvent,
   type GestureState,
@@ -77,7 +76,6 @@ test("pointerDown starts a drag and captures the pointer", () => {
   expect(state.mode).toBe("drag");
   expect(state.activePointerId).toBe(1);
   expect(commands).toContainEqual({ kind: "capturePointer", id: 1 });
-  expect(commands).toContainEqual({ kind: "clearDefer" });
 });
 
 test("pointerDown is ignored in read mode so reading never grabs the globe", () => {
@@ -246,7 +244,27 @@ test("a tap landing during an in-flight settle redirects to the tapped country",
   });
 });
 
-test("a first side-third tap while listening defers its select", () => {
+test("a lone empty side-third tap while listening arms the window and does nothing else", () => {
+  const { state, commands } = run(initGestureState(START), [
+    down(1, 20, 100),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 5,
+      region: "left",
+      hitCode: null,
+      listening: true,
+    },
+  ]);
+
+  expect(state.lastEdgeTapAt).toBe(5);
+  expect(commands.some((c) => c.kind === "settle")).toBe(false);
+  expect(commands.some((c) => c.kind === "signalSkip")).toBe(false);
+});
+
+test("a side-third tap on a pin selects immediately instead of arming a skip", () => {
   const { state, commands } = run(initGestureState(START), [
     down(1, 20, 100),
     {
@@ -261,23 +279,8 @@ test("a first side-third tap while listening defers its select", () => {
     },
   ]);
 
-  expect(state.lastEdgeTapAt).toBe(5);
-  expect(state.pendingSelectCode).toBe("ca");
-  expect(commands).toContainEqual({
-    kind: "armDefer",
-    delayMs: SELECT_DEFER_MS,
-  });
-  expect(commands.some((c) => c.kind === "settle")).toBe(false);
-});
-
-test("a fired deferred timer selects the pending country", () => {
-  const armed: GestureState = {
-    ...initGestureState(START),
-    mode: "drag",
-    pendingSelectCode: "ca",
-  };
-  const { commands } = run(armed, [{ type: "deferFire" }]);
-
+  expect(state.lastEdgeTapAt).toBeNull();
+  expect(state.settleAz).toBeCloseTo(azOf("ca"));
   expect(commands).toContainEqual({
     kind: "settle",
     code: "ca",
@@ -286,14 +289,64 @@ test("a fired deferred timer selects the pending country", () => {
   });
 });
 
-test("a fired deferred timer bails when an external pick already settled", () => {
+test("a second side tap landing on a pin selects rather than skips", () => {
   const armed: GestureState = {
     ...initGestureState(START),
-    mode: "settle",
-    pendingSelectCode: "ca",
+    mode: "drag",
+    activePointerId: 1,
+    lastEdgeTapAt: 100,
+    downX: 20,
+    downY: 100,
   };
-  const { commands } = run(armed, [{ type: "deferFire" }]);
+  const { commands } = run(armed, [
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 100 + DOUBLE_TAP_MS - 1,
+      region: "left",
+      hitCode: "ca",
+      listening: true,
+    },
+  ]);
 
+  expect(commands).toContainEqual({
+    kind: "settle",
+    code: "ca",
+    changed: true,
+    viaTap: true,
+  });
+  expect(commands.some((c) => c.kind === "signalSkip")).toBe(false);
+});
+
+test("two empty side taps within the window skip in the second tap's direction", () => {
+  const { commands } = run(initGestureState(START), [
+    down(1, 20, 100),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 5,
+      region: "left",
+      hitCode: null,
+      listening: true,
+    },
+    down(1, 20, 100, 5 + DOUBLE_TAP_MS - 1),
+    {
+      type: "pointerUp",
+      id: 1,
+      x: 20,
+      y: 100,
+      t: 5 + DOUBLE_TAP_MS - 1,
+      region: "left",
+      hitCode: null,
+      listening: true,
+    },
+  ]);
+
+  expect(commands).toContainEqual({ kind: "signalSkip", dir: -1 });
   expect(commands.some((c) => c.kind === "settle")).toBe(false);
 });
 
@@ -314,19 +367,18 @@ test("pointerCancel snaps to a country so it never rests on open ocean", () => {
   expect(commands).toContainEqual({ kind: "releasePointer", id: 1 });
 });
 
-test("pointerCancel wipes an armed deferred select as it snaps", () => {
+test("pointerCancel wipes an armed skip window as it snaps", () => {
   const armedDrag: GestureState = {
     ...initGestureState(START),
     mode: "drag",
     activePointerId: 1,
     lastEdgeTapAt: 100,
-    pendingSelectCode: "ca",
   };
   const { state, commands } = run(armedDrag, [
     { type: "pointerCancel", id: 1, rng: half },
   ]);
 
-  expect(commands).toContainEqual({ kind: "clearDefer" });
+  expect(commands.some((c) => c.kind === "settle")).toBe(true);
   expect(state.lastEdgeTapAt).toBeNull();
 });
 
@@ -440,11 +492,11 @@ test("reduced motion cuts straight to the target with no settle glide", () => {
   expect(state.az).toBeCloseTo(azOf("ca"));
 });
 
-// The skip-during-settle resume. A second side-third tap within the window is a
-// skip: it moves no globe of its own, but the press that began it froze whatever
-// settle was gliding. These two lock the judgment the resume must make.
+// The skip-during-settle resume. A second empty side-third tap within the window
+// is a skip: it moves no globe of its own, but the press that began it froze
+// whatever settle was gliding. These lock the judgment the resume must make.
 
-test("a skip signals its direction and drops the pending select", () => {
+test("a skip signals its direction and settles nothing of its own", () => {
   const armed: GestureState = {
     ...initGestureState(START),
     mode: "drag",
@@ -453,7 +505,7 @@ test("a skip signals its direction and drops the pending select", () => {
     downX: 20,
     downY: 100,
   };
-  const { commands } = run(armed, [
+  const { state, commands } = run(armed, [
     {
       type: "pointerUp",
       id: 1,
@@ -461,13 +513,14 @@ test("a skip signals its direction and drops the pending select", () => {
       y: 100,
       t: 100 + DOUBLE_TAP_MS - 1,
       region: "left",
-      hitCode: "ca",
+      hitCode: null,
       listening: true,
     },
   ]);
 
   expect(commands).toContainEqual({ kind: "signalSkip", dir: -1 });
-  expect(commands).toContainEqual({ kind: "clearDefer" });
+  expect(commands.some((c) => c.kind === "settle")).toBe(false);
+  expect(state.lastEdgeTapAt).toBeNull();
 });
 
 test("a skip mid-glide resumes the interrupted settle, never stranding the globe", () => {

--- a/src/components/globe/spin-gesture.ts
+++ b/src/components/globe/spin-gesture.ts
@@ -6,17 +6,17 @@ import { type HorizontalThird, classifyTap, isTap } from "./tap-detect";
 
 // The gesture state machine for the spun globe, as a pure reducer. Every drag,
 // fling, settle, tap, skip, and interruption transition lives here so the
-// interruption matrix (tap-during-settle, skip-during-settle, cancel-during-
-// defer, pointer arbitration) is table-testable instead of reasoned by hand in
-// event-handler closures. The React shell (`spin-snap-controls.tsx`) owns only
-// the impure edges: it translates DOM pointer events into the events below,
-// runs the returned commands, and draws the camera from the returned state.
+// interruption matrix (tap-during-settle, skip-during-settle, pointer
+// arbitration) is table-testable instead of reasoned by hand in event-handler
+// closures. The React shell (`spin-snap-controls.tsx`) owns only the impure
+// edges: it translates DOM pointer events into the events below, runs the
+// returned commands, and draws the camera from the returned state.
 //
-// Purity contract: `reduce` never touches the DOM, the camera, timers, the
-// chart store, or `Math.random`. Anything impure enters as event payload the
-// shell resolves first (the tap's `region` and `hitCode`, the snap draw's
-// `rng`) or leaves as a command the shell runs (`settle`, `signalSkip`,
-// `armDefer`, `clearDefer`, `capturePointer`, `releasePointer`).
+// Purity contract: `reduce` never touches the DOM, the camera, the chart store,
+// or `Math.random`. Anything impure enters as event payload the shell resolves
+// first (the tap's `region` and `hitCode`, the snap draw's `rng`) or leaves as
+// a command the shell runs (`settle`, `signalSkip`, `capturePointer`,
+// `releasePointer`).
 
 const DEG = Math.PI / 180;
 const DRAG_RAD_PER_PX = 0.005; // base drag gain, scaled by the sensitivity slider
@@ -30,10 +30,6 @@ const SNAP_OMEGA = 17; // snap spring frequency: higher settles faster
 const MAX_SETTLE_VEL = 7;
 const TAP_MAX_PX = 8; // press-to-release drift under which a gesture is a tap
 export const DOUBLE_TAP_MS = 280; // edge double-tap window: a 2nd side-third tap within this skips
-// Deferred-select delay: waits past the double-tap window (longer than
-// DOUBLE_TAP_MS) so main-thread jank can't fire the select before a second
-// tap's pointerup and misclassify a skip as a select.
-export const SELECT_DEFER_MS = 360;
 // Angular tolerance (rad) for "the camera sits on the settle target": ends a
 // settle, and tells a skip whether a settle was interrupted mid-glide.
 const SETTLE_EPS = 0.002;
@@ -53,8 +49,7 @@ export type GestureMode = "idle" | "drag" | "fling" | "settle";
 // The whole gesture machine as plain data: camera orientation and velocity, the
 // live mode, the settle targets and last-landed country, the one pointer that
 // owns the active gesture, the press/last-sample bookkeeping that anchors
-// tap-vs-spin and release velocity, the double-tap arm window, and the country a
-// deferred edge-tap select will land on when its timer fires.
+// tap-vs-spin and release velocity, and the double-tap arm window.
 export interface GestureState {
   az: number;
   el: number;
@@ -75,11 +70,9 @@ export interface GestureState {
   lastT: number;
   vx: number;
   vy: number;
-  // Time of the prior deferred side-third tap, or null. Arms the double-tap
+  // Time of the prior empty side-third tap, or null. Arms the double-tap
   // window: a second side tap within DOUBLE_TAP_MS turns the pair into a skip.
   lastEdgeTapAt: number | null;
-  // Country a pending deferred-select timer will land on when it fires.
-  pendingSelectCode: string | null;
 }
 
 // Config the shell feeds in with each event: the live slider/prop snapshot the
@@ -113,8 +106,6 @@ export type GestureEvent =
       listening: boolean;
     }
   | { type: "pointerCancel"; id: number; rng: () => number }
-  // A deferred edge-tap select timer fired.
-  | { type: "deferFire" }
   // ?cc= changed: the a11y country list or a shared link drives the globe.
   | { type: "externalSelect"; code: string | null }
   | { type: "frame"; dt: number; rng: () => number };
@@ -124,8 +115,6 @@ export type GestureEvent =
 export type GestureCommand =
   | { kind: "settle"; code: string; changed: boolean; viaTap: boolean }
   | { kind: "signalSkip"; dir: 1 | -1 }
-  | { kind: "armDefer"; delayMs: number }
-  | { kind: "clearDefer" }
   | { kind: "capturePointer"; id: number }
   | { kind: "releasePointer"; id: number };
 
@@ -160,7 +149,6 @@ export function initGestureState(code: string): GestureState {
     vx: 0,
     vy: 0,
     lastEdgeTapAt: null,
-    pendingSelectCode: null,
   };
 }
 
@@ -211,10 +199,9 @@ function settleTo(
 }
 
 // Select the tapped country, re-centring the current one on an ocean miss so a
-// tap never jumps away. Shared by the immediate-select path and the deferred
-// timer; bails when the situation changed while a deferred select was armed:
-// read mode forbids moving the globe under the reader, and mode "settle" means
-// an external ?cc= already landed during the window.
+// tap never jumps away. Bails when the situation forbids moving the globe: read
+// mode holds it still under the reader, and mode "settle" means an external
+// ?cc= already landed a selection.
 function runSelect(
   s: GestureState,
   commands: GestureCommand[],
@@ -243,9 +230,8 @@ export function reduce(
       // A gesture already owns a pointer: ignore a second finger rather than let
       // it reset the drag anchor and hurl the globe on the next move.
       if (s.activePointerId !== null) break;
-      // Cancel a deferred edge-tap select so it can't fire mid-gesture; the
-      // armed window survives this press so a second tap can still skip.
-      commands.push({ kind: "clearDefer" });
+      // The armed double-tap window survives this press so a second empty side
+      // tap can still skip.
       s.mode = "drag";
       s.vAz = 0;
       s.vEl = 0;
@@ -303,43 +289,44 @@ export function reduce(
         const action = classifyTap({
           listening: event.listening,
           region: event.region,
+          hit: event.hitCode !== null,
           now: event.t,
           lastEdgeTapAt: s.lastEdgeTapAt,
           windowMs: DOUBLE_TAP_MS,
         });
 
-        if (action.kind === "skip") {
-          // A second side-third tap within the window: drop the first tap's
-          // pending select and skip instead. A skip moves no globe of its own.
-          commands.push({ kind: "clearDefer" });
-          s.lastEdgeTapAt = null;
-          // The press that began this tap froze any in-flight settle by setting
-          // mode to "drag" (see pointerDown). At rest az/el already sit on the
-          // targets, so return to idle; otherwise a settle was interrupted mid-
-          // glide and its targets still hold the intended landing, so resume it
-          // rather than strand the globe mid-flight, possibly on open ocean.
+        // A skip and an arming tap move no globe of their own. The press that
+        // began this tap froze any in-flight settle by setting mode to "drag"
+        // (see pointerDown). At rest az/el already sit on the targets, so return
+        // to idle; otherwise a settle was interrupted mid-glide and its targets
+        // still hold the intended landing, so resume it rather than strand the
+        // globe mid-flight, possibly on open ocean.
+        const resumeFrozenSettle = () => {
           const atTarget =
             Math.abs(shortestAngle(s.settleAz - s.az)) < SETTLE_EPS &&
             Math.abs(s.settleEl - s.el) < SETTLE_EPS;
           s.mode = atTarget ? "idle" : "settle";
+        };
+
+        if (action.kind === "skip") {
+          // A second empty side-third tap within the window: skip instead of
+          // select.
+          s.lastEdgeTapAt = null;
+          resumeFrozenSettle();
           commands.push({ kind: "signalSkip", dir: action.dir });
           break;
         }
 
-        if (action.kind === "deferSelect") {
-          // First side-third tap while listening: defer the select past the
-          // double-tap window so a second tap can turn it into a skip; select if
-          // none comes. Coordinates are already resolved into hitCode, so the
-          // deferred run still aims at the tap point.
-          commands.push({ kind: "clearDefer" });
+        if (action.kind === "armSkip") {
+          // First empty side-third tap while listening: arm the skip window and
+          // select nothing, so a second tap within it reads as a skip.
           s.lastEdgeTapAt = event.t;
-          s.pendingSelectCode = event.hitCode ?? s.settledCode;
-          commands.push({ kind: "armDefer", delayMs: SELECT_DEFER_MS });
+          resumeFrozenSettle();
           break;
         }
 
-        // Center third or no preview: a double-tap has no skip meaning, so
-        // select with no delay and arm no window.
+        // A pin hit, a center tap, or no preview: select with no delay and arm
+        // no window.
         runSelect(s, commands, cfg, event.hitCode ?? s.settledCode);
         break;
       }
@@ -352,11 +339,6 @@ export function reduce(
       break;
     }
 
-    case "deferFire": {
-      runSelect(s, commands, cfg, s.pendingSelectCode ?? s.settledCode);
-      break;
-    }
-
     case "pointerCancel": {
       // An interrupted touch (system gesture, multi-touch) fires pointercancel,
       // not pointerup. Snap to the nearest country so it still never rests on
@@ -364,7 +346,6 @@ export function reduce(
       if (s.activePointerId === null || !owns(s, event.id)) break;
       s.activePointerId = null;
       commands.push({ kind: "releasePointer", id: event.id });
-      commands.push({ kind: "clearDefer" });
       s.lastEdgeTapAt = null;
       settleTo(
         s,
@@ -378,10 +359,9 @@ export function reduce(
     case "externalSelect": {
       // Follow ?cc=: settle to it like a gesture would when we aren't there. A
       // gesture's own settle wrote ?cc= first, so code === settledCode by the
-      // time this runs and it no-ops, no feedback loop. Cancel any armed
-      // edge-tap select so a following tap isn't misread as a second tap.
+      // time this runs and it no-ops, no feedback loop. Drop any armed skip
+      // window so a following tap isn't misread as a second tap.
       if (event.code && event.code !== s.settledCode) {
-        commands.push({ kind: "clearDefer" });
         s.lastEdgeTapAt = null;
         settleTo(s, commands, cfg, event.code);
       }

--- a/src/components/globe/spin-snap-controls.tsx
+++ b/src/components/globe/spin-snap-controls.tsx
@@ -73,9 +73,6 @@ export function SpinSnapControls({
   });
   const onSettleRef = useRef(onSettle);
 
-  // The pending deferred edge-tap select timer (armDefer/clearDefer commands).
-  const deferTimer = useRef<number | null>(null);
-
   // Keep the long-lived pointer handlers and per-frame loop reading the latest
   // props without re-subscribing. Written in an effect, never during render.
   useEffect(() => {
@@ -109,10 +106,7 @@ export function SpinSnapControls({
   };
 
   // Run one command: the impure work the reducer can only name (notify, skip,
-  // arm/clear the deferred-select timer, capture/release the pointer). A fired
-  // timer re-enters the machine via dispatchRef, since useFrame (not an effect)
-  // must drive dispatch and so it can't be a useEffectEvent.
-  const dispatchRef = useRef<(event: GestureEvent) => void>(() => {});
+  // capture/release the pointer).
   const runCommand = useCallback(
     (command: GestureCommand, el: HTMLCanvasElement) => {
       switch (command.kind) {
@@ -121,20 +115,6 @@ export function SpinSnapControls({
           break;
         case "signalSkip":
           globeChartStore.getState().signalSkip(command.dir);
-          break;
-        case "armDefer":
-          if (deferTimer.current !== null)
-            window.clearTimeout(deferTimer.current);
-          deferTimer.current = window.setTimeout(() => {
-            deferTimer.current = null;
-            dispatchRef.current({ type: "deferFire" });
-          }, command.delayMs);
-          break;
-        case "clearDefer":
-          if (deferTimer.current !== null) {
-            window.clearTimeout(deferTimer.current);
-            deferTimer.current = null;
-          }
           break;
         case "capturePointer":
           el.setPointerCapture?.(command.id);
@@ -160,12 +140,6 @@ export function SpinSnapControls({
     },
     [gl, runCommand],
   );
-  // Keep the timer re-entry pointed at the latest dispatch. Its only trigger is
-  // a dispatch identity change, so the deferred-select callback never fires a
-  // stale closure.
-  useEffect(() => {
-    dispatchRef.current = dispatch;
-  }, [dispatch]);
 
   // Follow external selection: when ?cc= changes (the a11y country list, a
   // shared link) settle to it like a gesture would. A gesture's own settle
@@ -231,10 +205,6 @@ export function SpinSnapControls({
     el.addEventListener("pointerup", onUp);
     el.addEventListener("pointercancel", onCancel);
     return () => {
-      if (deferTimer.current !== null) {
-        window.clearTimeout(deferTimer.current);
-        deferTimer.current = null;
-      }
       el.removeEventListener("pointerdown", onDown);
       el.removeEventListener("pointermove", onMove);
       el.removeEventListener("pointerup", onUp);

--- a/src/components/globe/tap-detect.test.ts
+++ b/src/components/globe/tap-detect.test.ts
@@ -44,10 +44,11 @@ test("horizontalThird leans the right boundary into the right zone", () => {
 
 const WINDOW = 280;
 
-test("classifyTap selects immediately for a center tap while listening", () => {
+test("classifyTap selects immediately for an empty center tap while listening", () => {
   const action = classifyTap({
     listening: true,
     region: "center",
+    hit: false,
     now: 1000,
     lastEdgeTapAt: null,
     windowMs: WINDOW,
@@ -56,10 +57,11 @@ test("classifyTap selects immediately for a center tap while listening", () => {
   expect(action).toEqual({ kind: "select" });
 });
 
-test("classifyTap selects immediately for a side tap when not listening", () => {
+test("classifyTap selects immediately for an empty side tap when not listening", () => {
   const action = classifyTap({
     listening: false,
     region: "left",
+    hit: false,
     now: 1000,
     lastEdgeTapAt: 900,
     windowMs: WINDOW,
@@ -68,23 +70,52 @@ test("classifyTap selects immediately for a side tap when not listening", () => 
   expect(action).toEqual({ kind: "select" });
 });
 
-test("classifyTap defers a first side tap while listening", () => {
+test("classifyTap selects immediately for a pin hit in a side third while listening", () => {
   const action = classifyTap({
     listening: true,
     region: "right",
+    hit: true,
     now: 1000,
     lastEdgeTapAt: null,
     windowMs: WINDOW,
   });
 
-  expect(action).toEqual({ kind: "deferSelect" });
+  expect(action).toEqual({ kind: "select" });
 });
 
-test("classifyTap skips back on a second left tap within the window", () => {
+test("classifyTap selects, not skips, when the second side tap lands on a pin", () => {
   const first = 1000;
   const action = classifyTap({
     listening: true,
     region: "left",
+    hit: true,
+    now: first + WINDOW - 1,
+    lastEdgeTapAt: first,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "select" });
+});
+
+test("classifyTap arms the skip window on a first empty side tap while listening", () => {
+  const action = classifyTap({
+    listening: true,
+    region: "right",
+    hit: false,
+    now: 1000,
+    lastEdgeTapAt: null,
+    windowMs: WINDOW,
+  });
+
+  expect(action).toEqual({ kind: "armSkip" });
+});
+
+test("classifyTap skips back on a second empty left tap within the window", () => {
+  const first = 1000;
+  const action = classifyTap({
+    listening: true,
+    region: "left",
+    hit: false,
     now: first + WINDOW - 1,
     lastEdgeTapAt: first,
     windowMs: WINDOW,
@@ -93,11 +124,12 @@ test("classifyTap skips back on a second left tap within the window", () => {
   expect(action).toEqual({ kind: "skip", dir: -1 });
 });
 
-test("classifyTap skips forward on a second right tap within the window", () => {
+test("classifyTap skips forward on a second empty right tap within the window", () => {
   const first = 1000;
   const action = classifyTap({
     listening: true,
     region: "right",
+    hit: false,
     now: first + WINDOW - 1,
     lastEdgeTapAt: first,
     windowMs: WINDOW,
@@ -106,11 +138,12 @@ test("classifyTap skips forward on a second right tap within the window", () => 
   expect(action).toEqual({ kind: "skip", dir: 1 });
 });
 
-test("classifyTap counts a second tap exactly at the window edge as a skip", () => {
+test("classifyTap counts a second empty tap exactly at the window edge as a skip", () => {
   const first = 1000;
   const action = classifyTap({
     listening: true,
     region: "right",
+    hit: false,
     now: first + WINDOW,
     lastEdgeTapAt: first,
     windowMs: WINDOW,
@@ -119,15 +152,16 @@ test("classifyTap counts a second tap exactly at the window edge as a skip", () 
   expect(action).toEqual({ kind: "skip", dir: 1 });
 });
 
-test("classifyTap defers again once the window has elapsed", () => {
+test("classifyTap re-arms once the window has elapsed", () => {
   const first = 1000;
   const action = classifyTap({
     listening: true,
     region: "left",
+    hit: false,
     now: first + WINDOW + 1,
     lastEdgeTapAt: first,
     windowMs: WINDOW,
   });
 
-  expect(action).toEqual({ kind: "deferSelect" });
+  expect(action).toEqual({ kind: "armSkip" });
 });

--- a/src/components/globe/tap-detect.ts
+++ b/src/components/globe/tap-detect.ts
@@ -27,33 +27,36 @@ export function horizontalThird(x: number, width: number): HorizontalThird {
   return "center";
 }
 
-// What a settled tap should do: skip a track, select immediately, or hold the
-// select for one double-tap window. A skip needs a preview playing and two taps
-// in a side third within `windowMs`; the second tap's side picks the direction.
+// What a settled tap should do: skip a track, select immediately, or arm the
+// double-tap skip window. A skip needs a preview playing and two empty taps in
+// a side third within `windowMs`; the second tap's side picks the direction.
 export type TapAction =
   | { kind: "skip"; dir: 1 | -1 }
   | { kind: "select" }
-  | { kind: "deferSelect" };
+  | { kind: "armSkip" };
 
-// Single-tap selects everywhere, so the side thirds keep no dead zone. The skip
-// gesture is a layer on top: a side-third tap while listening defers, and a
-// second side-third tap within the window turns the pair into a skip. A center
-// tap or a tap with no preview has no skip meaning, so it selects with no delay.
-// `lastEdgeTapAt` is the time of the prior deferred side tap, or null.
+// A tap that resolves to a country pin (`hit`) selects with no delay wherever
+// it lands, so a country rendered in a side third is never second-class. The
+// skip gesture lives only over empty globe: an empty side-third tap while
+// listening arms the window, and a second one within it turns the pair into a
+// skip. An empty center tap or a tap with no preview has no skip meaning, so
+// it selects with no delay. `lastEdgeTapAt` is the time of the prior arming
+// tap, or null.
 export function classifyTap(args: {
   listening: boolean;
   region: HorizontalThird;
+  hit: boolean;
   now: number;
   lastEdgeTapAt: number | null;
   windowMs: number;
 }): TapAction {
-  const { listening, region, now, lastEdgeTapAt, windowMs } = args;
+  const { listening, region, hit, now, lastEdgeTapAt, windowMs } = args;
 
-  if (!listening || region === "center") return { kind: "select" };
+  if (hit || !listening || region === "center") return { kind: "select" };
 
   if (lastEdgeTapAt !== null && now - lastEdgeTapAt <= windowMs) {
     return { kind: "skip", dir: region === "left" ? -1 : 1 };
   }
 
-  return { kind: "deferSelect" };
+  return { kind: "armSkip" };
 }


### PR DESCRIPTION
Edge-skip was geometric: any tap in the outer screen third while listening was a skip candidate, so a country pin rendered near the edge took a ~280ms defer and a quick second tap skipped the track instead of selecting it. This gates the skip on the tap resolving to no country pin, so a hit on a real country selects immediately and only genuine empty-globe edge taps enter the double-tap skip path. Edge-positioned countries stop being second-class by screen position.

The hand-rolled defer (`SELECT_DEFER_MS`, `pendingSelect`, `clearPendingSelect`) is deleted; `classifyTap` now takes a `hit` flag and short-circuits to select before any region branch. A first empty edge tap only arms the skip window and reuses the skip branch's frozen-settle resume, so an interrupted glide never strands.

Closes #169

## Test plan
- `pnpm lint` / `typecheck` / `test` green (660 tests, 2 new: pin hit in a side third selects immediately; a second side tap on a pin selects, not skips).
- `pnpm build` clean with env sourced.

## Open items
- On-device re-test (the issue calls it out): the skip trigger changed. Verify a lone empty edge tap now moving nothing (no 360ms re-center) feels right, and a second tap on a pin selecting is intended.
- Nit: `spin-snap-controls.tsx` `const hit` holds a country code but reads boolean; `hitCode` disambiguates (the #207 reducer branch already renamed it). Left as-is to keep the diff minimal; fold into whichever of the two lands second.

## Merge order
Conflicts wholesale with the in-flight `refactor/207` gesture-reducer WIP in `spin-snap-controls.tsx` (`onUp`). Whichever lands second rebases.
