### PR TITLE
feat(mini-player): slide the now-playing content with the skip swipe

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -326,6 +326,20 @@ function ChartScreenInner({
   // no-ops, so the button need not predict the draw.
   const canNext = hasCurrentTrack && currentCountryCode !== null;
 
+  // The plain adjacent tracks, for the mini-player's swipe rail preview. Null at
+  // a chart end, where the step rolls to another country rather than a neighbour
+  // (the roll target isn't previewed — it's a bigger context change on commit).
+  const [prevTrack, nextTrack] = useMemo(() => {
+    if (currentTrack === null || currentCountryCode === null)
+      return [null, null] as const;
+    const source = charts.countries[currentCountryCode];
+    if (!source) return [null, null] as const;
+    return [
+      findAdjacentPlayable(source.tracks, currentTrack, -1),
+      findAdjacentPlayable(source.tracks, currentTrack, 1),
+    ] as const;
+  }, [currentTrack, currentCountryCode, charts.countries]);
+
   // Skip lives here, not in the audio store: routing prev/next needs the chart
   // data to find the adjacent playable track, which the store doesn't hold.
   useEffect(() => {
@@ -390,6 +404,8 @@ function ChartScreenInner({
         onNext={goNext}
         canPrev={canPrev}
         canNext={canNext}
+        prevTrack={prevTrack}
+        nextTrack={nextTrack}
       />
       {/* Only while the globe is visible: at full the sheet covers it, so
           showing the hint there would burn one of its capped displays unseen. */}

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -57,6 +57,8 @@ function renderMiniPlayer(
     onNext: vi.fn(),
     canPrev: true,
     canNext: true,
+    prevTrack: null,
+    nextTrack: null,
     ...props,
   };
   const utils = render(
@@ -100,8 +102,12 @@ describe("MiniPlayer", () => {
 
     expect(screen.getByText("Hot Track")).toBeDefined();
     expect(screen.getByText("Hot Artist")).toBeDefined();
-    const artwork = container.querySelector('[aria-hidden="true"]');
-    expect(artwork?.getAttribute("style")).toContain(track.artworkUrl);
+    // The current card's artwork, found among the rail's aria-hidden nodes by
+    // its background image (the empty prev/next preview slots carry none).
+    const artwork = [
+      ...container.querySelectorAll('[aria-hidden="true"]'),
+    ].find((el) => el.getAttribute("style")?.includes(track.artworkUrl));
+    expect(artwork).toBeDefined();
   });
 
   test("tap on main area fires onTap callback", () => {

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -175,34 +175,72 @@ describe("MiniPlayer", () => {
     expect((prevButton as HTMLButtonElement).disabled).toBe(true);
   });
 
-  test("swipe left fires onNext and suppresses the tap", () => {
-    const onNext = vi.fn();
-    const onTap = vi.fn();
+  test("a left swipe fires onNext after the commit slide and suppresses the tap", () => {
+    vi.useFakeTimers();
+    try {
+      const onNext = vi.fn();
+      const onTap = vi.fn();
 
-    renderMiniPlayer({ onNext, onTap }, { currentTrack: makeTrack() });
+      renderMiniPlayer({ onNext, onTap }, { currentTrack: makeTrack() });
 
-    const area = screen.getByRole("button", { name: /reopen chart/i });
-    fireEvent.pointerDown(area, { clientX: 200, clientY: 10 });
-    fireEvent.pointerUp(area, { clientX: 40, clientY: 10 });
-    fireEvent.click(area);
+      const area = screen.getByRole("button", { name: /reopen chart/i });
+      fireEvent.pointerDown(area, { clientX: 200, clientY: 10 });
+      fireEvent.pointerMove(area, { clientX: 40, clientY: 10 });
+      fireEvent.pointerUp(area, { clientX: 40, clientY: 10 });
+      // The skip is deferred until the outgoing slide finishes.
+      expect(onNext).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      fireEvent.click(area);
 
-    expect(onNext).toHaveBeenCalledTimes(1);
-    expect(onTap).not.toHaveBeenCalled();
+      expect(onNext).toHaveBeenCalledTimes(1);
+      expect(onTap).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  test("swipe right fires onPrev and suppresses the tap", () => {
+  test("a right swipe fires onPrev after the commit slide and suppresses the tap", () => {
+    vi.useFakeTimers();
+    try {
+      const onPrev = vi.fn();
+      const onTap = vi.fn();
+
+      renderMiniPlayer({ onPrev, onTap }, { currentTrack: makeTrack() });
+
+      const area = screen.getByRole("button", { name: /reopen chart/i });
+      fireEvent.pointerDown(area, { clientX: 40, clientY: 10 });
+      fireEvent.pointerMove(area, { clientX: 200, clientY: 10 });
+      fireEvent.pointerUp(area, { clientX: 200, clientY: 10 });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      fireEvent.click(area);
+
+      expect(onPrev).toHaveBeenCalledTimes(1);
+      expect(onTap).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a vertical drag does not skip and still reopens on tap", () => {
+    const onNext = vi.fn();
     const onPrev = vi.fn();
     const onTap = vi.fn();
 
-    renderMiniPlayer({ onPrev, onTap }, { currentTrack: makeTrack() });
+    renderMiniPlayer({ onNext, onPrev, onTap }, { currentTrack: makeTrack() });
 
     const area = screen.getByRole("button", { name: /reopen chart/i });
-    fireEvent.pointerDown(area, { clientX: 40, clientY: 10 });
-    fireEvent.pointerUp(area, { clientX: 200, clientY: 10 });
+    fireEvent.pointerDown(area, { clientX: 100, clientY: 10 });
+    fireEvent.pointerMove(area, { clientX: 104, clientY: 90 });
+    fireEvent.pointerUp(area, { clientX: 104, clientY: 90 });
     fireEvent.click(area);
 
-    expect(onPrev).toHaveBeenCalledTimes(1);
-    expect(onTap).not.toHaveBeenCalled();
+    expect(onNext).not.toHaveBeenCalled();
+    expect(onPrev).not.toHaveBeenCalled();
+    expect(onTap).toHaveBeenCalledTimes(1);
   });
 
   test("commentary badge is absent when the track carries no commentary", () => {

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -269,6 +269,33 @@ describe("MiniPlayer", () => {
     }
   });
 
+  test("re-grabbing during the commit slide flushes the pending skip once", () => {
+    vi.useFakeTimers();
+    try {
+      const onNext = vi.fn();
+      renderMiniPlayer({ onNext }, { currentTrack: makeTrack() });
+
+      const area = screen.getByRole("button", { name: /reopen chart/i });
+      fireEvent.pointerDown(area, { clientX: 200, clientY: 10 });
+      fireEvent.pointerMove(area, { clientX: 40, clientY: 10 });
+      fireEvent.pointerUp(area, { clientX: 40, clientY: 10 });
+      // Grab again before the slide's timer fires: the interrupted skip lands now.
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(onNext).not.toHaveBeenCalled();
+      fireEvent.pointerDown(area, { clientX: 150, clientY: 10 });
+      expect(onNext).toHaveBeenCalledTimes(1);
+      // The elapsed timer must not fire it a second time.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(onNext).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("commentary badge is absent when the track carries no commentary", () => {
     renderMiniPlayer({}, { currentTrack: makeTrack() });
 

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -243,6 +243,26 @@ describe("MiniPlayer", () => {
     expect(onTap).toHaveBeenCalledTimes(1);
   });
 
+  test("a swipe that starts on a control still skips: the whole bar is the surface", () => {
+    vi.useFakeTimers();
+    try {
+      const onNext = vi.fn();
+      renderMiniPlayer({ onNext }, { currentTrack: makeTrack() });
+
+      const play = screen.getByRole("button", { name: /play preview/i });
+      fireEvent.pointerDown(play, { clientX: 200, clientY: 10 });
+      fireEvent.pointerMove(play, { clientX: 40, clientY: 10 });
+      fireEvent.pointerUp(play, { clientX: 40, clientY: 10 });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(onNext).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("commentary badge is absent when the track carries no commentary", () => {
     renderMiniPlayer({}, { currentTrack: makeTrack() });
 

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -4,6 +4,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -15,6 +16,7 @@ import { SkipBackIcon } from "@/components/icons/skip-back";
 import { SkipForwardIcon } from "@/components/icons/skip-forward";
 import { useOverflowMarquee } from "@/components/use-overflow-marquee";
 import { VolumeControl } from "@/components/volume-control";
+import type { Track } from "@/lib/chart-schema";
 import { trackKey } from "@/lib/track-identity";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
@@ -27,10 +29,15 @@ export interface MiniPlayerProps {
   onNext: () => void;
   canPrev: boolean;
   canNext: boolean;
+  // The adjacent playable tracks, previewed in the swipe rail so a drag shows
+  // where it's heading. Null at a chart end, where the skip rolls to another
+  // country instead of a plain neighbour.
+  prevTrack: Track | null;
+  nextTrack: Track | null;
 }
 
 // Horizontal travel (px) past which a press is a drag, not a tap: suppresses the
-// reopen-chart click and lets the now-playing content follow the finger.
+// reopen-chart click and lets the rail follow the finger.
 const DRAG_ENGAGE_PX = 8;
 // Swipe feel, tuned by eye. Left = next; a release commits past a third of the
 // width or on a fast flick, else springs back.
@@ -39,18 +46,46 @@ const SWIPE_CFG: SwipeCommitConfig = {
   flickToCommit: true,
   flickVelPxPerMs: 0.5,
 };
-// Commit slide: the content leaves in the swipe direction (ease-out, no
-// overshoot). The incoming track slides in via the existing data-track-change
-// cue, so the audio skip is deferred one commit so the two read as one motion.
+// Commit slide (ease-out, no overshoot) and the spring-back on a release that
+// didn't commit (a light overshoot gives it life without wobbling).
 const COMMIT_MS = 260;
 const COMMIT_EASE = "cubic-bezier(0.22, 0.61, 0.36, 1)";
-// Spring-back on a release that didn't commit: a light overshoot gives it life
-// without wobbling a small element.
 const RETURN_MS = 232;
 const RETURN_EASE = "cubic-bezier(0.34, 1.3, 0.64, 1)";
+// The rail lays out prev | current | next, each the strip's full width, and
+// rests shifted one card left so the current sits in the window. A commit slides
+// the committed neighbour into the window as the current slides out.
+const RAIL_REST = "translateX(-100%)";
+const RAIL_NEXT = "translateX(-200%)";
+const RAIL_PREV = "translateX(0%)";
 
 const SKIP_BUTTON_CLASS =
   "text-fg-2 hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-30";
+
+// A non-interactive preview of an adjacent track for the rail: only the current
+// card carries the marquee, EQ, and a11y text, so the neighbours stay plain and
+// hidden from assistive tech. Null (a chart end) renders an empty slot.
+function PreviewCard({ track }: { track: Track | null }) {
+  if (track === null)
+    return <div className="w-full shrink-0" aria-hidden="true" />;
+  return (
+    <div
+      aria-hidden="true"
+      className="flex w-full shrink-0 items-center gap-[14px]"
+    >
+      <div
+        style={{ backgroundImage: `url(${track.artworkUrl})` }}
+        className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="text-sunrise text-body truncate font-medium">
+          {track.name}
+        </p>
+        <p className="text-fg-2 text-small truncate">{track.artist}</p>
+      </div>
+    </div>
+  );
+}
 
 export function MiniPlayer({
   onTap,
@@ -59,18 +94,27 @@ export function MiniPlayer({
   onNext,
   canPrev,
   canNext,
+  prevTrack,
+  nextTrack,
 }: MiniPlayerProps) {
   const currentTrack = useAudioStore((s) => s.currentTrack);
   const isPlaying = useAudioStore((s) => s.isPlaying);
   const toggle = useAudioStore((s) => s.toggle);
   const lastStep = useAudioStore((s) => s.lastStep);
 
-  // A track change caused by a skip arrives with a fresh step nonce, and the
-  // incoming content should slide in from the skip direction; a change without
-  // one (a direct row tap) stays cue-free. Derived by adjusting state during
-  // render (the same idiom as the sheet's country reset): an effect would both
-  // flag a cascading setState and start the cue one frame after the remount.
   const contentKey = currentTrack === null ? null : trackKey(currentTrack);
+
+  const railRef = useRef<HTMLDivElement | null>(null);
+  // A swipe already slid the rail, so it suppresses the one-shot directional cue
+  // the swap would otherwise fire, to avoid a double motion. State, not a ref, so
+  // the render-time cue derivation can read it without touching a ref.
+  const [suppressCue, setSuppressCue] = useState(false);
+
+  // The 14px directional cue is for changes the rail does NOT animate itself: a
+  // skip button, media keys, auto-advance. A change with a fresh step nonce that
+  // wasn't a swipe slides the incoming content in from that side; a direct tap,
+  // or a swipe (which already animated), stays cue-free. Derived by adjusting
+  // state during render, the same idiom as the sheet's country reset.
   const [stepCue, setStepCue] = useState<{
     key: string | null;
     nonce: number;
@@ -80,11 +124,13 @@ export function MiniPlayer({
     stepCue.key !== contentKey ||
     (lastStep !== null && lastStep.nonce !== stepCue.nonce)
   ) {
+    const fromStep = lastStep !== null && lastStep.nonce !== stepCue.nonce;
+    if (suppressCue) setSuppressCue(false);
     setStepCue({
       key: contentKey,
       nonce: lastStep?.nonce ?? 0,
       dir:
-        lastStep !== null && lastStep.nonce !== stepCue.nonce
+        fromStep && !suppressCue
           ? lastStep.dir === 1
             ? "next"
             : "prev"
@@ -103,10 +149,8 @@ export function MiniPlayer({
   });
 
   // Transient swipe state in refs so following the pointer never re-renders; the
-  // content transform is written straight to the DOM node (cardRef). touch-pan-y
-  // (below) hands horizontal drags to JS but can't cancel Safari's system
-  // edge-swipe, so a prev-swipe begun at the very screen edge may still navigate
-  // back.
+  // rail transform is written straight to the DOM node. touch-pan-y (below) hands
+  // horizontal drags to JS and lets vertical scrolls through.
   const startXRef = useRef(0);
   const startYRef = useRef(0);
   const lastXRef = useRef(0);
@@ -115,15 +159,7 @@ export function MiniPlayer({
   const trackingRef = useRef(false);
   const engagedRef = useRef(false);
   const swipedRef = useRef(false);
-  const cardRef = useRef<HTMLDivElement | null>(null);
   const commitTimerRef = useRef<number | null>(null);
-
-  const clearCommitTimer = () => {
-    if (commitTimerRef.current !== null) {
-      window.clearTimeout(commitTimerRef.current);
-      commitTimerRef.current = null;
-    }
-  };
 
   // A committed skip fires after the slide; drop it if the player unmounts first.
   useEffect(
@@ -134,6 +170,31 @@ export function MiniPlayer({
     [],
   );
 
+  // Snap the rail back to rest the moment the committed neighbour becomes the
+  // current card. Runs before paint, so the reset from the commit's end position
+  // is seamless and there's no flash of an off-centre rail on mount.
+  useLayoutEffect(() => {
+    const rail = railRef.current;
+    if (rail) {
+      rail.style.transition = "none";
+      rail.style.transform = RAIL_REST;
+    }
+  }, [contentKey]);
+
+  const clearCommitTimer = () => {
+    if (commitTimerRef.current !== null) {
+      window.clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+  };
+
+  const settleRail = (transform: string, ms: number, ease: string) => {
+    const rail = railRef.current;
+    if (!rail) return;
+    rail.style.transition = `transform ${ms}ms ${ease}`;
+    rail.style.transform = transform;
+  };
+
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     clearCommitTimer();
     startXRef.current = lastXRef.current = e.clientX;
@@ -143,15 +204,9 @@ export function MiniPlayer({
     trackingRef.current = true;
     engagedRef.current = false;
     swipedRef.current = false;
-    // Drag is 1:1, so the content must be the drag's alone: drop any leftover
-    // spring transition AND the incoming data-track-change cue, whose `both`
-    // fill-mode otherwise keeps overriding the inline transform (a CSS animation
-    // outranks inline style), freezing every drag after the first skip.
-    if (cardRef.current) {
-      cardRef.current.style.transition = "none";
-      cardRef.current.style.animation = "none";
-    }
-    // Capture so a swipe that drifts off the button still delivers its pointerup
+    // Drag is 1:1: drop any leftover settle transition before following.
+    if (railRef.current) railRef.current.style.transition = "none";
+    // Capture so a swipe that drifts off the bar still delivers its pointerup
     // here; the browser releases the capture on pointerup/cancel.
     try {
       e.currentTarget.setPointerCapture(e.pointerId);
@@ -164,7 +219,7 @@ export function MiniPlayer({
     if (!trackingRef.current) return;
     const dx = e.clientX - startXRef.current;
     const dy = e.clientY - startYRef.current;
-    // Engage once the travel is decisively horizontal; from then on the content
+    // Engage once the travel is decisively horizontal; from then on the rail
     // follows the finger and the trailing click is a swipe, not a reopen tap.
     if (!engagedRef.current) {
       if (Math.abs(dx) <= DRAG_ENGAGE_PX || Math.abs(dx) <= Math.abs(dy))
@@ -172,19 +227,12 @@ export function MiniPlayer({
       engagedRef.current = true;
       swipedRef.current = true;
     }
-    if (cardRef.current)
-      cardRef.current.style.transform = `translateX(${dx}px)`;
+    if (railRef.current)
+      railRef.current.style.transform = `translateX(calc(-100% + ${dx}px))`;
     const dt = Math.max(1, e.timeStamp - lastTRef.current);
     velRef.current = (e.clientX - lastXRef.current) / dt;
     lastXRef.current = e.clientX;
     lastTRef.current = e.timeStamp;
-  };
-
-  const settleCard = (transform: string, ms: number, ease: string) => {
-    const card = cardRef.current;
-    if (!card) return;
-    card.style.transition = `transform ${ms}ms ${ease}`;
-    card.style.transform = transform;
   };
 
   const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
@@ -204,18 +252,20 @@ export function MiniPlayer({
     );
 
     if (outcome === "cancel") {
-      settleCard("translateX(0)", RETURN_MS, RETURN_EASE);
+      settleRail(RAIL_REST, RETURN_MS, RETURN_EASE);
       return;
     }
 
-    // Slide the outgoing content off, then skip: the remount's data-track-change
-    // cue slides the new track in from the same side, so the two read as one
-    // continuous motion.
-    settleCard(
-      `translateX(${outcome === "next" ? -100 : 100}%)`,
+    // Slide the committed neighbour into the window as the current leaves, then
+    // skip: onNext/onPrev swaps the store, the neighbour becomes the current
+    // card, and the layout effect snaps the rail back to rest seamlessly. The
+    // cue is suppressed so the swap doesn't re-animate what the rail just did.
+    settleRail(
+      outcome === "next" ? RAIL_NEXT : RAIL_PREV,
       COMMIT_MS,
       COMMIT_EASE,
     );
+    setSuppressCue(true);
     commitTimerRef.current = window.setTimeout(() => {
       commitTimerRef.current = null;
       if (outcome === "next") onNext();
@@ -226,7 +276,7 @@ export function MiniPlayer({
   const handlePointerCancel = () => {
     if (!trackingRef.current) return;
     trackingRef.current = false;
-    if (engagedRef.current) settleCard("translateX(0)", RETURN_MS, RETURN_EASE);
+    if (engagedRef.current) settleRail(RAIL_REST, RETURN_MS, RETURN_EASE);
   };
 
   // The swipe surface is the whole bar, so a completed swipe must swallow the
@@ -261,50 +311,52 @@ export function MiniPlayer({
           type="button"
           onClick={onTap}
           aria-label="Reopen chart"
-          className="focus-visible:outline-aurora flex min-w-0 flex-1 overflow-hidden text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
+          className="focus-visible:outline-aurora min-w-0 flex-1 overflow-hidden text-left focus-visible:outline-2 focus-visible:outline-offset-2"
         >
-          {/* Keyed on the stable song id so a track change remounts the content
-              and restarts the cue from zero: a rapid skip drops the outgoing
-              node instead of queueing, and the marquee re-measures the new
-              title. The button's overflow-hidden keeps the slide from pushing
-              layout. */}
-          <div
-            key={contentKey}
-            ref={cardRef}
-            data-track-change={stepCue.dir ?? undefined}
-            className="flex min-w-0 flex-1 items-center gap-[14px]"
-          >
+          {/* The rail: prev | current | next, each the strip's full width, so a
+              drag reveals the neighbours and a commit slides one into place. The
+              current card is keyed on the stable song id so a track change
+              remounts it (marquee re-measures; the cue restarts from zero). */}
+          <div ref={railRef} style={{ transform: RAIL_REST }} className="flex">
+            <PreviewCard track={prevTrack} />
             <div
-              aria-hidden="true"
-              style={{ backgroundImage: `url(${currentTrack.artworkUrl})` }}
-              className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-            />
-            <div className="min-w-0 flex-1">
-              <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
-                <span className="block min-w-0 overflow-hidden">
-                  <span
-                    ref={titleRef}
-                    className="marquee-track"
-                    data-marquee={titleScrolling || undefined}
-                    style={titleStyle}
-                  >
-                    {currentTrack.name}
+              key={contentKey}
+              data-track-change={stepCue.dir ?? undefined}
+              className="flex w-full shrink-0 items-center gap-[14px]"
+            >
+              <div
+                aria-hidden="true"
+                style={{ backgroundImage: `url(${currentTrack.artworkUrl})` }}
+                className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
+                  <span className="block min-w-0 overflow-hidden">
+                    <span
+                      ref={titleRef}
+                      className="marquee-track"
+                      data-marquee={titleScrolling || undefined}
+                      style={titleStyle}
+                    >
+                      {currentTrack.name}
+                    </span>
                   </span>
-                </span>
-                <span
-                  className="eq shrink-0"
-                  data-paused={!isPlaying || undefined}
-                  aria-hidden
-                >
-                  <span />
-                  <span />
-                  <span />
-                </span>
-              </p>
-              <p className="text-fg-2 text-small truncate">
-                {currentTrack.artist}
-              </p>
+                  <span
+                    className="eq shrink-0"
+                    data-paused={!isPlaying || undefined}
+                    aria-hidden
+                  >
+                    <span />
+                    <span />
+                    <span />
+                  </span>
+                </p>
+                <p className="text-fg-2 text-small truncate">
+                  {currentTrack.artist}
+                </p>
+              </div>
             </div>
+            <PreviewCard track={nextTrack} />
           </div>
         </button>
         {/* A sibling of the strip button, never inside it: nested buttons are

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   useEffect,
   useRef,
@@ -133,7 +134,7 @@ export function MiniPlayer({
     [],
   );
 
-  const handlePointerDown = (e: ReactPointerEvent<HTMLButtonElement>) => {
+  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     clearCommitTimer();
     startXRef.current = lastXRef.current = e.clientX;
     startYRef.current = e.clientY;
@@ -159,7 +160,7 @@ export function MiniPlayer({
     }
   };
 
-  const handlePointerMove = (e: ReactPointerEvent<HTMLButtonElement>) => {
+  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
     if (!trackingRef.current) return;
     const dx = e.clientX - startXRef.current;
     const dy = e.clientY - startYRef.current;
@@ -186,7 +187,7 @@ export function MiniPlayer({
     card.style.transform = transform;
   };
 
-  const handlePointerUp = (e: ReactPointerEvent<HTMLButtonElement>) => {
+  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
     if (!trackingRef.current) return;
     trackingRef.current = false;
     if (!engagedRef.current) return;
@@ -228,28 +229,39 @@ export function MiniPlayer({
     if (engagedRef.current) settleCard("translateX(0)", RETURN_MS, RETURN_EASE);
   };
 
-  const handleTap = () => {
+  // The swipe surface is the whole bar, so a completed swipe must swallow the
+  // trailing click no matter which control it lands on (strip reopen, skip, play,
+  // volume). Caught on the row in the capture phase, it never reaches the target.
+  const handleBarClickCapture = (e: ReactMouseEvent<HTMLDivElement>) => {
     if (swipedRef.current) {
       swipedRef.current = false;
-      return;
+      e.stopPropagation();
+      e.preventDefault();
     }
-    onTap();
   };
 
   if (currentTrack === null) return null;
 
   return (
     <div className="bg-void border-fg-1/10 shadow-sheet fixed inset-x-0 bottom-0 z-50 border-t">
-      <div className="flex items-center gap-[14px] px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]">
+      {/* The whole bar is the swipe surface (grab anywhere to skip); only the
+          now-playing strip translates, since the controls don't change per
+          track. touch-pan-y hands horizontal drags to JS and lets vertical
+          scrolls through; the capture-phase click guard swallows the click a
+          swipe leaves behind before it reaches any control. */}
+      <div
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onClickCapture={handleBarClickCapture}
+        className="flex touch-pan-y items-center gap-[14px] px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]"
+      >
         <button
           type="button"
-          onClick={handleTap}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerCancel}
+          onClick={onTap}
           aria-label="Reopen chart"
-          className="focus-visible:outline-aurora flex min-w-0 flex-1 touch-pan-y overflow-hidden text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
+          className="focus-visible:outline-aurora flex min-w-0 flex-1 overflow-hidden text-left transition-transform duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.98]"
         >
           {/* Keyed on the stable song id so a track change remounts the content
               and restarts the cue from zero: a rapid skip drops the outgoing

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { useState } from "react";
 
 import { ExpandIcon } from "@/components/icons/expand";
 import { PauseIcon } from "@/components/icons/pause";
@@ -20,7 +13,7 @@ import type { Track } from "@/lib/chart-schema";
 import { trackKey } from "@/lib/track-identity";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
-import { type SwipeCommitConfig, decideSwipeCommit } from "./swipe-commit";
+import { RAIL_REST, useSwipeRail } from "./use-swipe-rail";
 
 export interface MiniPlayerProps {
   onTap: () => void;
@@ -36,31 +29,21 @@ export interface MiniPlayerProps {
   nextTrack: Track | null;
 }
 
-// Horizontal travel (px) past which a press is a drag, not a tap: suppresses the
-// reopen-chart click and lets the rail follow the finger.
-const DRAG_ENGAGE_PX = 8;
-// Swipe feel, tuned by eye. Left = next; a release commits past a third of the
-// width or on a fast flick, else springs back.
-const SWIPE_CFG: SwipeCommitConfig = {
-  commitThresholdPct: 33,
-  flickToCommit: true,
-  flickVelPxPerMs: 0.5,
-};
-// Commit slide (ease-out, no overshoot) and the spring-back on a release that
-// didn't commit (a light overshoot gives it life without wobbling).
-const COMMIT_MS = 260;
-const COMMIT_EASE = "cubic-bezier(0.22, 0.61, 0.36, 1)";
-const RETURN_MS = 232;
-const RETURN_EASE = "cubic-bezier(0.34, 1.3, 0.64, 1)";
-// The rail lays out prev | current | next, each the strip's full width, and
-// rests shifted one card left so the current sits in the window. A commit slides
-// the committed neighbour into the window as the current slides out.
-const RAIL_REST = "translateX(-100%)";
-const RAIL_NEXT = "translateX(-200%)";
-const RAIL_PREV = "translateX(0%)";
-
 const SKIP_BUTTON_CLASS =
   "text-fg-2 hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-30";
+
+// The 48px cover thumbnail, shared by the current card and the rail's preview
+// cards so a style change stays in one place. Decorative (the a11y track text
+// lives on the current card's title), so always aria-hidden.
+function TrackArtwork({ url }: { url: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ backgroundImage: `url(${url})` }}
+      className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+    />
+  );
+}
 
 // A non-interactive preview of an adjacent track for the rail: only the current
 // card carries the marquee, EQ, and a11y text, so the neighbours stay plain and
@@ -73,10 +56,7 @@ function PreviewCard({ track }: { track: Track | null }) {
       aria-hidden="true"
       className="flex w-full shrink-0 items-center gap-[14px]"
     >
-      <div
-        style={{ backgroundImage: `url(${track.artworkUrl})` }}
-        className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-      />
+      <TrackArtwork url={track.artworkUrl} />
       <div className="min-w-0 flex-1">
         <p className="text-sunrise text-body truncate font-medium">
           {track.name}
@@ -104,7 +84,6 @@ export function MiniPlayer({
 
   const contentKey = currentTrack === null ? null : trackKey(currentTrack);
 
-  const railRef = useRef<HTMLDivElement | null>(null);
   // A swipe already slid the rail, so it suppresses the one-shot directional cue
   // the swap would otherwise fire, to avoid a double motion. State, not a ref, so
   // the render-time cue derivation can read it without touching a ref.
@@ -148,147 +127,14 @@ export function MiniPlayer({
     text: currentTrack?.name,
   });
 
-  // Transient swipe state in refs so following the pointer never re-renders; the
-  // rail transform is written straight to the DOM node. touch-pan-y (below) hands
-  // horizontal drags to JS and lets vertical scrolls through.
-  const startXRef = useRef(0);
-  const startYRef = useRef(0);
-  const lastXRef = useRef(0);
-  const lastTRef = useRef(0);
-  const velRef = useRef(0);
-  const trackingRef = useRef(false);
-  const engagedRef = useRef(false);
-  const swipedRef = useRef(false);
-  const commitTimerRef = useRef<number | null>(null);
-
-  // A committed skip fires after the slide; drop it if the player unmounts first.
-  useEffect(
-    () => () => {
-      if (commitTimerRef.current !== null)
-        window.clearTimeout(commitTimerRef.current);
-    },
-    [],
-  );
-
-  // Snap the rail back to rest the moment the committed neighbour becomes the
-  // current card. Runs before paint, so the reset from the commit's end position
-  // is seamless and there's no flash of an off-centre rail on mount.
-  useLayoutEffect(() => {
-    const rail = railRef.current;
-    if (rail) {
-      rail.style.transition = "none";
-      rail.style.transform = RAIL_REST;
-    }
-  }, [contentKey]);
-
-  const clearCommitTimer = () => {
-    if (commitTimerRef.current !== null) {
-      window.clearTimeout(commitTimerRef.current);
-      commitTimerRef.current = null;
-    }
-  };
-
-  const settleRail = (transform: string, ms: number, ease: string) => {
-    const rail = railRef.current;
-    if (!rail) return;
-    rail.style.transition = `transform ${ms}ms ${ease}`;
-    rail.style.transform = transform;
-  };
-
-  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
-    clearCommitTimer();
-    startXRef.current = lastXRef.current = e.clientX;
-    startYRef.current = e.clientY;
-    lastTRef.current = e.timeStamp;
-    velRef.current = 0;
-    trackingRef.current = true;
-    engagedRef.current = false;
-    swipedRef.current = false;
-    // Drag is 1:1: drop any leftover settle transition before following.
-    if (railRef.current) railRef.current.style.transition = "none";
-    // Capture so a swipe that drifts off the bar still delivers its pointerup
-    // here; the browser releases the capture on pointerup/cancel.
-    try {
-      e.currentTarget.setPointerCapture(e.pointerId);
-    } catch {
-      /* setPointerCapture is unsupported under jsdom; capture is best-effort */
-    }
-  };
-
-  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
-    if (!trackingRef.current) return;
-    const dx = e.clientX - startXRef.current;
-    const dy = e.clientY - startYRef.current;
-    // Engage once the travel is decisively horizontal; from then on the rail
-    // follows the finger and the trailing click is a swipe, not a reopen tap.
-    if (!engagedRef.current) {
-      if (Math.abs(dx) <= DRAG_ENGAGE_PX || Math.abs(dx) <= Math.abs(dy))
-        return;
-      engagedRef.current = true;
-      swipedRef.current = true;
-    }
-    if (railRef.current)
-      railRef.current.style.transform = `translateX(calc(-100% + ${dx}px))`;
-    const dt = Math.max(1, e.timeStamp - lastTRef.current);
-    velRef.current = (e.clientX - lastXRef.current) / dt;
-    lastXRef.current = e.clientX;
-    lastTRef.current = e.timeStamp;
-  };
-
-  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
-    if (!trackingRef.current) return;
-    trackingRef.current = false;
-    if (!engagedRef.current) return;
-
-    const outcome = decideSwipeCommit(
-      {
-        dx: e.clientX - startXRef.current,
-        vx: velRef.current,
-        width: e.currentTarget.clientWidth,
-        canPrev,
-        canNext,
-      },
-      SWIPE_CFG,
-    );
-
-    if (outcome === "cancel") {
-      settleRail(RAIL_REST, RETURN_MS, RETURN_EASE);
-      return;
-    }
-
-    // Slide the committed neighbour into the window as the current leaves, then
-    // skip: onNext/onPrev swaps the store, the neighbour becomes the current
-    // card, and the layout effect snaps the rail back to rest seamlessly. The
-    // cue is suppressed so the swap doesn't re-animate what the rail just did.
-    settleRail(
-      outcome === "next" ? RAIL_NEXT : RAIL_PREV,
-      COMMIT_MS,
-      COMMIT_EASE,
-    );
-    setSuppressCue(true);
-    commitTimerRef.current = window.setTimeout(() => {
-      commitTimerRef.current = null;
-      if (outcome === "next") onNext();
-      else onPrev();
-    }, COMMIT_MS);
-  };
-
-  const handlePointerCancel = () => {
-    if (!trackingRef.current) return;
-    trackingRef.current = false;
-    if (engagedRef.current) settleRail(RAIL_REST, RETURN_MS, RETURN_EASE);
-  };
-
-  // The swipe surface is the whole bar, so a completed swipe must swallow the
-  // trailing click no matter which control it lands on (strip reopen, skip, play,
-  // volume). Caught on the row in the capture phase, it never reaches the target.
-  const handleBarClickCapture = (e: ReactMouseEvent<HTMLDivElement>) => {
-    if (swipedRef.current) {
-      swipedRef.current = false;
-      e.stopPropagation();
-      e.preventDefault();
-    }
-  };
+  const { railRef, swipeHandlers } = useSwipeRail({
+    contentKey,
+    canPrev,
+    canNext,
+    onPrev,
+    onNext,
+    onCommitStart: () => setSuppressCue(true),
+  });
 
   if (currentTrack === null) return null;
 
@@ -300,11 +146,7 @@ export function MiniPlayer({
           scrolls through; the capture-phase click guard swallows the click a
           swipe leaves behind before it reaches any control. */}
       <div
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerCancel}
-        onClickCapture={handleBarClickCapture}
+        {...swipeHandlers}
         className="flex touch-pan-y items-center gap-[14px] px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]"
       >
         <button
@@ -324,11 +166,7 @@ export function MiniPlayer({
               data-track-change={stepCue.dir ?? undefined}
               className="flex w-full shrink-0 items-center gap-[14px]"
             >
-              <div
-                aria-hidden="true"
-                style={{ backgroundImage: `url(${currentTrack.artworkUrl})` }}
-                className="bg-fg-1/5 h-12 w-12 shrink-0 rounded-lg bg-cover bg-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-              />
+              <TrackArtwork url={currentTrack.artworkUrl} />
               <div className="min-w-0 flex-1">
                 <p className="text-sunrise text-body flex min-w-0 items-center gap-2 font-medium">
                   <span className="block min-w-0 overflow-hidden">

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -142,8 +142,14 @@ export function MiniPlayer({
     trackingRef.current = true;
     engagedRef.current = false;
     swipedRef.current = false;
-    // Drag is 1:1, so drop any leftover spring transition before following.
-    if (cardRef.current) cardRef.current.style.transition = "none";
+    // Drag is 1:1, so the content must be the drag's alone: drop any leftover
+    // spring transition AND the incoming data-track-change cue, whose `both`
+    // fill-mode otherwise keeps overriding the inline transform (a CSS animation
+    // outranks inline style), freezing every drag after the first skip.
+    if (cardRef.current) {
+      cardRef.current.style.transition = "none";
+      cardRef.current.style.animation = "none";
+    }
     // Capture so a swipe that drifts off the button still delivers its pointerup
     // here; the browser releases the capture on pointerup/cancel.
     try {

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -2,6 +2,7 @@
 
 import {
   type PointerEvent as ReactPointerEvent,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -16,6 +17,8 @@ import { VolumeControl } from "@/components/volume-control";
 import { trackKey } from "@/lib/track-identity";
 import { useAudioStore } from "@/providers/audio-store-provider";
 
+import { type SwipeCommitConfig, decideSwipeCommit } from "./swipe-commit";
+
 export interface MiniPlayerProps {
   onTap: () => void;
   onCommentary: () => void;
@@ -25,9 +28,25 @@ export interface MiniPlayerProps {
   canNext: boolean;
 }
 
-// Horizontal pointer travel (px) that turns a press on the now-playing area into
-// a skip swipe instead of a tap that reopens the chart.
-const SWIPE_THRESHOLD_PX = 40;
+// Horizontal travel (px) past which a press is a drag, not a tap: suppresses the
+// reopen-chart click and lets the now-playing content follow the finger.
+const DRAG_ENGAGE_PX = 8;
+// Swipe feel, tuned by eye. Left = next; a release commits past a third of the
+// width or on a fast flick, else springs back.
+const SWIPE_CFG: SwipeCommitConfig = {
+  commitThresholdPct: 33,
+  flickToCommit: true,
+  flickVelPxPerMs: 0.5,
+};
+// Commit slide: the content leaves in the swipe direction (ease-out, no
+// overshoot). The incoming track slides in via the existing data-track-change
+// cue, so the audio skip is deferred one commit so the two read as one motion.
+const COMMIT_MS = 260;
+const COMMIT_EASE = "cubic-bezier(0.22, 0.61, 0.36, 1)";
+// Spring-back on a release that didn't commit: a light overshoot gives it life
+// without wobbling a small element.
+const RETURN_MS = 232;
+const RETURN_EASE = "cubic-bezier(0.34, 1.3, 0.64, 1)";
 
 const SKIP_BUTTON_CLASS =
   "text-fg-2 hover:bg-orbit hover:text-fg-1 focus-visible:outline-aurora flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-all duration-150 ease-[var(--ease-spring)] focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-30";
@@ -82,20 +101,49 @@ export function MiniPlayer({
     text: currentTrack?.name,
   });
 
-  // Transient swipe state in refs so tracking the pointer never re-renders.
-  // touch-pan-y (below) hands horizontal drags to JS but can't cancel Safari's
-  // system edge-swipe, so a prev-swipe begun at the very screen edge may still
-  // navigate back.
+  // Transient swipe state in refs so following the pointer never re-renders; the
+  // content transform is written straight to the DOM node (cardRef). touch-pan-y
+  // (below) hands horizontal drags to JS but can't cancel Safari's system
+  // edge-swipe, so a prev-swipe begun at the very screen edge may still navigate
+  // back.
   const startXRef = useRef(0);
   const startYRef = useRef(0);
+  const lastXRef = useRef(0);
+  const lastTRef = useRef(0);
+  const velRef = useRef(0);
   const trackingRef = useRef(false);
+  const engagedRef = useRef(false);
   const swipedRef = useRef(false);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const commitTimerRef = useRef<number | null>(null);
+
+  const clearCommitTimer = () => {
+    if (commitTimerRef.current !== null) {
+      window.clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+  };
+
+  // A committed skip fires after the slide; drop it if the player unmounts first.
+  useEffect(
+    () => () => {
+      if (commitTimerRef.current !== null)
+        window.clearTimeout(commitTimerRef.current);
+    },
+    [],
+  );
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLButtonElement>) => {
-    startXRef.current = e.clientX;
+    clearCommitTimer();
+    startXRef.current = lastXRef.current = e.clientX;
     startYRef.current = e.clientY;
+    lastTRef.current = e.timeStamp;
+    velRef.current = 0;
     trackingRef.current = true;
+    engagedRef.current = false;
     swipedRef.current = false;
+    // Drag is 1:1, so drop any leftover spring transition before following.
+    if (cardRef.current) cardRef.current.style.transition = "none";
     // Capture so a swipe that drifts off the button still delivers its pointerup
     // here; the browser releases the capture on pointerup/cancel.
     try {
@@ -105,22 +153,73 @@ export function MiniPlayer({
     }
   };
 
+  const handlePointerMove = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!trackingRef.current) return;
+    const dx = e.clientX - startXRef.current;
+    const dy = e.clientY - startYRef.current;
+    // Engage once the travel is decisively horizontal; from then on the content
+    // follows the finger and the trailing click is a swipe, not a reopen tap.
+    if (!engagedRef.current) {
+      if (Math.abs(dx) <= DRAG_ENGAGE_PX || Math.abs(dx) <= Math.abs(dy))
+        return;
+      engagedRef.current = true;
+      swipedRef.current = true;
+    }
+    if (cardRef.current)
+      cardRef.current.style.transform = `translateX(${dx}px)`;
+    const dt = Math.max(1, e.timeStamp - lastTRef.current);
+    velRef.current = (e.clientX - lastXRef.current) / dt;
+    lastXRef.current = e.clientX;
+    lastTRef.current = e.timeStamp;
+  };
+
+  const settleCard = (transform: string, ms: number, ease: string) => {
+    const card = cardRef.current;
+    if (!card) return;
+    card.style.transition = `transform ${ms}ms ${ease}`;
+    card.style.transform = transform;
+  };
+
   const handlePointerUp = (e: ReactPointerEvent<HTMLButtonElement>) => {
     if (!trackingRef.current) return;
     trackingRef.current = false;
-    const dx = e.clientX - startXRef.current;
-    const dy = e.clientY - startYRef.current;
-    if (Math.abs(dx) <= SWIPE_THRESHOLD_PX || Math.abs(dx) <= Math.abs(dy)) {
+    if (!engagedRef.current) return;
+
+    const outcome = decideSwipeCommit(
+      {
+        dx: e.clientX - startXRef.current,
+        vx: velRef.current,
+        width: e.currentTarget.clientWidth,
+        canPrev,
+        canNext,
+      },
+      SWIPE_CFG,
+    );
+
+    if (outcome === "cancel") {
+      settleCard("translateX(0)", RETURN_MS, RETURN_EASE);
       return;
     }
-    // A swipe fired: flag it so the click that follows doesn't also reopen.
-    swipedRef.current = true;
-    if (dx < 0) onNext();
-    else onPrev();
+
+    // Slide the outgoing content off, then skip: the remount's data-track-change
+    // cue slides the new track in from the same side, so the two read as one
+    // continuous motion.
+    settleCard(
+      `translateX(${outcome === "next" ? -100 : 100}%)`,
+      COMMIT_MS,
+      COMMIT_EASE,
+    );
+    commitTimerRef.current = window.setTimeout(() => {
+      commitTimerRef.current = null;
+      if (outcome === "next") onNext();
+      else onPrev();
+    }, COMMIT_MS);
   };
 
   const handlePointerCancel = () => {
+    if (!trackingRef.current) return;
     trackingRef.current = false;
+    if (engagedRef.current) settleCard("translateX(0)", RETURN_MS, RETURN_EASE);
   };
 
   const handleTap = () => {
@@ -140,6 +239,7 @@ export function MiniPlayer({
           type="button"
           onClick={handleTap}
           onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerCancel}
           aria-label="Reopen chart"
@@ -152,6 +252,7 @@ export function MiniPlayer({
               layout. */}
           <div
             key={contentKey}
+            ref={cardRef}
             data-track-change={stepCue.dir ?? undefined}
             className="flex min-w-0 flex-1 items-center gap-[14px]"
           >

--- a/src/components/swipe-commit.test.ts
+++ b/src/components/swipe-commit.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "vitest";
+
+import {
+  type SwipeCommitConfig,
+  type SwipeSample,
+  decideSwipeCommit,
+} from "./swipe-commit";
+
+const CFG: SwipeCommitConfig = {
+  commitThresholdPct: 33,
+  flickToCommit: true,
+  flickVelPxPerMs: 0.5,
+};
+
+const WIDTH = 300; // threshold = 33% => 99px
+
+const sample = (over: Partial<SwipeSample>): SwipeSample => ({
+  dx: 0,
+  vx: 0,
+  width: WIDTH,
+  canPrev: true,
+  canNext: true,
+  ...over,
+});
+
+test("a still release with no travel springs back", () => {
+  expect(decideSwipeCommit(sample({ dx: 0 }), CFG)).toBe("cancel");
+});
+
+test("a zero-width area can't measure a threshold, so it cancels", () => {
+  expect(decideSwipeCommit(sample({ dx: -200, width: 0 }), CFG)).toBe("cancel");
+});
+
+test("a slow drag past the threshold to the left skips to the next track", () => {
+  expect(decideSwipeCommit(sample({ dx: -120 }), CFG)).toBe("next");
+});
+
+test("a slow drag past the threshold to the right skips to the previous track", () => {
+  expect(decideSwipeCommit(sample({ dx: 120 }), CFG)).toBe("prev");
+});
+
+test("a drag short of the threshold with no flick springs back", () => {
+  expect(decideSwipeCommit(sample({ dx: -60, vx: -0.1 }), CFG)).toBe("cancel");
+});
+
+test("a short but fast leftward flick commits to the next track", () => {
+  expect(decideSwipeCommit(sample({ dx: -40, vx: -0.9 }), CFG)).toBe("next");
+});
+
+test("a flick whose velocity opposes the drag does not commit", () => {
+  expect(decideSwipeCommit(sample({ dx: -40, vx: 0.9 }), CFG)).toBe("cancel");
+});
+
+test("with flick disabled a short fast swipe still springs back", () => {
+  const noFlick = { ...CFG, flickToCommit: false };
+  expect(decideSwipeCommit(sample({ dx: -40, vx: -0.9 }), noFlick)).toBe(
+    "cancel",
+  );
+});
+
+test("a drag exactly at the threshold commits", () => {
+  expect(decideSwipeCommit(sample({ dx: -99 }), CFG)).toBe("next");
+});
+
+test("a next-ward commit at the last track clamps to a spring-back", () => {
+  expect(decideSwipeCommit(sample({ dx: -120, canNext: false }), CFG)).toBe(
+    "cancel",
+  );
+});
+
+test("a prev-ward commit at the first track clamps to a spring-back", () => {
+  expect(decideSwipeCommit(sample({ dx: 120, canPrev: false }), CFG)).toBe(
+    "cancel",
+  );
+});

--- a/src/components/swipe-commit.ts
+++ b/src/components/swipe-commit.ts
@@ -1,0 +1,61 @@
+// Decides what a released track-skip swipe does: commit to the next or previous
+// track, or spring back. Pure so the whole matrix (short-but-fast flick,
+// long-but-slow drag, a commit toward the chart end) is table-testable without a
+// browser, matching the gesture-judgment leaves `tap-detect` and `spin-gesture`.
+
+export interface SwipeCommitConfig {
+  // Past this fraction of the swipe area's width, a release commits.
+  commitThresholdPct: number;
+  // A fast flick commits even below the distance threshold.
+  flickToCommit: boolean;
+  // Minimum release speed (px/ms) that counts as a flick.
+  flickVelPxPerMs: number;
+}
+
+export type SwipeOutcome = "next" | "prev" | "cancel";
+
+export interface SwipeSample {
+  // Total horizontal travel since press (px); negative is leftward.
+  dx: number;
+  // Release velocity (px/ms); its sign is the flick direction.
+  vx: number;
+  // Swipe-area width (px), the basis for the percentage threshold.
+  width: number;
+  // Whether a previous / next track exists to skip to (chart-end clamp).
+  canPrev: boolean;
+  canNext: boolean;
+}
+
+// Swipe left (dx < 0) skips to the next track, swipe right to the previous —
+// the carousel convention. A release commits when it clears the distance
+// threshold OR flicks fast enough (when enabled); otherwise it springs back.
+// A commit toward a side with no track (chart end, before the roll logic in the
+// caller) cancels instead.
+export function decideSwipeCommit(
+  sample: SwipeSample,
+  cfg: SwipeCommitConfig,
+): SwipeOutcome {
+  const { dx, vx, width, canPrev, canNext } = sample;
+
+  // No travel: nothing to judge.
+  if (dx === 0) return "cancel";
+
+  // Distance needs a width to size the threshold against; a flick doesn't, so
+  // the width guard sits here, not over the whole decision.
+  const pastDistance =
+    width > 0 && Math.abs(dx) / width >= cfg.commitThresholdPct / 100;
+  // A flick counts only when the release accelerates the same way the drag
+  // went; a finger reversing at the last instant is not a commit.
+  const flicked =
+    cfg.flickToCommit &&
+    Math.abs(vx) >= cfg.flickVelPxPerMs &&
+    Math.sign(vx) === Math.sign(dx);
+  if (!pastDistance && !flicked) return "cancel";
+
+  const dir: SwipeOutcome = dx < 0 ? "next" : "prev";
+
+  // Nowhere to skip to on that side (chart end, before the caller's roll): hold.
+  if (dir === "next" && !canNext) return "cancel";
+  if (dir === "prev" && !canPrev) return "cancel";
+  return dir;
+}

--- a/src/components/swipe-commit.ts
+++ b/src/components/swipe-commit.ts
@@ -26,7 +26,7 @@ export interface SwipeSample {
   canNext: boolean;
 }
 
-// Swipe left (dx < 0) skips to the next track, swipe right to the previous —
+// Swipe left (dx < 0) skips to the next track, swipe right to the previous:
 // the carousel convention. A release commits when it clears the distance
 // threshold OR flicks fast enough (when enabled); otherwise it springs back.
 // A commit toward a side with no track (chart end, before the roll logic in the

--- a/src/components/use-swipe-rail.ts
+++ b/src/components/use-swipe-rail.ts
@@ -1,0 +1,238 @@
+"use client";
+
+import {
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
+
+import { type SwipeCommitConfig, decideSwipeCommit } from "./swipe-commit";
+
+// Horizontal travel (px) past which a press is a drag, not a tap: suppresses the
+// reopen-chart click and lets the rail follow the finger.
+const DRAG_ENGAGE_PX = 8;
+// Swipe feel, tuned by eye. Left = next; a release commits past a third of the
+// width or on a fast flick, else springs back.
+const SWIPE_CFG: SwipeCommitConfig = {
+  commitThresholdPct: 33,
+  flickToCommit: true,
+  flickVelPxPerMs: 0.5,
+};
+// Commit slide (ease-out, no overshoot) and the spring-back on a release that
+// didn't commit (a light overshoot gives it life without wobbling).
+const COMMIT_MS = 260;
+const COMMIT_EASE = "cubic-bezier(0.22, 0.61, 0.36, 1)";
+const RETURN_MS = 232;
+const RETURN_EASE = "cubic-bezier(0.34, 1.3, 0.64, 1)";
+// The rail lays out prev | current | next, each the strip's full width, and
+// rests shifted one card left so the current sits in the window. A commit slides
+// the committed neighbour into the window as the current slides out.
+export const RAIL_REST = "translateX(-100%)";
+const RAIL_NEXT = "translateX(-200%)";
+const RAIL_PREV = "translateX(0%)";
+
+export interface SwipeRailOptions {
+  // The stable song id of the current track; a change means the store swapped.
+  contentKey: string | null;
+  canPrev: boolean;
+  canNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  // Fired the instant a release commits (before the slide finishes), so the
+  // caller can suppress the directional cue the coming swap would otherwise play.
+  onCommitStart: () => void;
+}
+
+// Owns the mini-player's track-skip swipe: follows the finger by writing the
+// rail transform straight to the DOM (never re-rendering per move), judges the
+// release with the pure `decideSwipeCommit`, then slides + defers the skip. The
+// gesture is a self-contained unit, kept out of the component so the render body
+// stays about layout, not pointer bookkeeping.
+export function useSwipeRail({
+  contentKey,
+  canPrev,
+  canNext,
+  onPrev,
+  onNext,
+  onCommitStart,
+}: SwipeRailOptions) {
+  const railRef = useRef<HTMLDivElement | null>(null);
+
+  // Transient swipe state in refs so following the pointer never re-renders.
+  // touch-pan-y (on the surface) hands horizontal drags to JS and lets vertical
+  // scrolls through.
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const lastXRef = useRef(0);
+  const lastTRef = useRef(0);
+  const velRef = useRef(0);
+  const trackingRef = useRef(false);
+  const engagedRef = useRef(false);
+  const swipedRef = useRef(false);
+  const commitTimerRef = useRef<number | null>(null);
+  // The deferred skip of an in-flight commit, held so a fresh press can decide
+  // its fate (see resolvePendingCommit) instead of silently dropping it.
+  const pendingCommitRef = useRef<(() => void) | null>(null);
+
+  // A committed skip fires after the slide; drop it if the player unmounts first.
+  useEffect(
+    () => () => {
+      if (commitTimerRef.current !== null)
+        window.clearTimeout(commitTimerRef.current);
+    },
+    [],
+  );
+
+  // Snap the rail back to rest the moment the committed neighbour becomes the
+  // current card. Runs before paint, so the reset from the commit's end position
+  // is seamless and there's no flash of an off-centre rail on mount.
+  useLayoutEffect(() => {
+    const rail = railRef.current;
+    if (rail) {
+      rail.style.transition = "none";
+      rail.style.transform = RAIL_REST;
+    }
+  }, [contentKey]);
+
+  const settleRail = (transform: string, ms: number, ease: string) => {
+    const rail = railRef.current;
+    if (!rail) return;
+    rail.style.transition = `transform ${ms}ms ${ease}`;
+    rail.style.transform = transform;
+  };
+
+  // Run the deferred skip exactly once: the ref is nulled before the call, so
+  // whichever of the timer or a re-grab fires second finds nothing and no-ops.
+  const flushPendingCommit = () => {
+    const skip = pendingCommitRef.current;
+    pendingCommitRef.current = null;
+    skip?.();
+  };
+
+  // A fresh press landed while a committed slide was still animating. Clear the
+  // stale timer, then flush the interrupted commit now so it still lands: the
+  // user already pushed that track off, and firing the skip swaps the store
+  // before the new drag begins, which snaps the rail to rest and consumes the
+  // latched cue suppression. Dropping it would leave the pushed-off track
+  // showing and strand the flag.
+  const resolvePendingCommit = () => {
+    if (commitTimerRef.current !== null) {
+      window.clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+    flushPendingCommit();
+  };
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    resolvePendingCommit();
+    startXRef.current = lastXRef.current = e.clientX;
+    startYRef.current = e.clientY;
+    lastTRef.current = e.timeStamp;
+    velRef.current = 0;
+    trackingRef.current = true;
+    engagedRef.current = false;
+    swipedRef.current = false;
+    // Drag is 1:1: drop any leftover settle transition before following.
+    if (railRef.current) railRef.current.style.transition = "none";
+    // Capture so a swipe that drifts off the bar still delivers its pointerup
+    // here; the browser releases the capture on pointerup/cancel.
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      /* setPointerCapture is unsupported under jsdom; capture is best-effort */
+    }
+  };
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!trackingRef.current) return;
+    const dx = e.clientX - startXRef.current;
+    const dy = e.clientY - startYRef.current;
+    // Engage once the travel is decisively horizontal; from then on the rail
+    // follows the finger and the trailing click is a swipe, not a reopen tap.
+    if (!engagedRef.current) {
+      if (Math.abs(dx) <= DRAG_ENGAGE_PX || Math.abs(dx) <= Math.abs(dy))
+        return;
+      engagedRef.current = true;
+      swipedRef.current = true;
+    }
+    if (railRef.current)
+      railRef.current.style.transform = `translateX(calc(-100% + ${dx}px))`;
+    const dt = Math.max(1, e.timeStamp - lastTRef.current);
+    velRef.current = (e.clientX - lastXRef.current) / dt;
+    lastXRef.current = e.clientX;
+    lastTRef.current = e.timeStamp;
+  };
+
+  const onPointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!trackingRef.current) return;
+    trackingRef.current = false;
+    if (!engagedRef.current) return;
+
+    const outcome = decideSwipeCommit(
+      {
+        dx: e.clientX - startXRef.current,
+        vx: velRef.current,
+        // The whole bar is the swipe surface, so the threshold is a fraction of
+        // the bar, not of the narrower card that visibly travels. Deliberate:
+        // the bar's width is stable, while the card's flex-1 width shifts per
+        // track as the commentary badge and controls come and go, which would
+        // otherwise make the commit distance jitter track to track.
+        width: e.currentTarget.clientWidth,
+        canPrev,
+        canNext,
+      },
+      SWIPE_CFG,
+    );
+
+    if (outcome === "cancel") {
+      settleRail(RAIL_REST, RETURN_MS, RETURN_EASE);
+      return;
+    }
+
+    // Slide the committed neighbour into the window as the current leaves, then
+    // skip: onNext/onPrev swaps the store, the neighbour becomes the current
+    // card, and the layout effect snaps the rail back to rest seamlessly. The
+    // cue is suppressed so the swap doesn't re-animate what the rail just did.
+    settleRail(
+      outcome === "next" ? RAIL_NEXT : RAIL_PREV,
+      COMMIT_MS,
+      COMMIT_EASE,
+    );
+    onCommitStart();
+    pendingCommitRef.current = outcome === "next" ? onNext : onPrev;
+    commitTimerRef.current = window.setTimeout(() => {
+      commitTimerRef.current = null;
+      flushPendingCommit();
+    }, COMMIT_MS);
+  };
+
+  const onPointerCancel = () => {
+    if (!trackingRef.current) return;
+    trackingRef.current = false;
+    if (engagedRef.current) settleRail(RAIL_REST, RETURN_MS, RETURN_EASE);
+  };
+
+  // The swipe surface is the whole bar, so a completed swipe must swallow the
+  // trailing click no matter which control it lands on (strip reopen, skip, play,
+  // volume). Caught on the row in the capture phase, it never reaches the target.
+  const onClickCapture = (e: ReactMouseEvent<HTMLDivElement>) => {
+    if (swipedRef.current) {
+      swipedRef.current = false;
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  };
+
+  return {
+    railRef,
+    swipeHandlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onClickCapture,
+    },
+  };
+}


### PR DESCRIPTION
> **Draft: the slide *feel* is off-device-untunable.** The commit/cancel judgment is table-tested, but the drag-follow, the rail hand-off, and the timing can only be judged on a touch device. Static checks (typecheck / lint / build, 773 tests) pass.

## Why

The mini-player already skipped tracks on a horizontal swipe, but the content never moved, so the direction read as ambiguous in use. It now follows the finger and, on a committed swipe, the adjacent track slides in as the current slides out — next/prev is self-evident and the swipe surface is the whole bar.

## What

- **`swipe-commit.ts`** — pure `decideSwipeCommit(sample, cfg) → "next" | "prev" | "cancel"`: commits past a third of the width **or** on a fast flick, clamped at the chart ends. Table-tested (11 cases).
- **Rail** — the strip renders `prev | current | next`, each its full width, resting one card left. A drag translates the rail (reveals the neighbour it's heading to); a commit slides that neighbour into the window as the current leaves (`260ms` ease-out), then the skip fires and a layout effect snaps the rail back to rest seamlessly. `chart-screen` feeds the adjacent tracks (null at a chart end, where the step rolls). The 14px directional cue stays for changes the rail doesn't animate (skip buttons, media keys, auto-advance) and is suppressed after a swipe.
- **Whole bar is the swipe surface** — drag starts anywhere, not just the strip; a capture-phase click guard swallows the click a completed swipe leaves behind before it reaches any control.
- Pointer tracking + rail transform via refs (no re-render per move).

Feel (tuned by eye): commit threshold **33%** · follow **1:1** · commit **260ms** ease-out · return-spring bounce **33** · flick **on** · swipe-left = next.

## Scope

Out of scope: the discoverability **nudge**, the **volume popover dismiss-first** fix, the first-play sheet-scroll bug (#243), and the edge-double-tap → country-change model change.

## Test plan

- [x] typecheck / lint / build / 773 unit tests
- [ ] **Device:** drag follows the finger 1:1; releasing past ~a third or on a flick skips, else springs back
- [ ] **Device:** the adjacent track slides IN as the current slides out (rail), not a fade
- [ ] **Device:** the second swipe and every one after still animates
- [ ] **Device:** the swipe starts anywhere on the bar, incl. over the controls
- [ ] **Device:** a plain tap on a control still works; a swipe ending on one doesn't also trigger it
- [ ] **Device:** swipe left = next, right = prev
- [ ] **Device:** at a chart end the swipe rolls to another country (this is the existing skip-roll behavior, not a spring-back)
- [ ] **Device:** a vertical scroll doesn't skip

Closes #241
