### PR TITLE
fix(chart-sheet): auto-scroll on a skip, not a direct tap

### DIFF
--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -121,6 +121,7 @@ function ChartScreenInner({
   const selectedCountry = useGlobeChart((s) => s.selectedCountry);
   const currentTrack = useAudioStore((s) => s.currentTrack);
   const currentCountryCode = useAudioStore((s) => s.currentCountryCode);
+  const lastStep = useAudioStore((s) => s.lastStep);
   const hasCurrentTrack = currentTrack !== null;
   const currentTrackRank = currentTrack?.rank ?? null;
   const audioStore = useAudioStoreApi();
@@ -381,6 +382,7 @@ function ChartScreenInner({
         currentCountryCode={currentCountryCode}
         hasMiniPlayer={hasCurrentTrack}
         scrollSignal={scrollSignal}
+        stepSignal={lastStep?.nonce ?? 0}
         focusIntent={focusIntent}
       />
       <MiniPlayer

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -405,6 +405,46 @@ describe("ChartSheet", () => {
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });
 
+  test("does not scroll on a direct tap: a rank change with no step", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // Off-screen row: a skip would pull it in, but a direct tap must not.
+    stubRects(rect(0, 100), rect(200, 240));
+    const first = COUNTRY_KR.tracks[0].rank;
+    const other = COUNTRY_KR.tracks[2].rank;
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={first}
+          stepSignal={0}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    // A tap: the rank changes but the step signal does not.
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="peek"
+          onSnapChange={vi.fn()}
+          currentTrackRank={other}
+          stepSignal={0}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
   test("does not scroll when currentTrackRank is null", async () => {
     const scrollIntoViewMock = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoViewMock;
@@ -438,7 +478,7 @@ describe("ChartSheet", () => {
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 
-  test("scrolls the now-playing row into view when the track changes while open and the row is off-screen", async () => {
+  test("scrolls the now-playing row into view on a skip while open when the row is off-screen", async () => {
     const scrollIntoViewMock = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoViewMock;
     // Row sits below the peek viewport, so reveal-only must pull it in.
@@ -454,11 +494,13 @@ describe("ChartSheet", () => {
           snap="peek"
           onSnapChange={vi.fn()}
           currentTrackRank={first}
+          stepSignal={0}
         />
       </AudioStoreProvider>,
     );
     scrollIntoViewMock.mockClear();
 
+    // A skip: the rank changes and the step signal bumps.
     rerender(
       <AudioStoreProvider>
         <ChartSheet
@@ -467,6 +509,7 @@ describe("ChartSheet", () => {
           snap="peek"
           onSnapChange={vi.fn()}
           currentTrackRank={next}
+          stepSignal={1}
         />
       </AudioStoreProvider>,
     );

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -27,6 +27,11 @@ export interface ChartSheetProps {
   currentCountryCode?: string | null;
   hasMiniPlayer?: boolean;
   scrollSignal?: number;
+  // Bumped on a skip / auto-advance (the step nonce). The auto-scroll follows an
+  // indirect track change (a skip reveals the new row) but not a direct tap (the
+  // tapped item is already under the finger), so it gates on this, not the raw
+  // rank change, which can't tell the two apart.
+  stepSignal?: number;
   // An outside ask (the mini-player's commentary badge) to open a row's focused
   // reader card; the nonce marks each ask so dep-only re-runs never re-focus.
   focusIntent?: { rank: number; nonce: number } | null;
@@ -128,6 +133,7 @@ export function ChartSheet({
   currentCountryCode = null,
   hasMiniPlayer = false,
   scrollSignal = 0,
+  stepSignal = 0,
   focusIntent = null,
 }: ChartSheetProps) {
   const sheetRef = useRef<HTMLDivElement | null>(null);
@@ -572,16 +578,16 @@ export function ChartSheet({
 
   const prevSnapRef = useRef(snap);
   const prevSignalRef = useRef(scrollSignal);
-  const prevRankRef = useRef(currentTrackRank);
+  const prevStepRef = useRef(stepSignal);
 
   useEffect(() => {
     const wasMin =
       prevSnapRef.current === "closed" || prevSnapRef.current === "hidden";
     const signalChanged = prevSignalRef.current !== scrollSignal;
-    const rankChanged = prevRankRef.current !== currentTrackRank;
+    const stepChanged = prevStepRef.current !== stepSignal;
     prevSnapRef.current = snap;
     prevSignalRef.current = scrollSignal;
-    prevRankRef.current = currentTrackRank;
+    prevStepRef.current = stepSignal;
     if (snap === "closed" || snap === "hidden") return;
     if (currentTrackRank === null) return;
     // The now-playing row only exists in the displayed list when the playing
@@ -590,13 +596,14 @@ export function ChartSheet({
     // until they align (null = nothing playing, already handled above).
     if (currentCountryCode !== null && currentCountryCode !== countryCode)
       return;
-    // A reopen (raised from minimized, or a mini-player tap that bumped the
-    // signal) always reveals the row. An in-place track change while the sheet
-    // is already open only follows it when the row would otherwise be hidden,
-    // so a row that's already visible (an adjacent step, or one the user tapped)
-    // never yanks the list.
+    // Reveal the row on an INDIRECT change only: a reopen (raised from
+    // minimized, or a mini-player tap that bumped the signal), or a skip /
+    // auto-advance (a bumped step). A DIRECT tap changes the rank with no step,
+    // and the tapped item is already under the finger, so the list never yanks
+    // to it (which for the gem hero would scroll to its ranked-row duplicate).
+    // A step to an already-visible neighbour still holds, gated below.
     const isReopen = wasMin || signalChanged;
-    if (!isReopen && !rankChanged) return;
+    if (!isReopen && !stepChanged) return;
     // Defer one frame so the new snap/country is in the DOM before query.
     const id = requestAnimationFrame(() => {
       const ol = olRef.current;
@@ -611,7 +618,14 @@ export function ChartSheet({
       });
     });
     return () => cancelAnimationFrame(id);
-  }, [snap, currentTrackRank, scrollSignal, countryCode, currentCountryCode]);
+  }, [
+    snap,
+    currentTrackRank,
+    scrollSignal,
+    stepSignal,
+    countryCode,
+    currentCountryCode,
+  ]);
 
   return (
     // Rendered in place, not portaled: the sheet must be in the server HTML so


### PR DESCRIPTION
## Why

Tapping the today's-gem card at `peek` scrolled the sheet to the wrong place instead of the tapped song, and the edge-tap hint appeared at the same moment. Both rooted in one thing: a direct tap plays at `peek` and never raises the sheet to `full`.

The auto-scroll fired on any `rankChanged`, so it couldn't tell a **skip** from a **direct tap** — `scrollSignal` only bumps on a mini-player reopen, and a skip bumps a *separate* step signal (`lastStep`), not `scrollSignal`. On a gem tap it targeted `[data-rank=gem.rank]`, the ranked-row **duplicate** of the hero the user tapped, and on the *first* play the `currentTrack` null→set flip also flipped `hasMiniPlayer`, whose 0.34s sheet re-placement the single-rAF scroll measured mid-flight at a peek-clamped viewport, landing wrong. Later taps didn't race.

## What

Auto-scroll now reveals the now-playing row only on an **indirect** change — a reopen, or a skip / auto-advance — never a **direct tap** (the tapped item is already under the finger). Gate on the step signal (`lastStep.nonce`, which a skip/advance bumps) instead of the raw rank change. A first play is a tap, so it no longer scrolls, which also removes the first-play re-placement race.

- `sheet.tsx` — new `stepSignal` prop; the scroll effect gates on `isReopen || stepChanged` instead of `rankChanged`.
- `chart-screen.tsx` — passes `stepSignal={lastStep?.nonce ?? 0}`.
- Tests — a direct tap (rank change, no step) does not scroll; a skip (rank change + step) still reveals an off-screen row.

The edge-tap hint appearing is separate and working as coded (`hasCurrentTrack && snap !== "full"` — a track plays and the globe is reachable). It's slated for retirement in the edge-double-tap → country-change model change, so it's left as-is here.

## Test plan

- [x] typecheck / lint / build / 761 unit tests
- [ ] **Device:** first gem tap plays without yanking the list; the gem hero stays put
- [ ] **Device:** a skip (button / swipe / auto-advance) still scrolls an off-screen now-playing row into view
- [ ] **Device:** a mini-player reopen still reveals the row

Closes #243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart sheet scrolling during playback skips.
  * Prevented the sheet from unexpectedly scrolling when users directly select a track.
  * Ensured the currently playing track is revealed when playback advances automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->