### PR TITLE
feat(player): surface the playing track's commentary from the mini-player

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -298,6 +298,58 @@ describe("ChartScreen globe coupling", () => {
   });
 });
 
+describe("ChartScreen commentary badge", () => {
+  const commentaryTrack = COUNTRY_US.tracks.find((t) => t.commentary)!;
+  const plainTrack = COUNTRY_US.tracks.find(
+    (t) => !t.commentary && t.previewUrl,
+  )!;
+
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams(`cc=${CODE_US}`);
+    audioEngine.reset();
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("no badge renders while the playing track has no commentary", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Play preview of ${plainTrack.name} by ${plainTrack.artist}`,
+      }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /why this track is trending/i }),
+    ).toBeNull();
+  });
+
+  test("the badge reopens the sheet and expands the now-playing row's commentary card", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
+    const sheet = screen.getByTestId("chart-sheet");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Play preview of ${commentaryTrack.name} by ${commentaryTrack.artist}`,
+      }),
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(sheet.dataset.snap).toBe("closed");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /why this track is trending/i }),
+    );
+
+    expect(sheet.dataset.snap).toBe("peek");
+    expect(
+      screen.getByRole("button", { name: "Collapse commentary" }),
+    ).toBeDefined();
+  });
+});
+
 describe("ChartScreen auto-advance", () => {
   beforeEach(() => {
     mockSearchParams.value = new URLSearchParams(`cc=${ADJ_CODE}`);

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -75,6 +75,10 @@ function ChartScreenInner({
 }) {
   const [snap, setSnap] = useState<SnapState>("peek");
   const [scrollSignal, setScrollSignal] = useState(0);
+  const [focusIntent, setFocusIntent] = useState<{
+    rank: number;
+    nonce: number;
+  } | null>(null);
   const [skipFlash, setSkipFlash] = useState<{
     dir: 1 | -1;
     nonce: number;
@@ -156,6 +160,20 @@ function ChartScreenInner({
     setSnap((s) => (s === "hidden" || s === "closed" ? "peek" : s));
     setScrollSignal((n) => n + 1);
   }, [audioStore, countryCode]);
+
+  // The badge rides the same reopen path as a strip tap, then asks the sheet to
+  // expand the now-playing row's commentary card. The rank is the playing
+  // track's rank in its source country, which is the country the reopen lands
+  // on.
+  const handleCommentaryTap = useCallback(() => {
+    const { currentTrack } = audioStore.getState();
+    if (currentTrack === null) return;
+    handleMiniTap();
+    setFocusIntent((prev) => ({
+      rank: currentTrack.rank,
+      nonce: (prev?.nonce ?? 0) + 1,
+    }));
+  }, [audioStore, handleMiniTap]);
 
   // Step within the source country, not the visible one. Reads live store state
   // so the callbacks stay stable across track changes.
@@ -241,9 +259,11 @@ function ChartScreenInner({
         currentCountryCode={currentCountryCode}
         hasMiniPlayer={hasCurrentTrack}
         scrollSignal={scrollSignal}
+        focusIntent={focusIntent}
       />
       <MiniPlayer
         onTap={handleMiniTap}
+        onCommentary={handleCommentaryTap}
         onPrev={goPrev}
         onNext={goNext}
         canPrev={canPrev}

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -27,6 +27,9 @@ export interface ChartSheetProps {
   currentCountryCode?: string | null;
   hasMiniPlayer?: boolean;
   scrollSignal?: number;
+  // An outside ask (the mini-player's commentary badge) to open a row's focused
+  // reader card; the nonce marks each ask so dep-only re-runs never re-focus.
+  focusIntent?: { rank: number; nonce: number } | null;
 }
 
 // translateY as a fraction of the sheet's own height at each snap: full shows
@@ -125,6 +128,7 @@ export function ChartSheet({
   currentCountryCode = null,
   hasMiniPlayer = false,
   scrollSignal = 0,
+  focusIntent = null,
 }: ChartSheetProps) {
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const olRef = useRef<HTMLOListElement | null>(null);
@@ -160,6 +164,21 @@ export function ChartSheet({
   if (focusCountry !== countryCode) {
     setFocusCountry(countryCode);
     setFocusedRank(null);
+  }
+
+  // Apply an outside focus ask during render (the same idiom as the reset
+  // above, placed after it so it wins on the same pass). Ranks repeat across
+  // countries, so the intent targets its row only once the displayed country
+  // is the playing one; until then the nonce stays unconsumed, so the focus
+  // lands after the country change instead of being clobbered by its reset.
+  const [consumedFocusNonce, setConsumedFocusNonce] = useState(0);
+  if (
+    focusIntent !== null &&
+    focusIntent.nonce !== consumedFocusNonce &&
+    (currentCountryCode === null || currentCountryCode === countryCode)
+  ) {
+    setConsumedFocusNonce(focusIntent.nonce);
+    setFocusedRank(focusIntent.rank);
   }
 
   // While a card is focused, dismiss on Escape or a click outside it (a dimmed

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import type { AudioEngine } from "@/lib/audio-engine";
 import { type AudioState, createAudioStore } from "@/lib/audio-store";
-import type { Track } from "@/lib/chart-schema";
+import type { Commentary, Track } from "@/lib/chart-schema";
 import { AudioStoreContext } from "@/providers/audio-store-provider";
 
 import { MiniPlayer, type MiniPlayerProps } from "./mini-player";
@@ -32,6 +32,16 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
   };
 }
 
+function makeCommentary(): Commentary {
+  return {
+    lead: "Test lead",
+    tag: "test-tag",
+    claim: "what-it-is",
+    sources: ["https://example.com/source"],
+    generatedAt: "2026-04-25T03:00:00Z",
+  };
+}
+
 function renderMiniPlayer(
   props: Partial<MiniPlayerProps> = {},
   init?: Partial<AudioState>,
@@ -42,6 +52,7 @@ function renderMiniPlayer(
   }
   const fullProps: MiniPlayerProps = {
     onTap: vi.fn(),
+    onCommentary: vi.fn(),
     onPrev: vi.fn(),
     onNext: vi.fn(),
     canPrev: true,
@@ -191,6 +202,37 @@ describe("MiniPlayer", () => {
     fireEvent.click(area);
 
     expect(onPrev).toHaveBeenCalledTimes(1);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  test("commentary badge is absent when the track carries no commentary", () => {
+    renderMiniPlayer({}, { currentTrack: makeTrack() });
+
+    expect(
+      screen.queryByRole("button", { name: /why this track is trending/i }),
+    ).toBeNull();
+  });
+
+  test("commentary badge is absent when commentary is explicitly null", () => {
+    renderMiniPlayer({}, { currentTrack: makeTrack({ commentary: null }) });
+
+    expect(
+      screen.queryByRole("button", { name: /why this track is trending/i }),
+    ).toBeNull();
+  });
+
+  test("commentary badge fires onCommentary, not onTap", () => {
+    const onCommentary = vi.fn();
+    const onTap = vi.fn();
+    const track = makeTrack({ commentary: makeCommentary() });
+
+    renderMiniPlayer({ onCommentary, onTap }, { currentTrack: track });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /why this track is trending/i }),
+    );
+
+    expect(onCommentary).toHaveBeenCalledTimes(1);
     expect(onTap).not.toHaveBeenCalled();
   });
 

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -2,6 +2,7 @@
 
 import { type PointerEvent as ReactPointerEvent, useRef } from "react";
 
+import { ExpandIcon } from "@/components/icons/expand";
 import { PauseIcon } from "@/components/icons/pause";
 import { PlayIcon } from "@/components/icons/play";
 import { SkipBackIcon } from "@/components/icons/skip-back";
@@ -12,6 +13,7 @@ import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface MiniPlayerProps {
   onTap: () => void;
+  onCommentary: () => void;
   onPrev: () => void;
   onNext: () => void;
   canPrev: boolean;
@@ -27,6 +29,7 @@ const SKIP_BUTTON_CLASS =
 
 export function MiniPlayer({
   onTap,
+  onCommentary,
   onPrev,
   onNext,
   canPrev,
@@ -141,6 +144,20 @@ export function MiniPlayer({
             </p>
           </div>
         </button>
+        {/* A sibling of the strip button, never inside it: nested buttons are
+            invalid HTML and would tangle the strip's tap/swipe tracking.
+            Commentary is gated per track, so the affordance renders only when
+            the playing track actually carries it. */}
+        {currentTrack.commentary ? (
+          <button
+            type="button"
+            onClick={onCommentary}
+            aria-label="Read why this track is trending"
+            className={SKIP_BUTTON_CLASS}
+          >
+            <ExpandIcon className="h-4 w-4" />
+          </button>
+        ) : null}
         <VolumeControl />
         <button
           type="button"


### PR DESCRIPTION
The grounded per-track commentary is the app's differentiator but was buried three steps deep (open sheet, scroll to the track, expand). A listener watching the globe with the mini-player up now gets a distinct commentary badge that reopens the sheet and auto-expands the now-playing row's commentary card, reusing the existing focused-card and now-playing auto-scroll paths.

The badge is a sibling button with its own handler, so the strip tap keeps its reopen behavior. It renders only when the current track actually has commentary (commentary is gated), so it never promises context that isn't there. The focus intent is a nonce'd `{rank}` consumed during render once the displayed country matches the playing country, guarding against ranks repeating across countries.

Closes #172

## Test plan
- `pnpm lint` / `typecheck` / `test` green (663 tests, incl. badge absent without commentary, badge fires the commentary handler not the strip tap, and reopen-to-peek + focused-card open).
- `pnpm build` clean with env sourced.

## Open items
- The badge reuses `SKIP_BUTTON_CLASS`, so it reads visually like the prev/next transport buttons; distinctness rides on the expand glyph (which matches the commentary card's own expand affordance). Revisit if it reads as another transport control on device.
- Tapping the badge opens the card but keyboard/SR focus stays on the badge with no announcement; the existing strip-tap reopen shares this, so it's consistency-level, not a regression.
- On-device check for smooth-scroll contention between the reopen auto-scroll and the focused-card nudge (both fire on the same tap).
