### PR TITLE
feat(player): roll into a fresh country when a chart ends

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { CHARTS, CODE_BR, CODE_US, COUNTRY_US } from "@/lib/__fixtures__";
 import type { AudioEngine } from "@/lib/audio-engine";
-import type { ChartFile } from "@/lib/chart-schema";
+import type { ChartFile, Country, Track } from "@/lib/chart-schema";
+import { COUNTRIES } from "@/lib/countries";
 import { globeChartStore } from "@/lib/globe-chart-store";
 
 const mockSearchParams = vi.hoisted(() => ({
@@ -121,6 +122,68 @@ const ADJACENCY_CHARTS: ChartFile = {
         },
       ],
     },
+  },
+};
+
+// The end-of-chart roll draws from the full country universe, so a roll target
+// must be keyed by a real country code. With no visits every pool weight is 1
+// and r=0 draws the first non-excluded pool entry, so pinning Math.random to 0
+// makes each landing deterministic: the first universe entry, then (once it is
+// excluded by a failed attempt) the next, and so on.
+const DRAW_1 = COUNTRIES[0].code;
+const DRAW_2 = COUNTRIES[1].code;
+const DRAW_3 = COUNTRIES[2].code;
+
+// No `i=` id on appleUrl, so track identity falls back to artist+name; unique
+// names keep every fixture track distinct across countries.
+function rollTrack(
+  rank: number,
+  name: string,
+  previewUrl: string | null,
+): Track {
+  return {
+    rank,
+    name,
+    artist: `${name} artist`,
+    previewUrl,
+    artworkUrl: "https://example.com/roll.jpg",
+    appleUrl: "https://music.apple.com/x/roll",
+    spotifyUrl: "https://open.spotify.com/x/roll",
+  };
+}
+
+function rollCountry(tracks: Track[]): Country {
+  return { name: "Roll fixture chart", valid: true, tracks };
+}
+
+// A leading preview-less track, so a roll must land on the first *playable*
+// track, not row one.
+const LANDING_START = "Landing start";
+const ROLL_CHARTS: ChartFile = {
+  ...ADJACENCY_CHARTS,
+  countries: {
+    ...ADJACENCY_CHARTS.countries,
+    [DRAW_1]: rollCountry([
+      rollTrack(1, "Landing gap", null),
+      rollTrack(2, LANDING_START, "https://example.com/landing-2.m4a"),
+      rollTrack(3, "Landing follow-up", "https://example.com/landing-3.m4a"),
+    ]),
+  },
+};
+
+// The first draw has no playable track, so the roll must redraw past it.
+const REDRAW_START = "Redraw start";
+const REDRAW_CHARTS: ChartFile = {
+  ...ADJACENCY_CHARTS,
+  countries: {
+    ...ADJACENCY_CHARTS.countries,
+    [DRAW_1]: rollCountry([
+      rollTrack(1, "Silent one", null),
+      rollTrack(2, "Silent two", null),
+    ]),
+    [DRAW_2]: rollCountry([
+      rollTrack(1, REDRAW_START, "https://example.com/redraw-1.m4a"),
+    ]),
   },
 };
 
@@ -433,8 +496,215 @@ describe("ChartScreen auto-advance", () => {
       audioEngine.end();
     });
 
-    // step(1) finds no track past the tail, returns false, and advances nothing,
-    // so the chart ends in silence rather than wrapping back to the head.
+    // With no other playable chart in the file the roll dead-stops, so the
+    // chart ends in silence rather than wrapping back to the head.
     expect(playingRank(container)).toBeNull();
+  });
+});
+
+describe("ChartScreen end-of-chart roll", () => {
+  let replaceState: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams(`cc=${ADJ_CODE}`);
+    audioEngine.reset();
+    globeChartStore.setState({
+      selectedCountry: null,
+      readMode: false,
+      settleSignal: 0,
+      skipIntent: { dir: 1, nonce: 0 },
+      visited: new Set(),
+    });
+    replaceState = vi
+      .spyOn(window.history, "replaceState")
+      .mockImplementation(() => {});
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Render the chart and start its last playable track, the seat every roll
+  // begins from.
+  function playLastPlayable(charts: ChartFile) {
+    const rendered = render(
+      <ChartScreen charts={charts} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable tail by Tail artist",
+      }),
+    );
+    return rendered;
+  }
+
+  function flashIcon(container: HTMLElement): Element | null {
+    return container.querySelector(".skip-flash svg");
+  }
+
+  test("ending the last playable track rolls into a drawn country and plays its first playable", () => {
+    const { container } = playLastPlayable(ROLL_CHARTS);
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    expect(screen.getByText(LANDING_START)).toBeTruthy();
+    expect(globeChartStore.getState().selectedCountry).toBe(DRAW_1);
+    expect(replaceState).toHaveBeenCalledWith(null, "", `?cc=${DRAW_1}`);
+    const icon = flashIcon(container);
+    expect(icon).not.toBeNull();
+    expect(icon!.getAttribute("class") ?? "").not.toContain("-scale-x-100");
+  });
+
+  test("pressing next at the last playable rolls the same way the ended signal does", () => {
+    playLastPlayable(ROLL_CHARTS);
+    const next = screen.getByRole("button", {
+      name: "Next track",
+    }) as HTMLButtonElement;
+
+    expect(next.disabled).toBe(false);
+    fireEvent.click(next);
+
+    expect(screen.getByText(LANDING_START)).toBeTruthy();
+    expect(globeChartStore.getState().selectedCountry).toBe(DRAW_1);
+  });
+
+  test("a roll leaves a dismissed sheet closed, unlike a plain settle", () => {
+    playLastPlayable(ROLL_CHARTS);
+    const sheet = screen.getByTestId("chart-sheet");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(sheet.dataset.snap).toBe("closed");
+
+    act(() => {
+      audioEngine.end();
+    });
+    act(() => {
+      globeChartStore.getState().signalSettle();
+    });
+
+    expect(screen.getByText(LANDING_START)).toBeTruthy();
+    expect(sheet.dataset.snap).toBe("closed");
+  });
+
+  test("the roll's resurface guard is one-shot: a later settle raises again", () => {
+    playLastPlayable(ROLL_CHARTS);
+    const sheet = screen.getByTestId("chart-sheet");
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    act(() => {
+      audioEngine.end();
+    });
+    act(() => {
+      globeChartStore.getState().signalSettle();
+    });
+    expect(sheet.dataset.snap).toBe("closed");
+
+    act(() => {
+      globeChartStore.getState().signalSettle();
+    });
+    expect(sheet.dataset.snap).toBe("peek");
+  });
+
+  test("an edge-tap skip intent at the last playable rolls with a single forward cue", () => {
+    const { container } = playLastPlayable(ROLL_CHARTS);
+
+    act(() => {
+      globeChartStore.getState().signalSkip(1);
+    });
+
+    expect(screen.getByText(LANDING_START)).toBeTruthy();
+    expect(container.querySelectorAll(".skip-flash")).toHaveLength(1);
+  });
+
+  test("an edge-tap skip intent mid-chart still advances and flashes", () => {
+    const { container } = render(
+      <ChartScreen charts={ROLL_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+
+    act(() => {
+      globeChartStore.getState().signalSkip(1);
+    });
+
+    expect(playingRank(container)).toBe("3");
+    expect(container.querySelectorAll(".skip-flash")).toHaveLength(1);
+  });
+
+  test("a drawn chart with no playable track is redrawn until one can play", () => {
+    playLastPlayable(REDRAW_CHARTS);
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    expect(screen.getByText(REDRAW_START)).toBeTruthy();
+    expect(globeChartStore.getState().selectedCountry).toBe(DRAW_2);
+  });
+
+  test("when every redraw fails the chart dead-stops as before", () => {
+    const { container } = playLastPlayable(ADJACENCY_CHARTS);
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    expect(playingRank(container)).toBeNull();
+    expect(globeChartStore.getState().selectedCountry).toBe(ADJ_CODE);
+    expect(replaceState).not.toHaveBeenCalled();
+    expect(container.querySelector(".skip-flash")).toBeNull();
+  });
+
+  test("prev at the rolled-in first playable returns to the origin's last playable with a reverse cue", () => {
+    const { container } = playLastPlayable(ROLL_CHARTS);
+    act(() => {
+      audioEngine.end();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+    expect(playingRank(container)).toBe("3");
+    expect(globeChartStore.getState().selectedCountry).toBe(ADJ_CODE);
+    expect(replaceState).toHaveBeenCalledWith(null, "", `?cc=${ADJ_CODE}`);
+    expect(flashIcon(container)!.getAttribute("class") ?? "").toContain(
+      "-scale-x-100",
+    );
+  });
+
+  test("rolling forward again after a back-roll performs a fresh draw", () => {
+    playLastPlayable(ROLL_CHARTS);
+    act(() => {
+      audioEngine.end();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    expect(screen.getByText(LANDING_START)).toBeTruthy();
+    expect(globeChartStore.getState().selectedCountry).toBe(DRAW_1);
+  });
+
+  test("a manual country selection discards the back-roll return path", () => {
+    playLastPlayable(ROLL_CHARTS);
+    act(() => {
+      audioEngine.end();
+    });
+
+    act(() => {
+      globeChartStore.getState().setSelectedCountry(DRAW_3);
+    });
+
+    const prev = screen.getByRole("button", {
+      name: "Previous track",
+    }) as HTMLButtonElement;
+    expect(prev.disabled).toBe(true);
   });
 });

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
@@ -10,7 +17,18 @@ import { MiniPlayer } from "@/components/mini-player";
 import { TourHost } from "@/components/tour/tour-host";
 import { findAdjacentPlayable } from "@/lib/adjacent-playable";
 import type { ChartFile, Country } from "@/lib/chart-schema";
-import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
+import {
+  backRollTarget,
+  planRoll,
+  recordAfterSelection,
+  type RollRecord,
+} from "@/lib/end-of-chart-roll";
+import { pickShuffleCountry } from "@/lib/fairness-draw";
+import {
+  type GlobeChartState,
+  globeChartStore,
+  useGlobeChart,
+} from "@/lib/globe-chart-store";
 import { setSkipHandlers } from "@/lib/media-session";
 import {
   AudioStoreProvider,
@@ -83,6 +101,17 @@ function ChartScreenInner({
     dir: 1 | -1;
     nonce: number;
   } | null>(null);
+  // One counter for every skip cue (edge-tap, roll, back-roll): two counters
+  // could collide on a nonce and swallow a flash, since SkipFlash replays only
+  // on a nonce it hasn't seen.
+  const flashNonceRef = useRef(0);
+  const flashSkip = useCallback((dir: 1 | -1) => {
+    flashNonceRef.current += 1;
+    setSkipFlash({ dir, nonce: flashNonceRef.current });
+  }, []);
+  // The pending back-roll origin, or null when prev keeps its end-of-chart
+  // clamp. State, not a ref: it drives the prev button's enabled state.
+  const [rollRecord, setRollRecord] = useState<RollRecord | null>(null);
   const settleSignal = useGlobeChart((s) => s.settleSignal);
   // The gesture-driven selection (the tour's beat-1 signal). Not the countryCode
   // prop: that resolves from useSearchParams, which a replaceState-only globe
@@ -92,7 +121,6 @@ function ChartScreenInner({
   const currentCountryCode = useAudioStore((s) => s.currentCountryCode);
   const hasCurrentTrack = currentTrack !== null;
   const currentTrackRank = currentTrack?.rank ?? null;
-  const endedSignal = useAudioStore((s) => s.endedSignal);
   const audioStore = useAudioStoreApi();
 
   useEffect(() => {
@@ -144,11 +172,18 @@ function ChartScreenInner({
 
   // A globe landing resurfaces the result: raise a dismissed sheet to peek.
   // Ref-gated so only an actual settle (a bumped signal) triggers it, never a
-  // dep-only re-run, and so the mount value never force-raises.
+  // dep-only re-run, and so the mount value never force-raises. An end-of-chart
+  // roll arms suppressResurfaceRef first, so its own settle continues playback
+  // without reopening a sheet the listener closed.
   const prevSettleRef = useRef(settleSignal);
+  const suppressResurfaceRef = useRef(false);
   useEffect(() => {
     if (settleSignal === prevSettleRef.current) return;
     prevSettleRef.current = settleSignal;
+    if (suppressResurfaceRef.current) {
+      suppressResurfaceRef.current = false;
+      return;
+    }
     setSnap((s) => (s === "hidden" || s === "closed" ? "peek" : s));
   }, [settleSignal]);
 
@@ -175,51 +210,113 @@ function ChartScreenInner({
     }));
   }, [audioStore, handleMiniTap]);
 
-  // Step within the source country, not the visible one. Reads live store state
-  // so the callbacks stay stable across track changes.
+  // Step within the source country, not the visible one. Reads live audio
+  // state so the callback survives track changes; it re-forms only when the
+  // roll record turns over. Past the last playable, next rolls into a fresh
+  // fairness-drawn country instead of clamping; prev at a rolled-in chart's
+  // first playable rolls back to the origin. Every next/prev surface routes
+  // through here, so all of them inherit the roll.
   const step = useCallback(
-    (dir: 1 | -1): boolean => {
+    (dir: 1 | -1): "adjacent" | "rolled" | "backRolled" | null => {
       const { currentTrack, currentCountryCode, toggle } =
         audioStore.getState();
-      if (currentTrack === null || currentCountryCode === null) return false;
+      if (currentTrack === null || currentCountryCode === null) return null;
       const source = charts.countries[currentCountryCode];
-      if (!source) return false;
+      if (!source) return null;
       const adj = findAdjacentPlayable(source.tracks, currentTrack, dir);
-      if (!adj) return false;
-      toggle(adj, currentCountryCode);
-      return true;
+      if (adj) {
+        toggle(adj, currentCountryCode);
+        return "adjacent";
+      }
+      if (dir === 1) {
+        const { visited, selectedCountry, setSelectedCountry } =
+          globeChartStore.getState();
+        const landing = planRoll(
+          charts.countries,
+          currentCountryCode,
+          (exclude) => pickShuffleCountry(visited, exclude),
+        );
+        if (!landing) return null;
+        // Playback first (same task as the triggering gesture or ended event),
+        // then the record, then the landing side effects. The record must be
+        // queued before setSelectedCountry so the selection subscription reads
+        // the landing as the roll's own, not a manual pick to clear on. Arm the
+        // resurface guard before the selection so the roll's settle continues
+        // playback without reopening a dismissed sheet, but only when the code
+        // actually changes: a no-op selection produces no settle, so an armed
+        // flag would linger and swallow a later unrelated resurface.
+        toggle(landing.track, landing.code);
+        setRollRecord({
+          originCountryCode: currentCountryCode,
+          originTrack: currentTrack,
+          rolledToCode: landing.code,
+        });
+        if (landing.code !== selectedCountry)
+          suppressResurfaceRef.current = true;
+        setSelectedCountry(landing.code);
+        window.history.replaceState(null, "", `?cc=${landing.code}`);
+        flashSkip(1);
+        return "rolled";
+      }
+      const back = backRollTarget(
+        rollRecord,
+        charts.countries,
+        currentTrack,
+        currentCountryCode,
+      );
+      if (!back) return null;
+      toggle(back.track, back.countryCode);
+      setRollRecord(null);
+      const store = globeChartStore.getState();
+      if (back.countryCode !== store.selectedCountry)
+        suppressResurfaceRef.current = true;
+      store.setSelectedCountry(back.countryCode);
+      window.history.replaceState(null, "", `?cc=${back.countryCode}`);
+      flashSkip(-1);
+      return "backRolled";
     },
-    [audioStore, charts.countries],
+    [audioStore, charts.countries, rollRecord, flashSkip],
   );
   const goPrev = useCallback(() => step(-1), [step]);
   const goNext = useCallback(() => step(1), [step]);
 
   // A track ending advances through the same step as the buttons, swipe, media
-  // keys, and edge-tap, so every "next track" shares one adjacency rule. Step
-  // no-ops past the last playable track, so the chart still ends in silence.
-  // Ref-gated so only an actual ended event advances, never a dep-only re-run.
-  const prevEndedRef = useRef(endedSignal);
+  // keys, and edge-tap, so every "next track" shares one adjacency rule and,
+  // past the last playable, the same roll into a fresh country. A direct store
+  // subscription (not a selector + effect) because the ended signal is an
+  // external event to react to, not state this screen renders; the signal diff
+  // means only an actual ended event advances, never a resubscribe. step is an
+  // Effect Event so its dep churn (it re-forms on every rollRecord change) never
+  // tears down and re-subscribes the store listener.
+  const advanceOnEnded = useEffectEvent(() => step(1));
   useEffect(() => {
-    if (endedSignal === prevEndedRef.current) return;
-    prevEndedRef.current = endedSignal;
-    if (endedSignal === 0) return;
-    step(1);
-  }, [endedSignal, step]);
+    return audioStore.subscribe((state, prev) => {
+      if (state.endedSignal !== prev.endedSignal) advanceOnEnded();
+    });
+  }, [audioStore]);
 
   const canPrev = useMemo(() => {
     if (currentTrack === null || currentCountryCode === null) return false;
     const source = charts.countries[currentCountryCode];
-    return source
-      ? findAdjacentPlayable(source.tracks, currentTrack, -1) !== null
-      : false;
-  }, [currentTrack, currentCountryCode, charts.countries]);
-  const canNext = useMemo(() => {
-    if (currentTrack === null || currentCountryCode === null) return false;
-    const source = charts.countries[currentCountryCode];
-    return source
-      ? findAdjacentPlayable(source.tracks, currentTrack, 1) !== null
-      : false;
-  }, [currentTrack, currentCountryCode, charts.countries]);
+    if (
+      source &&
+      findAdjacentPlayable(source.tracks, currentTrack, -1) !== null
+    ) {
+      return true;
+    }
+    return (
+      backRollTarget(
+        rollRecord,
+        charts.countries,
+        currentTrack,
+        currentCountryCode,
+      ) !== null
+    );
+  }, [currentTrack, currentCountryCode, charts.countries, rollRecord]);
+  // Next never dead-ends while listening: past the last playable the step
+  // rolls into a fresh country, and if even the bounded redraws fail it
+  // no-ops, so the button need not predict the draw.
+  const canNext = hasCurrentTrack && currentCountryCode !== null;
 
   // Skip lives here, not in the audio store: routing prev/next needs the chart
   // data to find the adjacent playable track, which the store doesn't hold.
@@ -237,16 +334,29 @@ function ChartScreenInner({
   }, [hasCurrentTrack]);
 
   // A globe edge-tap raises a skip-intent; the chart owns adjacency, so it runs
-  // the shared step and flashes only on a real track change. Subscribing to the
-  // store sets flash state inside the change callback (the pattern for reacting
-  // to an external system) and spares the screen a re-render per skip. The nonce
-  // diff drops dep-only re-runs; step's own return gates the clamped end-of-list.
-  useEffect(() => {
-    return globeChartStore.subscribe((state, prev) => {
-      if (state.skipIntent.nonce === prev.skipIntent.nonce) return;
-      if (step(state.skipIntent.dir)) setSkipFlash(state.skipIntent);
-    });
-  }, [step]);
+  // the shared step and flashes only on a real track change. Reacting inside the
+  // change callback (the pattern for an external system) spares the screen a
+  // re-render per skip. A roll or back-roll fires its own cue inside step, so
+  // only a plain adjacent move flashes here. The same signal watches
+  // selectedCountry: any selection that isn't the roll's own landing discards
+  // the back-roll record, which is how a manual country pick clears it. An
+  // Effect Event captures the latest step/flashSkip so the store listener
+  // subscribes once for the screen's life, never re-subscribing on their churn.
+  const onGlobeSignal = useEffectEvent(
+    (state: GlobeChartState, prev: GlobeChartState) => {
+      if (state.skipIntent.nonce !== prev.skipIntent.nonce) {
+        if (step(state.skipIntent.dir) === "adjacent") {
+          flashSkip(state.skipIntent.dir);
+        }
+      }
+      if (state.selectedCountry !== prev.selectedCountry) {
+        setRollRecord((record) =>
+          recordAfterSelection(record, state.selectedCountry),
+        );
+      }
+    },
+  );
+  useEffect(() => globeChartStore.subscribe(onGlobeSignal), []);
 
   return (
     <>

--- a/src/components/globe/globe-scene.tsx
+++ b/src/components/globe/globe-scene.tsx
@@ -5,6 +5,7 @@ import { Canvas, useThree } from "@react-three/fiber";
 import { PerspectiveCamera } from "three";
 
 import { COUNTRIES } from "@/lib/countries";
+import { addVisited, pickShuffleCountry } from "@/lib/fairness-draw";
 import { globeChartStore, useGlobeChart } from "@/lib/globe-chart-store";
 import { getCountryOutlinesPromise } from "@/lib/topo-loader";
 import { tourBridge } from "@/lib/tour-bridge";
@@ -16,7 +17,6 @@ import { CountryFill } from "./country-fill";
 import { CountryOutlinesLayer } from "./country-outlines";
 import { CountryPins } from "./country-pins";
 import { triggerLandingHaptic } from "./landing-haptic";
-import { addVisited, pickShuffleCountry } from "./spin-select";
 import { SpinSnapControls } from "./spin-snap-controls";
 import { StarBackdrop } from "./star-backdrop";
 
@@ -71,12 +71,17 @@ function SceneContent() {
   const selectedIsoNum =
     selectedCode !== null ? (ISO_BY_CODE.get(selectedCode) ?? null) : null;
 
-  // Per-session anti-repeat memory for the fairness-weighted fling; resets on
-  // reload. Seeded once with whatever the globe first centered on.
+  // The anti-repeat memory lives in the globe-chart store (the chart draws
+  // from it too); the globe owns the writes. Seed it once with whatever the
+  // globe first centered on, in a lazy initializer so the write runs exactly
+  // once at mount rather than in an effect that a later re-render could re-fire;
+  // addVisited is idempotent, so a Strict-Mode double-invoke is harmless.
   const [initialCode] = useState(() => selectedCode ?? FALLBACK_CODE);
-  const [visited, setVisited] = useState<ReadonlySet<string>>(
-    () => new Set([initialCode]),
-  );
+  useState(() => {
+    const store = globeChartStore.getState();
+    store.setVisited(addVisited(store.visited, initialCode));
+  });
+  const visited = useGlobeChart((s) => s.visited);
 
   // A landing is a selection: buzz where supported, write ?cc= (replaceState,
   // so rapid flinging doesn't flood history), record the country as visited,
@@ -89,9 +94,11 @@ function SceneContent() {
       globeChartStore.getState().signalSettle(viaTap);
       if (!changed) return;
       triggerLandingHaptic();
-      globeChartStore.getState().setSelectedCountry(code);
+      const { setSelectedCountry, visited, setVisited } =
+        globeChartStore.getState();
+      setSelectedCountry(code);
       window.history.replaceState(null, "", `?cc=${code}`);
-      setVisited((prev) => addVisited(prev, code));
+      setVisited(addVisited(visited, code));
     },
     [],
   );
@@ -108,7 +115,7 @@ function SceneContent() {
   useEffect(() => {
     if (shuffleSignal === prevShuffleRef.current) return;
     prevShuffleRef.current = shuffleSignal;
-    const code = pickShuffleCountry(visited, selectedCode ?? initialCode);
+    const code = pickShuffleCountry(visited, [selectedCode ?? initialCode]);
     globeChartStore.getState().shuffleTo(code);
   }, [shuffleSignal, visited, selectedCode, initialCode]);
 

--- a/src/components/globe/spin-select.test.ts
+++ b/src/components/globe/spin-select.test.ts
@@ -5,13 +5,10 @@ import { COUNTRIES, type CountryEntry } from "@/lib/countries";
 import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
 
 import {
-  addVisited,
   pickNearestToPoint,
-  pickShuffleCountry,
   pickSnapCountry,
   projectFrontCountries,
   rankNearest,
-  weightedDraw,
 } from "./spin-select";
 
 const GLOBE_RADIUS = 3.5;
@@ -103,25 +100,6 @@ test("rankNearest caps the pool at n", () => {
   expect(rankNearest(0, 0, 5)).toHaveLength(5);
 });
 
-test("weightedDraw overwhelmingly prefers an unvisited country in the pool", () => {
-  const [seen, unseen] = COUNTRIES;
-  const pool = [seen.code, unseen.code];
-  const visited = new Set([seen.code]);
-
-  for (const r of [0.1, 0.5, 0.9]) {
-    expect(weightedDraw(pool, visited, r)).toBe(unseen.code);
-  }
-});
-
-test("weightedDraw flattens to a uniform draw once every pool member is visited", () => {
-  const [first, second] = COUNTRIES;
-  const pool = [first.code, second.code];
-  const visited = new Set([first.code, second.code]);
-
-  expect(weightedDraw(pool, visited, 0.25)).toBe(first.code);
-  expect(weightedDraw(pool, visited, 0.75)).toBe(second.code);
-});
-
 test("pickSnapCountry returns the literal nearest country when fairness is off", () => {
   const target = COUNTRIES[0];
 
@@ -189,67 +167,4 @@ test("every country appears in some nearest pool over the reachable sphere", () 
     (c) => c.code,
   );
   expect(unreachable).toEqual([]);
-});
-
-test("pickShuffleCountry never returns the country already shown", () => {
-  const current = COUNTRIES[0].code;
-
-  // Sweep the whole draw range: none of it may land back on the current country.
-  for (let r = 0; r < 1; r += 0.02) {
-    expect(pickShuffleCountry(new Set(), current, () => r)).not.toBe(current);
-  }
-});
-
-test("pickShuffleCountry draws from the whole globe, not a rest-direction cluster", () => {
-  // r=0 takes the first pool member. With the current country excluded that is
-  // the first COUNTRIES entry that isn't current, so the pool spans every
-  // country rather than a geographic neighbourhood.
-  const current = COUNTRIES[1].code;
-  const firstOther = COUNTRIES.find((c) => c.code !== current)!.code;
-
-  expect(pickShuffleCountry(new Set(), current, () => 0)).toBe(firstOther);
-});
-
-test("pickShuffleCountry allows any country when nothing is shown yet", () => {
-  expect(pickShuffleCountry(new Set(), null, () => 0)).toBe(COUNTRIES[0].code);
-});
-
-test("pickShuffleCountry favours an unvisited country over any single visited one", () => {
-  // Visit every country but one; the current (also visited) is excluded from the
-  // pool. Across a uniform draw sweep the unvisited country wins far more often
-  // than any single visited one, and the current country never appears.
-  const current = COUNTRIES[0].code;
-  const unseen = COUNTRIES[COUNTRIES.length - 1].code;
-  const visited = new Set(
-    COUNTRIES.filter((c) => c.code !== current && c.code !== unseen).map(
-      (c) => c.code,
-    ),
-  );
-
-  const counts = new Map<string, number>();
-  for (let r = 0; r < 1; r += 0.001) {
-    const code = pickShuffleCountry(visited, current, () => r);
-    counts.set(code, (counts.get(code) ?? 0) + 1);
-  }
-
-  const unseenCount = counts.get(unseen) ?? 0;
-  const maxVisited = Math.max(
-    ...[...counts]
-      .filter(([code]) => code !== unseen)
-      .map(([, count]) => count),
-  );
-  expect(counts.has(current)).toBe(false);
-  expect(unseenCount).toBeGreaterThan(maxVisited);
-});
-
-test("addVisited records a newly settled country in the visited set", () => {
-  const result = addVisited(new Set(["us"]), "kr");
-
-  expect([...result].sort()).toEqual(["kr", "us"]);
-});
-
-test("addVisited returns the same set when the country is already visited", () => {
-  const visited = new Set(["us"]);
-
-  expect(addVisited(visited, "us")).toBe(visited);
 });

--- a/src/components/globe/spin-select.ts
+++ b/src/components/globe/spin-select.ts
@@ -2,6 +2,7 @@ import type { Camera } from "three";
 import { Vector3 } from "three";
 
 import { COUNTRIES, type CountryEntry } from "@/lib/countries";
+import { weightedDraw } from "@/lib/fairness-draw";
 import { latLonToVec3 } from "@/lib/lat-lon-to-vec3";
 
 const DEG = Math.PI / 180;
@@ -94,39 +95,6 @@ export function rankNearest(el: number, az: number, n: number): PoolEntry[] {
     .slice(0, n);
 }
 
-const VISITED_WEIGHT = 0.08; // how strongly an already-seen country is avoided
-
-// Weighted random draw from `pool`, biased away from already-visited countries
-// so the same few do not repeat. `r` (in [0, 1)) is the injected draw position,
-// so the bias stays testable without stubbing Math.random.
-export function weightedDraw(
-  pool: readonly string[],
-  visited: ReadonlySet<string>,
-  r: number,
-): string {
-  const weights = pool.map((code) => (visited.has(code) ? VISITED_WEIGHT : 1));
-  const total = weights.reduce((sum, w) => sum + w, 0);
-  let position = r * total;
-  for (let i = 0; i < pool.length; i++) {
-    position -= weights[i];
-    if (position <= 0) return pool[i];
-  }
-  return pool[pool.length - 1];
-}
-
-// The visited set with `code` added. Returns the input set unchanged when the
-// code is already present, so settling on the same country does not force a
-// re-render through a functional setState.
-export function addVisited(
-  visited: ReadonlySet<string>,
-  code: string,
-): ReadonlySet<string> {
-  if (visited.has(code)) return visited;
-  const next = new Set(visited);
-  next.add(code);
-  return next;
-}
-
 const SNAP_POOL = 10; // candidate countries near the rest point for a fair snap
 // Past this angle (radians) from the rest direction a country is across open
 // water, not a near neighbour. Beyond it fairness has no genuine cluster to
@@ -159,24 +127,4 @@ export function pickSnapCountry(
     visited,
     rng(),
   );
-}
-
-const ALL_CODES = COUNTRIES.map((c) => c.code);
-
-// Shuffle target: a fair random country from anywhere on the globe, never the
-// one already shown so "surprise me" always lands somewhere new. Unlike
-// pickSnapCountry there is no rest direction — geography doesn't narrow the pool,
-// every country is a candidate — but the draw reuses the same visited-weighting,
-// so a run of shuffles spreads across the map instead of repeating. Randomness
-// enters via `rng` (defaults to Math.random), injected so the draw stays
-// testable.
-export function pickShuffleCountry(
-  visited: ReadonlySet<string>,
-  current: string | null,
-  rng: () => number = Math.random,
-): string {
-  const pool = current
-    ? ALL_CODES.filter((code) => code !== current)
-    : ALL_CODES;
-  return weightedDraw(pool, visited, rng());
 }

--- a/src/lib/end-of-chart-roll.test.ts
+++ b/src/lib/end-of-chart-roll.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "vitest";
+
+import type { ChartFile, Country, Track } from "./chart-schema";
+import {
+  backRollTarget,
+  firstPlayable,
+  MAX_ROLL_ATTEMPTS,
+  planRoll,
+  recordAfterSelection,
+  type RollRecord,
+} from "./end-of-chart-roll";
+
+function makeTrack(
+  rank: number,
+  previewUrl: string | null,
+  appleUrl = `https://music.apple.com/x?i=${rank}`,
+): Track {
+  return {
+    rank,
+    name: `Track ${rank}`,
+    artist: `Artist ${rank}`,
+    previewUrl,
+    artworkUrl: "https://example.com/art.jpg",
+    appleUrl,
+    spotifyUrl: "https://open.spotify.com/search/x",
+  };
+}
+
+function makeCountry(tracks: Track[]): Country {
+  return { name: "Chart under test", valid: true, tracks };
+}
+
+// A draw stub that answers from a fixed queue and records the exclusion list
+// passed to each attempt, so tests can assert what a redraw may not repeat.
+function queuedDraw(codes: string[]) {
+  const excludeSeen: string[][] = [];
+  let call = 0;
+  const draw = (exclude: readonly string[]) => {
+    excludeSeen.push([...exclude]);
+    return codes[Math.min(call++, codes.length - 1)];
+  };
+  return { draw, excludeSeen };
+}
+
+const ORIGIN_CODE = "aa";
+
+describe("firstPlayable", () => {
+  test("skips leading tracks with no preview", () => {
+    const leadingGap = makeTrack(1, null);
+    const target = makeTrack(2, "https://example.com/2.m4a");
+    const later = makeTrack(3, "https://example.com/3.m4a");
+
+    expect(firstPlayable([leadingGap, target, later])).toBe(target);
+  });
+
+  test("returns null when no track can play", () => {
+    expect(firstPlayable([makeTrack(1, null), makeTrack(2, null)])).toBeNull();
+    expect(firstPlayable([])).toBeNull();
+  });
+});
+
+describe("planRoll", () => {
+  const playableHead = makeTrack(1, "https://example.com/1.m4a");
+
+  test("lands on the first draw when its chart can play, starting at its first playable", () => {
+    const gap = makeTrack(1, null);
+    const target = makeTrack(2, "https://example.com/2.m4a");
+    const countries: ChartFile["countries"] = {
+      [ORIGIN_CODE]: makeCountry([playableHead]),
+      bb: makeCountry([gap, target]),
+    };
+    const { draw, excludeSeen } = queuedDraw(["bb"]);
+
+    const landing = planRoll(countries, ORIGIN_CODE, draw);
+
+    expect(landing).toEqual({ code: "bb", track: target });
+    expect(excludeSeen).toEqual([[ORIGIN_CODE]]);
+  });
+
+  test("redraws past a drawn code with no chart, excluding the failed candidate", () => {
+    const countries: ChartFile["countries"] = {
+      [ORIGIN_CODE]: makeCountry([playableHead]),
+      cc: makeCountry([playableHead]),
+    };
+    const { draw, excludeSeen } = queuedDraw(["bb", "cc"]);
+
+    const landing = planRoll(countries, ORIGIN_CODE, draw);
+
+    expect(landing?.code).toBe("cc");
+    expect(excludeSeen).toEqual([[ORIGIN_CODE], [ORIGIN_CODE, "bb"]]);
+  });
+
+  test("redraws past a drawn chart with no playable track", () => {
+    const countries: ChartFile["countries"] = {
+      [ORIGIN_CODE]: makeCountry([playableHead]),
+      bb: makeCountry([makeTrack(1, null), makeTrack(2, null)]),
+      cc: makeCountry([playableHead]),
+    };
+    const { draw } = queuedDraw(["bb", "cc"]);
+
+    expect(planRoll(countries, ORIGIN_CODE, draw)?.code).toBe("cc");
+  });
+
+  test("every redraw excludes the origin and all earlier failed candidates", () => {
+    const countries: ChartFile["countries"] = {
+      [ORIGIN_CODE]: makeCountry([playableHead]),
+    };
+    const { draw, excludeSeen } = queuedDraw(["bb", "cc", "dd"]);
+
+    planRoll(countries, ORIGIN_CODE, draw);
+
+    expect(excludeSeen).toEqual([
+      [ORIGIN_CODE],
+      [ORIGIN_CODE, "bb"],
+      [ORIGIN_CODE, "bb", "cc"],
+    ]);
+  });
+
+  test("stops after the attempt bound and falls back to a dead stop", () => {
+    const countries: ChartFile["countries"] = {
+      [ORIGIN_CODE]: makeCountry([playableHead]),
+    };
+    const { draw, excludeSeen } = queuedDraw(["bb", "cc", "dd", "ee"]);
+
+    const landing = planRoll(countries, ORIGIN_CODE, draw);
+
+    expect(landing).toBeNull();
+    expect(excludeSeen).toHaveLength(MAX_ROLL_ATTEMPTS);
+  });
+});
+
+describe("backRollTarget", () => {
+  const originLast = makeTrack(9, "https://example.com/9.m4a");
+  const rolledGap = makeTrack(1, null);
+  const rolledFirst = makeTrack(2, "https://example.com/r2.m4a");
+  const rolledSecond = makeTrack(3, "https://example.com/r3.m4a");
+  const countries: ChartFile["countries"] = {
+    [ORIGIN_CODE]: makeCountry([originLast]),
+    bb: makeCountry([rolledGap, rolledFirst, rolledSecond]),
+  };
+  const record: RollRecord = {
+    originCountryCode: ORIGIN_CODE,
+    originTrack: originLast,
+    rolledToCode: "bb",
+  };
+
+  test("returns the origin at the rolled-in chart's first playable", () => {
+    expect(backRollTarget(record, countries, rolledFirst, "bb")).toEqual({
+      countryCode: ORIGIN_CODE,
+      track: originLast,
+    });
+  });
+
+  test("keeps the clamp past the rolled-in chart's first playable", () => {
+    expect(backRollTarget(record, countries, rolledSecond, "bb")).toBeNull();
+  });
+
+  test("keeps the clamp when playback is not on the rolled-in chart", () => {
+    expect(backRollTarget(record, countries, rolledFirst, "cc")).toBeNull();
+    expect(
+      backRollTarget(record, countries, originLast, ORIGIN_CODE),
+    ).toBeNull();
+  });
+
+  test("keeps the clamp with no record or nothing playing", () => {
+    expect(backRollTarget(null, countries, rolledFirst, "bb")).toBeNull();
+    expect(backRollTarget(record, countries, null, "bb")).toBeNull();
+  });
+
+  test("keeps the clamp when the rolled-in chart is gone from the chart file", () => {
+    const withoutRolled: ChartFile["countries"] = {
+      [ORIGIN_CODE]: makeCountry([originLast]),
+    };
+
+    expect(backRollTarget(record, withoutRolled, rolledFirst, "bb")).toBeNull();
+  });
+});
+
+describe("recordAfterSelection", () => {
+  const record: RollRecord = {
+    originCountryCode: ORIGIN_CODE,
+    originTrack: makeTrack(9, "https://example.com/9.m4a"),
+    rolledToCode: "bb",
+  };
+
+  test("keeps the record when the selection is the roll's own landing", () => {
+    expect(recordAfterSelection(record, "bb")).toBe(record);
+  });
+
+  test("clears the record when the selection moves anywhere else", () => {
+    expect(recordAfterSelection(record, "cc")).toBeNull();
+    expect(recordAfterSelection(record, ORIGIN_CODE)).toBeNull();
+    expect(recordAfterSelection(record, null)).toBeNull();
+  });
+
+  test("passes a missing record through", () => {
+    expect(recordAfterSelection(null, "bb")).toBeNull();
+  });
+});

--- a/src/lib/end-of-chart-roll.ts
+++ b/src/lib/end-of-chart-roll.ts
@@ -1,0 +1,84 @@
+import type { ChartFile, Track } from "./chart-schema";
+import { sameTrack } from "./track-identity";
+
+// Redraw bound for a roll whose drawn chart can't continue playback (absent
+// from the chart file, or every track preview-less). Past it the player
+// dead-stops, the pre-roll end-of-chart behavior.
+export const MAX_ROLL_ATTEMPTS = 3;
+
+// Where a roll came from, kept at depth exactly one: prev at the rolled-in
+// chart's first playable returns here, and a manual country selection or a
+// consumed back-roll discards it. `rolledToCode` both locates the return point
+// and marks the roll's own landing so it isn't read as a manual selection.
+export interface RollRecord {
+  originCountryCode: string;
+  originTrack: Track;
+  rolledToCode: string;
+}
+
+/** The first track that can play, or null when none can. */
+export function firstPlayable(tracks: Track[]): Track | null {
+  for (const track of tracks) {
+    if (track.previewUrl !== null) return track;
+  }
+  return null;
+}
+
+export interface RollLanding {
+  code: string;
+  track: Track;
+}
+
+/**
+ * The country a forward roll lands in and the track it starts, or null for a
+ * dead stop. `draw` is the fairness draw; each attempt excludes the origin and
+ * every candidate that already failed, so a redraw can't repeat a dead chart.
+ */
+export function planRoll(
+  countries: ChartFile["countries"],
+  originCountryCode: string,
+  draw: (exclude: readonly string[]) => string,
+  maxAttempts: number = MAX_ROLL_ATTEMPTS,
+): RollLanding | null {
+  const exclude = [originCountryCode];
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const code = draw(exclude);
+    const country = countries[code];
+    const track = country ? firstPlayable(country.tracks) : null;
+    if (track) return { code, track };
+    exclude.push(code);
+  }
+  return null;
+}
+
+/**
+ * The origin a back-roll returns to, or null when prev should keep its clamp:
+ * a back-roll is offered only while a record exists and playback sits on the
+ * rolled-in chart's first playable, the exact seat a roll lands on.
+ */
+export function backRollTarget(
+  record: RollRecord | null,
+  countries: ChartFile["countries"],
+  currentTrack: Track | null,
+  currentCountryCode: string | null,
+): { countryCode: string; track: Track } | null {
+  if (record === null || currentTrack === null) return null;
+  if (currentCountryCode !== record.rolledToCode) return null;
+  const rolled = countries[record.rolledToCode];
+  const first = rolled ? firstPlayable(rolled.tracks) : null;
+  if (first === null || !sameTrack(first, currentTrack)) return null;
+  return { countryCode: record.originCountryCode, track: record.originTrack };
+}
+
+/**
+ * The record after a country selection: kept only when the selection is the
+ * roll's own landing, so the roll setting its target doesn't discard the
+ * return path but any other selection (manual or a later landing) does.
+ */
+export function recordAfterSelection(
+  record: RollRecord | null,
+  selectedCode: string | null,
+): RollRecord | null {
+  if (record === null) return null;
+  return selectedCode === record.rolledToCode ? record : null;
+}

--- a/src/lib/fairness-draw.test.ts
+++ b/src/lib/fairness-draw.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "vitest";
+
+import { COUNTRIES } from "./countries";
+import { addVisited, pickShuffleCountry, weightedDraw } from "./fairness-draw";
+
+test("weightedDraw overwhelmingly prefers an unvisited country in the pool", () => {
+  const [seen, unseen] = COUNTRIES;
+  const pool = [seen.code, unseen.code];
+  const visited = new Set([seen.code]);
+
+  for (const r of [0.1, 0.5, 0.9]) {
+    expect(weightedDraw(pool, visited, r)).toBe(unseen.code);
+  }
+});
+
+test("weightedDraw flattens to a uniform draw once every pool member is visited", () => {
+  const [first, second] = COUNTRIES;
+  const pool = [first.code, second.code];
+  const visited = new Set([first.code, second.code]);
+
+  expect(weightedDraw(pool, visited, 0.25)).toBe(first.code);
+  expect(weightedDraw(pool, visited, 0.75)).toBe(second.code);
+});
+
+test("pickShuffleCountry never returns an excluded country", () => {
+  const excluded = COUNTRIES[0].code;
+
+  // Sweep the whole draw range: none of it may land on an excluded country.
+  for (let r = 0; r < 1; r += 0.02) {
+    expect(pickShuffleCountry(new Set(), [excluded], () => r)).not.toBe(
+      excluded,
+    );
+  }
+});
+
+test("pickShuffleCountry excludes every listed code, not only the first", () => {
+  const excluded = COUNTRIES.slice(0, 3).map((c) => c.code);
+
+  for (let r = 0; r < 1; r += 0.02) {
+    expect(excluded).not.toContain(
+      pickShuffleCountry(new Set(), excluded, () => r),
+    );
+  }
+});
+
+test("pickShuffleCountry draws from the whole globe, not a rest-direction cluster", () => {
+  // r=0 takes the first pool member. With one country excluded that is the
+  // first entry that isn't it, so the pool spans every country rather than a
+  // geographic neighbourhood.
+  const excluded = COUNTRIES[1].code;
+  const firstOther = COUNTRIES.find((c) => c.code !== excluded)!.code;
+
+  expect(pickShuffleCountry(new Set(), [excluded], () => 0)).toBe(firstOther);
+});
+
+test("pickShuffleCountry allows any country when nothing is excluded", () => {
+  expect(pickShuffleCountry(new Set(), [], () => 0)).toBe(COUNTRIES[0].code);
+});
+
+test("pickShuffleCountry favours an unvisited country over any single visited one", () => {
+  // Visit every country but one; the excluded (also visited) never enters the
+  // pool. Across a uniform draw sweep the unvisited country wins far more often
+  // than any single visited one, and the excluded country never appears.
+  const excluded = COUNTRIES[0].code;
+  const unseen = COUNTRIES[COUNTRIES.length - 1].code;
+  const visited = new Set(
+    COUNTRIES.filter((c) => c.code !== excluded && c.code !== unseen).map(
+      (c) => c.code,
+    ),
+  );
+
+  const counts = new Map<string, number>();
+  for (let r = 0; r < 1; r += 0.001) {
+    const code = pickShuffleCountry(visited, [excluded], () => r);
+    counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+
+  const unseenCount = counts.get(unseen) ?? 0;
+  const maxVisited = Math.max(
+    ...[...counts]
+      .filter(([code]) => code !== unseen)
+      .map(([, count]) => count),
+  );
+  expect(counts.has(excluded)).toBe(false);
+  expect(unseenCount).toBeGreaterThan(maxVisited);
+});
+
+test("addVisited records a newly settled country in the visited set", () => {
+  const result = addVisited(new Set(["us"]), "kr");
+
+  expect([...result].sort()).toEqual(["kr", "us"]);
+});
+
+test("addVisited returns the same set when the country is already visited", () => {
+  const visited = new Set(["us"]);
+
+  expect(addVisited(visited, "us")).toBe(visited);
+});

--- a/src/lib/fairness-draw.ts
+++ b/src/lib/fairness-draw.ts
@@ -1,0 +1,54 @@
+import { COUNTRIES } from "./countries";
+
+const VISITED_WEIGHT = 0.08; // how strongly an already-seen country is avoided
+
+// Weighted random draw from `pool`, biased away from already-visited countries
+// so the same few do not repeat. `r` (in [0, 1)) is the injected draw position,
+// so the bias stays testable without stubbing Math.random.
+export function weightedDraw(
+  pool: readonly string[],
+  visited: ReadonlySet<string>,
+  r: number,
+): string {
+  const weights = pool.map((code) => (visited.has(code) ? VISITED_WEIGHT : 1));
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  let position = r * total;
+  for (let i = 0; i < pool.length; i++) {
+    position -= weights[i];
+    if (position <= 0) return pool[i];
+  }
+  return pool[pool.length - 1];
+}
+
+// The visited set with `code` added. Returns the input set unchanged when the
+// code is already present, so settling on the same country does not force a
+// re-render through a functional setState.
+export function addVisited(
+  visited: ReadonlySet<string>,
+  code: string,
+): ReadonlySet<string> {
+  if (visited.has(code)) return visited;
+  const next = new Set(visited);
+  next.add(code);
+  return next;
+}
+
+const ALL_CODES = COUNTRIES.map((c) => c.code);
+
+// A fair random country from anywhere on the globe, never one in `exclude`
+// (the country already shown, plus any candidates the caller has already
+// rejected), so a shuffle always lands somewhere new and an end-of-chart roll
+// never redraws a chart that already failed. Unlike the fling snap there is no
+// rest direction: geography doesn't narrow the pool, every country is a
+// candidate, but the draw reuses the same visited-weighting, so repeated draws
+// spread across the map instead of repeating. Randomness enters via `rng`
+// (defaults to Math.random), injected so the draw stays testable.
+export function pickShuffleCountry(
+  visited: ReadonlySet<string>,
+  exclude: readonly string[],
+  rng: () => number = Math.random,
+): string {
+  const excluded = new Set(exclude);
+  const pool = ALL_CODES.filter((code) => !excluded.has(code));
+  return weightedDraw(pool, visited, rng());
+}

--- a/src/lib/globe-chart-store.ts
+++ b/src/lib/globe-chart-store.ts
@@ -43,6 +43,12 @@ export interface GlobeChartState {
   // set does), so the button can't run it directly; it signals across this seam
   // and the globe draws and settles like any other landing.
   shuffleSignal: number;
+  // Per-session anti-repeat memory behind every fairness draw (fling snap,
+  // shuffle, end-of-chart roll); resets on reload. The globe writes it on each
+  // landing. It lives here rather than in the globe tree because the chart
+  // draws from it too: an end-of-chart roll picks its country with the same
+  // visited-weighting a shuffle uses.
+  visited: ReadonlySet<string>;
   // The country a shuffle just drew, set by the globe when it lands one. The
   // screen-reader announcement keys on this rather than the next selectedCountry
   // change, so a selection from another source (a fling settling, a list pick)
@@ -50,6 +56,7 @@ export interface GlobeChartState {
   // even if a later shuffle repeats the country.
   shuffleLanded: { code: string; nonce: number } | null;
   setSelectedCountry: (code: string | null) => void;
+  setVisited: (visited: ReadonlySet<string>) => void;
   setReadMode: (readMode: boolean) => void;
   signalSettle: (viaTap?: boolean) => void;
   setListening: (listening: boolean) => void;
@@ -66,9 +73,11 @@ export const globeChartStore = createStore<GlobeChartState>()((set) => ({
   lastSettleViaTap: false,
   listening: false,
   skipIntent: { dir: 1, nonce: 0 },
+  visited: new Set<string>(),
   shuffleSignal: 0,
   shuffleLanded: null,
   setSelectedCountry: (selectedCountry) => set({ selectedCountry }),
+  setVisited: (visited) => set({ visited }),
   setReadMode: (readMode) => set({ readMode }),
   signalSettle: (viaTap = false) =>
     set((state) => ({


### PR DESCRIPTION
Finishing a country's chart was a silent dead-end: the mini-player froze on the last track with no cue, breaking the listening loop for the most engaged listeners. Now the last playable track finishing (or a manual next there) rolls into a fresh fairness-drawn country, auto-plays its first playable track, and fires the forward skip cue, so discovery continues without a stall. Prev at the rolled-in first track rolls back one step to the origin's last track; any manual country pick clears that return path. If drawn charts are unplayable it redraws up to three times, then falls back to today's dead-stop.

The roll runs inside the shared `step()`, so every next surface (auto-advance, buttons, swipe, media keys, edge-tap) inherits it. The fairness draw is extracted to `lib/fairness-draw.ts` and the anti-repeat `visited` memory moved into the globe-chart store so the chart can draw synchronously in the triggering task (keeps iOS autoplay alive across the country switch).

A roll leaves a dismissed sheet closed: unlike a fling or list pick, an auto-continuation should not reopen a panel the listener put away.

Closes #173

## Test plan
- `pnpm lint` / `typecheck` / `test` green (685 tests, incl. roll, redraw, dead-stop, back-roll, record-clear, single-cue edge-tap roll, and the dismissed-sheet-stays-closed / one-shot-guard cases).
- `pnpm build` clean with env sourced.

## Open items
- On-device iOS autoplay check across the country switch (play fires synchronously inside the ended/click task by design).
- A roll landing while the sheet is at full (read mode) swaps the chart under the reader; deferring the roll until collapse is a possible follow-up.
- `canNext` stays enabled at true end-of-content (all redraws exhausted), so the button silently no-ops there; sanctioned by the "button need not predict the draw" comment.
- No screen-reader announcement on a roll landing (shuffle and list picks announce; the roll has only the visual cue) — follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic end-of-chart rolling to another playable country.
  * Added redraw handling when selected destinations have no playable tracks.
  * Added back navigation from rolled charts to the originating track.
  * Improved country selection fairness by reducing immediate repeats.
  * Added URL and globe synchronization for rolled selections.

* **Bug Fixes**
  * Prevented invalid destinations and failed redraws from causing unexpected navigation.
  * Preserved sheet and skip-control behavior during roll transitions.
  * Ensured playback stops cleanly when no playable destination is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->