### PR TITLE
feat(player): slide the mini-player content in the skip direction

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -428,6 +428,123 @@ describe("ChartScreen commentary badge", () => {
   });
 });
 
+describe("ChartScreen directional cue", () => {
+  function cueDir(container: HTMLElement): string | null {
+    return (
+      container
+        .querySelector("[data-track-change]")
+        ?.getAttribute("data-track-change") ?? null
+    );
+  }
+
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams(`cc=${ADJ_CODE}`);
+    audioEngine.reset();
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("starting playback carries no directional cue", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+
+    expect(cueDir(container)).toBeNull();
+  });
+
+  test("the next button publishes the forward direction", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+
+    expect(cueDir(container)).toBe("next");
+  });
+
+  test("the prev button publishes the backward direction", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable tail by Tail artist",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+    expect(cueDir(container)).toBe("prev");
+  });
+
+  test("auto-advance publishes the forward direction through the same step", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+
+    act(() => {
+      audioEngine.end();
+    });
+
+    expect(cueDir(container)).toBe("next");
+  });
+
+  test("a globe skip-intent publishes its direction through the same step", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+
+    act(() => {
+      globeChartStore.getState().signalSkip(1);
+    });
+
+    expect(cueDir(container)).toBe("next");
+  });
+
+  test("a direct row tap changes the track without a directional cue", () => {
+    const { container } = render(
+      <ChartScreen charts={ADJACENCY_CHARTS} defaultCountryCode={ADJ_CODE} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable head by Head artist",
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Play preview of Playable tail by Tail artist",
+      }),
+    );
+
+    expect(cueDir(container)).toBeNull();
+  });
+});
+
 describe("ChartScreen auto-advance", () => {
   beforeEach(() => {
     mockSearchParams.value = new URLSearchParams(`cc=${ADJ_CODE}`);

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -220,14 +220,18 @@ function ChartScreenInner({
   // through here, so all of them inherit the roll.
   const step = useCallback(
     (dir: 1 | -1): "adjacent" | "rolled" | "backRolled" | null => {
-      const { currentTrack, currentCountryCode, toggle } =
+      const { currentTrack, currentCountryCode, toggle, signalStep } =
         audioStore.getState();
       if (currentTrack === null || currentCountryCode === null) return null;
       const source = charts.countries[currentCountryCode];
       if (!source) return null;
       const adj = findAdjacentPlayable(source.tracks, currentTrack, dir);
+      // Publish the direction after each real change, so every surface that
+      // steps (buttons, swipe, media keys, edge-tap, auto-advance, and a roll)
+      // feeds the one directional mini-player cue with no per-surface wiring.
       if (adj) {
         toggle(adj, currentCountryCode);
+        signalStep(dir);
         return "adjacent";
       }
       if (dir === 1) {
@@ -257,6 +261,7 @@ function ChartScreenInner({
           suppressResurfaceRef.current = true;
         setSelectedCountry(landing.code);
         window.history.replaceState(null, "", `?cc=${landing.code}`);
+        signalStep(dir);
         flashSkip(1);
         return "rolled";
       }
@@ -274,6 +279,7 @@ function ChartScreenInner({
         suppressResurfaceRef.current = true;
       store.setSelectedCountry(back.countryCode);
       window.history.replaceState(null, "", `?cc=${back.countryCode}`);
+      signalStep(dir);
       flashSkip(-1);
       return "backRolled";
     },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1043,6 +1043,40 @@
   animation: edge-chevron-breathe 2600ms ease-in-out infinite;
 }
 
+/* Track-change cue: the incoming now-playing content slides in from the skip
+   direction and cross-fades, so the player registers which way it moved.
+   Enter-only: the outgoing content is dropped with its keyed node, so rapid
+   skips restart the cue cleanly instead of queueing. Fade and slide split for
+   the same one-smooth-ease reason as the skip cue above. */
+@keyframes track-change-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes track-change-slide {
+  from {
+    transform: translateX(var(--track-change-from));
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+[data-track-change] {
+  --track-change-from: 14px;
+  animation:
+    track-change-fade 200ms linear both,
+    track-change-slide 200ms var(--ease-out) both;
+}
+
+[data-track-change="prev"] {
+  --track-change-from: -14px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .eq,
   .eq span {
@@ -1056,6 +1090,10 @@
   /* Skip cue keeps the opacity flash but drops the directional slide. */
   .skip-flash {
     animation: skip-fade var(--skip-flash-dur) linear forwards;
+  }
+  /* Track-change cue keeps the cross-fade but drops the directional slide. */
+  [data-track-change] {
+    animation: track-change-fade 200ms linear both;
   }
   .eq span {
     transform: scaleY(0.7);

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
 import type { AudioEngine } from "@/lib/audio-engine";
@@ -234,6 +234,83 @@ describe("MiniPlayer", () => {
 
     expect(onCommentary).toHaveBeenCalledTimes(1);
     expect(onTap).not.toHaveBeenCalled();
+  });
+
+  test("a forward skip marks the incoming content with the forward cue", () => {
+    const outgoing = makeTrack({
+      appleUrl: "https://music.apple.com/x/album?i=101",
+    });
+    const incoming = makeTrack({
+      rank: 2,
+      appleUrl: "https://music.apple.com/x/album?i=102",
+    });
+    const { container, store } = renderMiniPlayer(
+      {},
+      { currentTrack: outgoing },
+    );
+
+    act(() => {
+      store.setState({ currentTrack: incoming });
+      store.getState().signalStep(1);
+    });
+
+    const cue = container.querySelector("[data-track-change]");
+    expect(cue?.getAttribute("data-track-change")).toBe("next");
+  });
+
+  test("a backward skip marks the incoming content with the backward cue", () => {
+    const outgoing = makeTrack({
+      rank: 2,
+      appleUrl: "https://music.apple.com/x/album?i=102",
+    });
+    const incoming = makeTrack({
+      appleUrl: "https://music.apple.com/x/album?i=101",
+    });
+    const { container, store } = renderMiniPlayer(
+      {},
+      { currentTrack: outgoing },
+    );
+
+    act(() => {
+      store.setState({ currentTrack: incoming });
+      store.getState().signalStep(-1);
+    });
+
+    const cue = container.querySelector("[data-track-change]");
+    expect(cue?.getAttribute("data-track-change")).toBe("prev");
+  });
+
+  test("a track change without a step stays cue-free", () => {
+    const outgoing = makeTrack({
+      appleUrl: "https://music.apple.com/x/album?i=101",
+    });
+    const incoming = makeTrack({
+      rank: 2,
+      appleUrl: "https://music.apple.com/x/album?i=102",
+    });
+    const { container, store } = renderMiniPlayer(
+      {},
+      { currentTrack: outgoing },
+    );
+
+    act(() => {
+      store.setState({ currentTrack: incoming });
+    });
+
+    expect(container.querySelector("[data-track-change]")).toBeNull();
+  });
+
+  test("mounting with a step already recorded never animates", () => {
+    const track = makeTrack({
+      appleUrl: "https://music.apple.com/x/album?i=101",
+    });
+
+    const { container } = renderMiniPlayer(
+      {},
+      { currentTrack: track, lastStep: { dir: 1, nonce: 5 } },
+    );
+
+    expect(container.querySelector("[data-track-change]")).toBeNull();
   });
 
   test("a short press below the swipe threshold still taps", () => {

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { type PointerEvent as ReactPointerEvent, useRef } from "react";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useRef,
+  useState,
+} from "react";
 
 import { ExpandIcon } from "@/components/icons/expand";
 import { PauseIcon } from "@/components/icons/pause";
@@ -9,6 +13,7 @@ import { SkipBackIcon } from "@/components/icons/skip-back";
 import { SkipForwardIcon } from "@/components/icons/skip-forward";
 import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import { VolumeControl } from "@/components/volume-control";
+import { trackKey } from "@/lib/track-identity";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
 export interface MiniPlayerProps {
@@ -38,6 +43,34 @@ export function MiniPlayer({
   const currentTrack = useAudioStore((s) => s.currentTrack);
   const isPlaying = useAudioStore((s) => s.isPlaying);
   const toggle = useAudioStore((s) => s.toggle);
+  const lastStep = useAudioStore((s) => s.lastStep);
+
+  // A track change caused by a skip arrives with a fresh step nonce, and the
+  // incoming content should slide in from the skip direction; a change without
+  // one (a direct row tap) stays cue-free. Derived by adjusting state during
+  // render (the same idiom as the sheet's country reset): an effect would both
+  // flag a cascading setState and start the cue one frame after the remount.
+  const contentKey = currentTrack === null ? null : trackKey(currentTrack);
+  const [stepCue, setStepCue] = useState<{
+    key: string | null;
+    nonce: number;
+    dir: "next" | "prev" | null;
+  }>({ key: contentKey, nonce: lastStep?.nonce ?? 0, dir: null });
+  if (
+    stepCue.key !== contentKey ||
+    (lastStep !== null && lastStep.nonce !== stepCue.nonce)
+  ) {
+    setStepCue({
+      key: contentKey,
+      nonce: lastStep?.nonce ?? 0,
+      dir:
+        lastStep !== null && lastStep.nonce !== stepCue.nonce
+          ? lastStep.dir === 1
+            ? "next"
+            : "prev"
+          : null,
+    });
+  }
 
   // The now-playing title is always the current track, so it always scrolls.
   const {
@@ -110,38 +143,49 @@ export function MiniPlayer({
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerCancel}
           aria-label="Reopen chart"
-          className="focus-visible:outline-aurora flex min-w-0 flex-1 touch-pan-y items-center gap-[14px] text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
+          className="focus-visible:outline-aurora flex min-w-0 flex-1 touch-pan-y overflow-hidden text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
         >
+          {/* Keyed on the stable song id so a track change remounts the content
+              and restarts the cue from zero: a rapid skip drops the outgoing
+              node instead of queueing, and the marquee re-measures the new
+              title. The button's overflow-hidden keeps the slide from pushing
+              layout. */}
           <div
-            aria-hidden="true"
-            style={{ backgroundImage: `url(${currentTrack.artworkUrl})` }}
-            className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-          />
-          <div className="min-w-0 flex-1">
-            <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
-              <span className="block min-w-0 overflow-hidden">
-                <span
-                  ref={titleRef}
-                  className="marquee-track"
-                  data-marquee={titleScrolling || undefined}
-                  style={titleStyle}
-                >
-                  {currentTrack.name}
+            key={contentKey}
+            data-track-change={stepCue.dir ?? undefined}
+            className="flex min-w-0 flex-1 items-center gap-[14px]"
+          >
+            <div
+              aria-hidden="true"
+              style={{ backgroundImage: `url(${currentTrack.artworkUrl})` }}
+              className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
+                <span className="block min-w-0 overflow-hidden">
+                  <span
+                    ref={titleRef}
+                    className="marquee-track"
+                    data-marquee={titleScrolling || undefined}
+                    style={titleStyle}
+                  >
+                    {currentTrack.name}
+                  </span>
                 </span>
-              </span>
-              <span
-                className="eq shrink-0"
-                data-paused={!isPlaying || undefined}
-                aria-hidden
-              >
-                <span />
-                <span />
-                <span />
-              </span>
-            </p>
-            <p className="text-fg-2 text-small truncate">
-              {currentTrack.artist}
-            </p>
+                <span
+                  className="eq shrink-0"
+                  data-paused={!isPlaying || undefined}
+                  aria-hidden
+                >
+                  <span />
+                  <span />
+                  <span />
+                </span>
+              </p>
+              <p className="text-fg-2 text-small truncate">
+                {currentTrack.artist}
+              </p>
+            </div>
           </div>
         </button>
         {/* A sibling of the strip button, never inside it: nested buttons are

--- a/src/lib/audio-store.test.ts
+++ b/src/lib/audio-store.test.ts
@@ -83,6 +83,41 @@ describe("createAudioStore", () => {
     expect(store.getState().volume).toBe(1);
   });
 
+  test("lastStep starts null so a mounting surface never sees a direction", () => {
+    const store = createAudioStore(() => makeMockAudio());
+
+    expect(store.getState().lastStep).toBeNull();
+  });
+
+  test("signalStep records the direction and bumps the nonce per call", () => {
+    const store = createAudioStore(() => makeMockAudio());
+
+    store.getState().signalStep(1);
+    const first = store.getState().lastStep;
+    store.getState().signalStep(1);
+    const second = store.getState().lastStep;
+
+    expect(first).toEqual({ dir: 1, nonce: 1 });
+    expect(second).toEqual({ dir: 1, nonce: 2 });
+  });
+
+  test("signalStep keeps the nonce monotonic across a direction flip", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    store.getState().signalStep(1);
+
+    store.getState().signalStep(-1);
+
+    expect(store.getState().lastStep).toEqual({ dir: -1, nonce: 2 });
+  });
+
+  test("a plain toggle never records a step direction", () => {
+    const store = createAudioStore(() => makeMockAudio());
+
+    store.getState().toggle(makeTrack());
+
+    expect(store.getState().lastStep).toBeNull();
+  });
+
   test("setVolume updates the volume state", () => {
     const store = createAudioStore(() => makeMockAudio());
 

--- a/src/lib/audio-store.ts
+++ b/src/lib/audio-store.ts
@@ -26,7 +26,12 @@ export interface AudioState {
   volume: number;
   lastError: AudioError | null;
   endedSignal: number;
+  // The most recent skip's direction, nonced so a repeated direction still
+  // reads as a fresh change. Null until the first skip, so a mount or a
+  // non-skip track change never carries a direction.
+  lastStep: { dir: 1 | -1; nonce: number } | null;
   toggle: (track: Track, countryCode?: string) => void;
+  signalStep: (dir: 1 | -1) => void;
   setVolume: (value: number) => void;
   pause: () => void;
   stop: () => void;
@@ -118,6 +123,11 @@ export function createAudioStore(
       volume: 1,
       lastError: null,
       endedSignal: 0,
+      lastStep: null,
+      signalStep: (dir) =>
+        set((state) => ({
+          lastStep: { dir, nonce: (state.lastStep?.nonce ?? 0) + 1 },
+        })),
       toggle: (track, countryCode) => {
         const state = get();
         const a = getEngine();


### PR DESCRIPTION
Skip now fires from four surfaces, but the mini-player acknowledged a change only with a content swap, so it could feel abrupt or unregistered. The artwork and title now slide and cross-fade in the skip direction (next enters from the right, prev from the left, ~200ms); reduced-motion drops the slide and keeps the fade.

The direction is generalized at the shared step() seam: a nonced `lastStep` is published once inside step() after any real change, so all five surfaces (buttons, swipe, media keys, globe edge-tap, auto-advance) and the end-of-chart roll feed the one cue with no per-surface wiring. The animated content is keyed on the stable song id and enter-only, so rapid skips interrupt cleanly instead of queuing.

Closes #174

## Test plan
- `pnpm lint` / `typecheck` / `test` green (direction publishes through step from buttons, auto-advance, and globe skip-intent; initial play and direct row taps stay cue-free; a stale recorded step never animates on mount).
- `pnpm build` clean with env sourced.

## Open items
- On-device: cue distance (14px) and 200ms duration were chosen from design-system guidance, not eyeballed on a phone; verify the slide reads under the marquee and eq indicator, and that reduced-motion falls back to fade only.
- The effect is enter-only (the outgoing node is dropped on remount), not a literal two-layer cross-fade; reads fine where the slide dominates, but in reduced-motion the fade is the sole cue.

## Note
Built on the shared step() seam, so it inherits the end-of-chart roll's direction for free: a roll into a fresh country slides the mini-player in the next direction too.
