### PR TITLE
feat(globe): repeat the skip hint until used, add edge chevrons

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { readRecord } from "@/components/globe/edge-hint-record";
 import { CHARTS, CODE_BR, CODE_US, COUNTRY_US } from "@/lib/__fixtures__";
 import type { AudioEngine } from "@/lib/audio-engine";
 import type { ChartFile, Country, Track } from "@/lib/chart-schema";
@@ -346,6 +347,20 @@ describe("ChartScreen globe coupling", () => {
 
     unmount();
     expect(globeChartStore.getState().readMode).toBe(false);
+  });
+
+  test("an edge-skip gesture latches the hint record's used flag", () => {
+    localStorage.clear();
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_BR} />);
+    expect(readRecord().used).toBe(false);
+
+    act(() => {
+      globeChartStore.getState().signalSkip(1);
+    });
+
+    // The gesture alone latches it: no track is playing, so step declines the
+    // skip, yet the teaching affordances still retire.
+    expect(readRecord().used).toBe(true);
   });
 
   test("a settle never starts audio on its own", () => {

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -11,6 +11,8 @@ import {
 import { useSearchParams } from "next/navigation";
 
 import { ChartSheet, type SnapState } from "@/components/chart-sheet/sheet";
+import { EdgeChevrons } from "@/components/globe/edge-chevrons";
+import { markUsed } from "@/components/globe/edge-hint-record";
 import { EdgeTapHint } from "@/components/globe/edge-tap-hint";
 import { SkipFlash } from "@/components/globe/skip-flash";
 import { MiniPlayer } from "@/components/mini-player";
@@ -345,6 +347,10 @@ function ChartScreenInner({
   const onGlobeSignal = useEffectEvent(
     (state: GlobeChartState, prev: GlobeChartState) => {
       if (state.skipIntent.nonce !== prev.skipIntent.nonce) {
+        // The gesture itself proves the edge skip is learned, so the teaching
+        // affordances retire even when step clamps at the end of the chart,
+        // matching the hint's own dismiss-on-gesture rule.
+        markUsed();
         if (step(state.skipIntent.dir) === "adjacent") {
           flashSkip(state.skipIntent.dir);
         }
@@ -380,8 +386,12 @@ function ChartScreenInner({
         canNext={canNext}
       />
       {/* Only while the globe is visible: at full the sheet covers it, so
-          showing the hint there would burn its one-time display unseen. */}
+          showing the hint there would burn one of its capped displays unseen. */}
       <EdgeTapHint active={hasCurrentTrack && snap !== "full"} snap={snap} />
+      <EdgeChevrons
+        active={hasCurrentTrack && snap !== "full"}
+        sheetSnap={snap}
+      />
       <SkipFlash skip={skipFlash} sheetSnap={snap} />
       <TourHost
         snap={snap}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1024,6 +1024,25 @@
     skip-slide var(--skip-flash-dur) var(--ease-out) forwards;
 }
 
+/* Ambient skip affordance: faint aurora chevrons resting at both globe margins
+   while a track plays, until the first edge skip retires them. A slow breath
+   between barely-there and readable keeps them ambient, never competing with
+   the skip flash's confirmation glow. */
+@keyframes edge-chevron-breathe {
+  0%,
+  100% {
+    opacity: 0.14;
+  }
+  50% {
+    opacity: 0.38;
+  }
+}
+
+.edge-chevron {
+  color: var(--color-aurora);
+  animation: edge-chevron-breathe 2600ms ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .eq,
   .eq span {
@@ -1088,5 +1107,11 @@
   .tour-rail {
     animation: none;
     opacity: 0.6;
+  }
+  /* The ambient chevrons keep marking the edges; drop the breath, rest at a
+     steady faint level. */
+  .edge-chevron {
+    animation: none;
+    opacity: 0.26;
   }
 }

--- a/src/components/globe/edge-chevrons.tsx
+++ b/src/components/globe/edge-chevrons.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { SNAP_Y_PCT, type SnapState } from "@/components/chart-sheet/sheet";
+import { ChevronsRightIcon } from "@/components/icons/chevrons-right";
+import { useCoarsePointer } from "@/components/use-coarse-pointer";
+
+import { readRecord, subscribeRecord } from "./edge-hint-record";
+
+// SSR can't read the record; defaulting to "used" keeps the cue hidden until
+// the client confirms the gesture is still unlearned, so it can only appear,
+// never flash and vanish for a user who already skips.
+const readUsed = () => readRecord().used;
+const serverUsed = () => true;
+
+// Faint directional chevrons at both globe margins while a track plays: a
+// standing reminder that the edges skip, so the gesture stays discoverable
+// after the contextual hint has passed. Touch-primary devices only; pointer
+// devices have the visible prev/next buttons as their skip path. Retires
+// permanently on the first edge skip, via the shared edge-hint record.
+// Pointer-transparent and below the sheet, so it reads as part of the globe
+// backdrop, not chrome.
+export function EdgeChevrons({
+  active,
+  sheetSnap,
+}: {
+  active: boolean;
+  sheetSnap: SnapState;
+}) {
+  const used = useSyncExternalStore(subscribeRecord, readUsed, serverUsed);
+  const coarsePointer = useCoarsePointer();
+
+  if (!active || used || !coarsePointer) return null;
+
+  return (
+    <div
+      aria-hidden
+      data-testid="edge-chevrons"
+      style={{
+        // Bottom tracks the sheet so the pair centers on the visible globe,
+        // the same placement math as the skip flash.
+        bottom: sheetSnap === "full" ? "0%" : `${100 - SNAP_Y_PCT[sheetSnap]}%`,
+      }}
+      className="pointer-events-none fixed top-0 right-0 left-0 z-10 flex items-center justify-between px-3"
+    >
+      <span className="edge-chevron">
+        <ChevronsRightIcon className="h-7 w-7 -scale-x-100" />
+      </span>
+      <span className="edge-chevron">
+        <ChevronsRightIcon className="h-7 w-7" />
+      </span>
+    </div>
+  );
+}

--- a/src/components/globe/edge-hint-record.test.ts
+++ b/src/components/globe/edge-hint-record.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  decideShow,
+  emptyRecord,
+  markUsed,
+  readRecord,
+  recordShown,
+  recordUsed,
+  subscribeRecord,
+  writeRecord,
+  type EdgeHintRecord,
+} from "./edge-hint-record";
+
+const KEY = "sounds-abroad:edge-tap-hint:v2";
+
+function fakeStorage(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: vi.fn((k: string, v: string) => void map.set(k, v)),
+  };
+}
+
+describe("decideShow", () => {
+  test("a fresh record shows the cue", () => {
+    expect(decideShow(emptyRecord)).toBe(true);
+  });
+
+  test("keeps showing while under the cap and the gesture is unused", () => {
+    expect(decideShow({ shows: 2, used: false })).toBe(true);
+  });
+
+  test("stops at the show cap even when the gesture was never used", () => {
+    expect(decideShow({ shows: 3, used: false })).toBe(false);
+  });
+
+  test("stops permanently once used, regardless of remaining shows", () => {
+    expect(decideShow({ shows: 0, used: true })).toBe(false);
+  });
+});
+
+describe("recordShown", () => {
+  test("counts an appearance without touching used", () => {
+    expect(recordShown(emptyRecord)).toEqual({ shows: 1, used: false });
+  });
+
+  test("increments from a prior count", () => {
+    expect(recordShown({ shows: 2, used: false }).shows).toBe(3);
+  });
+});
+
+describe("recordUsed", () => {
+  test("latches used without touching the show count", () => {
+    expect(recordUsed({ shows: 2, used: false })).toEqual({
+      shows: 2,
+      used: true,
+    });
+  });
+});
+
+describe("readRecord", () => {
+  test("is the empty record when nothing is stored (a fresh v2 key)", () => {
+    expect(readRecord(fakeStorage())).toEqual(emptyRecord);
+  });
+
+  test("round-trips a written record", () => {
+    const record: EdgeHintRecord = { shows: 2, used: true };
+    const storage = fakeStorage();
+
+    writeRecord(record, storage);
+
+    expect(readRecord(storage)).toEqual(record);
+  });
+
+  test("falls back to the empty record on corrupt JSON rather than throwing", () => {
+    expect(readRecord(fakeStorage({ [KEY]: "{not json" }))).toEqual(
+      emptyRecord,
+    );
+  });
+
+  test("degrades wrong-typed fields individually rather than dropping the record", () => {
+    const stored = JSON.stringify({ shows: "9", used: true });
+
+    expect(readRecord(fakeStorage({ [KEY]: stored }))).toEqual({
+      shows: 0,
+      used: true,
+    });
+  });
+
+  test("returns the empty record instead of throwing when reading throws", () => {
+    const hostile = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: vi.fn(),
+    };
+
+    expect(readRecord(hostile)).toEqual(emptyRecord);
+  });
+});
+
+describe("writeRecord", () => {
+  test("swallows a failing write rather than throwing", () => {
+    const hostile = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+
+    expect(() => writeRecord(emptyRecord, hostile)).not.toThrow();
+  });
+
+  test("notifies a subscriber when the record is written", () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeRecord(onChange);
+
+    writeRecord(emptyRecord, fakeStorage());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("stops notifying after unsubscribe", () => {
+    const onChange = vi.fn();
+
+    subscribeRecord(onChange)();
+    writeRecord(emptyRecord, fakeStorage());
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("markUsed", () => {
+  test("latches used on top of the stored show count", () => {
+    const storage = fakeStorage();
+    writeRecord({ shows: 2, used: false }, storage);
+
+    markUsed(storage);
+
+    expect(readRecord(storage)).toEqual({ shows: 2, used: true });
+  });
+
+  test("a repeat use writes nothing further", () => {
+    const storage = fakeStorage();
+    markUsed(storage);
+    const writesAfterFirst = storage.setItem.mock.calls.length;
+
+    markUsed(storage);
+
+    expect(storage.setItem.mock.calls.length).toBe(writesAfterFirst);
+  });
+});

--- a/src/components/globe/edge-hint-record.ts
+++ b/src/components/globe/edge-hint-record.ts
@@ -1,0 +1,91 @@
+// The edge-skip cues' shared memory: unlike the one-shot seen flags, the edge
+// affordances repeat until the gesture lands. The contextual hint may open at
+// most once per visit, across up to MAX_SHOWS visits; every affordance retires
+// permanently the moment the user performs an edge skip. Pure schedule plus its
+// persistence, shaped like the tour record.
+
+import {
+  createMirroredStorage,
+  type MirroredStorage,
+} from "@/lib/mirrored-storage";
+
+export interface EdgeHintRecord {
+  shows: number;
+  used: boolean;
+}
+
+export const emptyRecord: EdgeHintRecord = { shows: 0, used: false };
+
+// Enough repeats to survive a missed or forgotten first flash without nagging
+// forever.
+const MAX_SHOWS = 3;
+
+export function decideShow(record: EdgeHintRecord): boolean {
+  return !record.used && record.shows < MAX_SHOWS;
+}
+
+// Count this appearance. Persisted at show time, not at dismissal, so the cap
+// holds even if the user leaves mid-show.
+export function recordShown(record: EdgeHintRecord): EdgeHintRecord {
+  return { ...record, shows: record.shows + 1 };
+}
+
+// The gesture landed: nothing needs to teach it again, ever.
+export function recordUsed(record: EdgeHintRecord): EdgeHintRecord {
+  return { ...record, used: true };
+}
+
+// A fresh key from the boolean flag's :v1 (no migration code, per the seen-flag
+// convention): repeat-until-used is a new contract, so users who saw the old
+// one-shot cue get the full schedule once more.
+const KEY = "sounds-abroad:edge-tap-hint:v2";
+
+const store = createMirroredStorage();
+const listeners = new Set<() => void>();
+
+// Reads tolerantly: any malformed or partial value degrades to the empty record
+// (the cue re-teaches) rather than throwing.
+function parseRecord(raw: string): EdgeHintRecord {
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null) return emptyRecord;
+  const value = parsed as Record<string, unknown>;
+  return {
+    shows: typeof value.shows === "number" ? value.shows : 0,
+    used: value.used === true,
+  };
+}
+
+export function readRecord(storage: MirroredStorage = store): EdgeHintRecord {
+  try {
+    const raw = storage.getItem(KEY);
+    return raw ? parseRecord(raw) : emptyRecord;
+  } catch {
+    return emptyRecord;
+  }
+}
+
+export function writeRecord(
+  record: EdgeHintRecord,
+  storage: MirroredStorage = store,
+): void {
+  try {
+    storage.setItem(KEY, JSON.stringify(record));
+  } catch {
+    // An injected storage may throw; the default's mirror already recorded it.
+  }
+  for (const listener of listeners) listener();
+}
+
+// Same-tab subscription so the persistent chevrons retire the instant the
+// gesture lands (a localStorage write fires no storage event in its own tab).
+export function subscribeRecord(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => listeners.delete(onChange);
+}
+
+// Latch used on the first edge skip; later skips leave the record alone.
+export function markUsed(storage: MirroredStorage = store): void {
+  const record = readRecord(storage);
+  if (record.used) return;
+  writeRecord(recordUsed(record), storage);
+}

--- a/src/components/globe/edge-tap-hint.test.tsx
+++ b/src/components/globe/edge-tap-hint.test.tsx
@@ -3,22 +3,38 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { globeChartStore } from "@/lib/globe-chart-store";
 
+import { readRecord, writeRecord } from "./edge-hint-record";
 import { EdgeTapHint } from "./edge-tap-hint";
-import { edgeTapSeen } from "./seen-edge-tap-hint";
 
 function renderHint(active = true) {
   return render(<EdgeTapHint active={active} snap="peek" />);
 }
 
+function stubPointer(coarse: boolean) {
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query: string) =>
+      ({
+        matches: query.includes("coarse") ? coarse : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList,
+  );
+}
+
 beforeEach(() => {
   localStorage.clear();
   globeChartStore.setState({ skipIntent: { dir: 1, nonce: 0 } });
+  stubPointer(true);
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("EdgeTapHint", () => {
-  test("shows the wordless skip cue only when active and unseen", () => {
+  test("shows the wordless skip cue only when active and scheduled", () => {
     expect(renderHint(false).queryByTestId("edge-tap-badge")).toBeNull();
     cleanup();
 
@@ -29,16 +45,51 @@ describe("EdgeTapHint", () => {
     expect(getByTestId("edge-tap-backdrop")).toBeTruthy();
   });
 
-  test("does not show again once the flag is already set", () => {
-    edgeTapSeen.markSeen();
+  test("stays hidden on a fine pointer, where the buttons are the skip path", () => {
+    stubPointer(false);
 
     expect(renderHint(true).queryByTestId("edge-tap-badge")).toBeNull();
   });
 
-  test("marks itself seen on show", () => {
+  test("does not consume a scheduled show on a fine pointer", () => {
+    stubPointer(false);
+
     renderHint(true);
 
-    expect(edgeTapSeen.hasSeen()).toBe(true);
+    expect(readRecord()).toEqual({ shows: 0, used: false });
+  });
+
+  test("does not show once the gesture has been used", () => {
+    writeRecord({ shows: 0, used: true });
+
+    expect(renderHint(true).queryByTestId("edge-tap-badge")).toBeNull();
+  });
+
+  test("shows again on a later visit while under the show cap", () => {
+    writeRecord({ shows: 2, used: false });
+
+    expect(renderHint(true).queryByTestId("edge-tap-badge")).toBeTruthy();
+  });
+
+  test("stops for good at the show cap even when never used", () => {
+    writeRecord({ shows: 3, used: false });
+
+    expect(renderHint(true).queryByTestId("edge-tap-badge")).toBeNull();
+  });
+
+  test("records the appearance on show without latching used", () => {
+    renderHint(true);
+
+    expect(readRecord()).toEqual({ shows: 1, used: false });
+  });
+
+  test("counts one appearance per visit even when the cue toggles away and back", () => {
+    const { rerender } = renderHint(true);
+
+    rerender(<EdgeTapHint active={false} snap="peek" />);
+    rerender(<EdgeTapHint active={true} snap="peek" />);
+
+    expect(readRecord().shows).toBe(1);
   });
 
   test("dismisses when the user performs a real skip", () => {

--- a/src/components/globe/edge-tap-hint.tsx
+++ b/src/components/globe/edge-tap-hint.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { SnapState } from "@/components/chart-sheet/sheet";
 import { PointerIcon } from "@/components/icons/pointer";
 import { useTourAnchor } from "@/components/tour/use-tour-anchor";
+import { useCoarsePointer } from "@/components/use-coarse-pointer";
 import { globeChartStore } from "@/lib/globe-chart-store";
 
-import { edgeTapSeen } from "./seen-edge-tap-hint";
+import {
+  decideShow,
+  readRecord,
+  recordShown,
+  writeRecord,
+} from "./edge-hint-record";
 
 // If the user never performs the skip, retire the cue rather than let it linger
 // over their listening.
@@ -18,14 +24,16 @@ const FALLBACK_MS = 6000;
 const HAND_EDGE_PCT = 83.5;
 const ECHO_EDGE_PCT = 100 - HAND_EDGE_PCT;
 
-// Contextual first-encounter cue for the double-tap-either-edge skip. Unlike the
-// linear onboarding tour, this waits for the moment the gesture first becomes
-// usable (a track plays and the sheet is below full, so the globe edges are
-// tappable), then teaches it in place. Shown once per device; the seen flag
-// persists. Pointer-transparent throughout so it never intercepts the taps it
-// teaches. Wordless chrome: a globe-dim / sheet-dim sandwich, two aurora edge
-// rails behind the sheet, one right-edge double-tap hand with a synced left-edge
-// ripple echo, and a "Double-tap either edge to skip" badge.
+// Contextual cue for the double-tap-either-edge skip. Unlike the linear
+// onboarding tour, this waits for the moment the gesture first becomes usable
+// (a track plays and the sheet is below full, so the globe edges are tappable),
+// then teaches it in place. Repeats until used: at most once per visit, across
+// a capped number of visits, stopping permanently once the user performs an
+// edge skip (the edge-hint record holds the schedule). Pointer-transparent
+// throughout so it never intercepts the taps it teaches. Wordless chrome: a
+// globe-dim / sheet-dim sandwich, two aurora edge rails behind the sheet, one
+// right-edge double-tap hand with a synced left-edge ripple echo, and a
+// "Double-tap either edge to skip" badge.
 export function EdgeTapHint({
   active,
   snap,
@@ -33,13 +41,20 @@ export function EdgeTapHint({
   active: boolean;
   snap: SnapState;
 }) {
-  // Read the persisted flag once at mount, before any track plays, so it holds
-  // the true prior-session value. Visibility is derived from `active`, not
-  // latched in an effect.
-  const [seenAtMount] = useState(() => edgeTapSeen.hasSeen());
+  // Decide from the persisted record once at mount, before any track plays, so
+  // this visit's own show can't feed back into the decision. Visibility is
+  // derived from `active`, not latched in an effect.
+  const [showThisVisit] = useState(() => decideShow(readRecord()));
   const [dismissed, setDismissed] = useState(false);
+  const countedRef = useRef(false);
 
-  const visible = active && !seenAtMount && !dismissed;
+  // Touch-primary devices only: the edge double-tap this teaches has no pointer
+  // equivalent, and desktop's skip path is the visible prev/next buttons. SSR
+  // assumes fine, so the hint can only appear post-hydration, never flash on
+  // desktop; gating here also keeps a desktop mount from consuming a show.
+  const coarsePointer = useCoarsePointer();
+
+  const visible = active && showThisVisit && coarsePointer && !dismissed;
 
   // Measure the sheet so the sheet-dim covers exactly it, matching its rounded
   // corners. `snap` is the watch signal: the sheet slides between snaps via
@@ -49,15 +64,19 @@ export function EdgeTapHint({
     snap,
   );
 
-  // Mark the cue seen and retire it once its lesson lands: dismiss the instant
-  // the user performs a real skip (a fresh skipIntent nonce during the show), or
-  // after FALLBACK_MS if they never do. Mirrors the tour's "complete only on a
-  // fresh gesture performed during the beat" rule.
+  // Count the appearance and retire the cue once its lesson lands: dismiss the
+  // instant the user performs a real skip (a fresh skipIntent nonce during the
+  // show), or after FALLBACK_MS if they never do. The permanent used latch is
+  // the chart's, written at its skip seam, so it also catches skips performed
+  // while no cue is showing.
   useEffect(() => {
     if (!visible) return;
-    // Mark seen on show, like the prior cue: one appearance per device even if
-    // the user leaves without skipping.
-    edgeTapSeen.markSeen();
+    // Count at show time, once per visit even if `active` toggles the cue away
+    // and back, so the cap survives a mid-show exit.
+    if (!countedRef.current) {
+      countedRef.current = true;
+      writeRecord(recordShown(readRecord()));
+    }
     const unsubscribe = globeChartStore.subscribe((state, prev) => {
       // Only a nonce change after this subscription is a fresh skip performed
       // during the show; a skip from before the cue appeared never counts.

--- a/src/components/globe/seen-edge-tap-hint.ts
+++ b/src/components/globe/seen-edge-tap-hint.ts
@@ -1,7 +1,0 @@
-import { createSeenFlag } from "@/lib/create-seen-flag";
-
-// One-time gate for the edge-tap-to-skip cue, persisted across sessions and kept
-// separate from the other hint flags so each surfaces on its own schedule.
-export const edgeTapSeen = createSeenFlag(
-  "sounds-abroad:edge-tap-hint-seen:v1",
-);

--- a/src/components/tour/tour-record.ts
+++ b/src/components/tour/tour-record.ts
@@ -2,7 +2,7 @@
 // re-teaches only the gestures they haven't performed and never nags. Pure: the
 // host reads the persisted record, asks decideShow what to run, and folds the
 // run's outcome back in. Only the three linear beats are teachable here; the
-// double-tap skip lives in its own contextual hint with its own flag.
+// double-tap skip lives in its own contextual hint with its own record.
 
 import type { TeachBeat } from "./tour-step";
 import { TEACH_ORDER } from "./tour-step";

--- a/src/components/use-coarse-pointer.test.tsx
+++ b/src/components/use-coarse-pointer.test.tsx
@@ -1,0 +1,71 @@
+import { act, render } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { useCoarsePointer } from "./use-coarse-pointer";
+
+let changeListener: (() => void) | null = null;
+let currentMatches = false;
+
+function stubMatchMedia(initial: boolean) {
+  currentMatches = initial;
+  changeListener = null;
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query: string) =>
+      ({
+        get matches() {
+          return query.includes("coarse") ? currentMatches : false;
+        },
+        media: query,
+        addEventListener: (_type: string, cb: () => void) => {
+          changeListener = cb;
+        },
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList,
+  );
+}
+
+function Harness() {
+  const coarse = useCoarsePointer();
+  return <span data-testid="probe" data-coarse={coarse || undefined} />;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useCoarsePointer", () => {
+  test("is false when the primary pointer is fine", () => {
+    stubMatchMedia(false);
+
+    const { getByTestId } = render(<Harness />);
+
+    expect(getByTestId("probe").getAttribute("data-coarse")).toBeNull();
+  });
+
+  test("is true when the primary pointer is coarse", () => {
+    stubMatchMedia(true);
+
+    const { getByTestId } = render(<Harness />);
+
+    expect(getByTestId("probe").getAttribute("data-coarse")).toBe("true");
+  });
+
+  test("updates when the primary pointer changes", () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<Harness />);
+
+    act(() => {
+      currentMatches = true;
+      changeListener?.();
+    });
+
+    expect(getByTestId("probe").getAttribute("data-coarse")).toBe("true");
+  });
+
+  test("assumes a fine pointer when rendered without matchMedia (SSR)", () => {
+    const html = renderToString(<Harness />);
+
+    expect(html).not.toContain("data-coarse");
+  });
+});

--- a/src/components/use-coarse-pointer.ts
+++ b/src/components/use-coarse-pointer.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(pointer: coarse)";
+
+function subscribe(onChange: () => void) {
+  const query = window.matchMedia(QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+// Whether the primary input is a coarse pointer (touch), as a live boolean.
+// Server has no matchMedia, so the SSR snapshot assumes a fine pointer:
+// touch-only affordances stay hidden until hydration confirms a touch device,
+// so they can only appear, never flash and vanish on desktop.
+export function useCoarsePointer(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/src/lib/create-seen-flag.ts
+++ b/src/lib/create-seen-flag.ts
@@ -1,8 +1,8 @@
 // A one-time "seen" flag persisted in localStorage: the shared machinery behind
-// the commentary-hint and edge-tap cues, each of which gates a cue that should
-// fire once and stay dismissed across sessions. One call per flag, keyed by its
-// storage key; bump the key's :v1 suffix to re-trigger everyone with no migration
-// code. Private-mode resilience (the in-memory mirror) comes from the shared
+// cues that should fire once and stay dismissed across sessions (currently the
+// commentary hint). One call per flag, keyed by its storage key; bump the key's
+// :v1 suffix to re-trigger everyone with no migration code. Private-mode
+// resilience (the in-memory mirror) comes from the shared
 // createMirroredStorage; injected storages (tests) bypass it, staying isolated.
 
 import { createMirroredStorage } from "./mirrored-storage";


### PR DESCRIPTION
A one-time hint and a hidden gesture get forgotten, so edge-skip adoption was near zero, especially on the web. On touch devices the edge-skip cue now returns once per visit for up to three visits, and faint aurora chevrons rest at the globe's left/right margins while a track plays. Both retire permanently the moment the listener performs an edge skip, tracked in one persisted record. Pointer/desktop is unchanged: the visible prev/next buttons are its skip path, so neither affordance shows there.

Closes #176

## Test plan
- `pnpm lint` / `typecheck` / `test` green (new tests for the show schedule: reshow under the cap, stop at cap, permanent stop on use, once-per-visit count; plus the coarse-pointer gate and the gesture-latches-used seam).
- `pnpm build` clean with env sourced.

## Open items
- On-device: chevron faintness/placement against the receded-rows commentary treatment, the breath cadence, and the full repeat-until-used flow.
- The used flag latches on the skip gesture (skipIntent nonce), not on step() success, so a clamped end-of-list skip also retires the affordances (intended: the gesture proves the skip is learned).
- Cross-tab: an edge skip in one tab leaves chevrons showing in another open tab until reload (same-tab store, no storage-event bridge). Low impact on touch.
