### PR TITLE
fix(volume): swallow the outside tap that dismisses the popover

### DIFF
--- a/src/components/volume-control.test.tsx
+++ b/src/components/volume-control.test.tsx
@@ -82,9 +82,27 @@ describe("VolumeControl", () => {
     renderVolumeControl();
     fireEvent.click(screen.getByRole("button", { name: /volume/i }));
 
-    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
 
     expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  test("the dismissing tap is swallowed, so the control it lands on doesn't fire", () => {
+    renderVolumeControl();
+    fireEvent.click(screen.getByRole("button", { name: /volume/i }));
+
+    // A control outside the popover that would fire if the dismissing click
+    // reached it; the capture-phase guard must cancel it before its own listener.
+    const outside = document.createElement("button");
+    const onClick = vi.fn();
+    outside.addEventListener("click", onClick);
+    document.body.appendChild(outside);
+
+    fireEvent.click(outside);
+
+    expect(screen.queryByRole("slider")).toBeNull();
+    expect(onClick).not.toHaveBeenCalled();
+    outside.remove();
   });
 
   test("a second trigger tap closes the popover", () => {

--- a/src/components/volume-control.tsx
+++ b/src/components/volume-control.tsx
@@ -16,14 +16,20 @@ export function VolumeControl() {
   // The level to come back to on unmute; tracks the last audible volume.
   const lastAudibleRef = useRef(volume || 1);
 
-  // While open, dismiss on an outside tap or Escape; Escape returns focus to the
-  // trigger. Opening focuses the slider so arrow keys adjust it immediately.
+  // While open, dismiss on an outside click or Escape; Escape returns focus to
+  // the trigger. Opening focuses the slider so arrow keys adjust it immediately.
   useEffect(() => {
     if (!open) return;
     sliderRef.current?.focus();
 
-    function handlePointerDown(event: PointerEvent) {
-      if (!wrapperRef.current?.contains(event.target as Node)) setOpen(false);
+    function handleClickOutside(event: MouseEvent) {
+      if (wrapperRef.current?.contains(event.target as Node)) return;
+      // Dismiss-first: the tap that closes the popover must not also fire the
+      // control it landed on. Caught in the capture phase, it's swallowed before
+      // it reaches any onClick.
+      event.stopPropagation();
+      event.preventDefault();
+      setOpen(false);
     }
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
@@ -31,10 +37,10 @@ export function VolumeControl() {
         buttonRef.current?.focus();
       }
     }
-    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("click", handleClickOutside, true);
     document.addEventListener("keydown", handleKeyDown);
     return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("click", handleClickOutside, true);
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open]);


### PR DESCRIPTION
## Why

With the volume slider open, tapping elsewhere on the mini-player (a skip button, play, the strip) both closed the popover AND fired that control. The dismissing tap should be swallowed: the first tap only closes.

## What

`volume-control.tsx` dismissed on an outside `pointerdown` but didn't stop the ensuing `click`, so the underlying control still activated. It now closes on an outside **click** caught in the **capture phase** and swallows it (`stopPropagation` + `preventDefault`), so the click never reaches the control. Escape and the in-popover controls are unchanged.

This mirrors the commentary focus card, which already dismisses on click (not pointerdown) for the same reason: closing un-dims siblings, so a pointerdown-close would let the same tap act on a sibling.

Trade-off: an outside *drag* (no click) no longer closes the popover; a subsequent tap does. A filling popover during a drag is harmless, and swallowing the dismissing tap is the reported fix.

## Test plan

- [x] typecheck / lint / build / 761 unit tests (outside click closes; the dismissing click is swallowed so an outside control's listener doesn't fire)
- [ ] **Device:** open volume, tap a skip / play / the strip → the popover closes and that control does NOT act; a second tap acts normally

Closes #245
