### PR TITLE
fix: hold the edge-skip cues until the tour ends, and scroll on the first cross-country reopen

### DIFF
--- a/src/app/chart-screen.test.tsx
+++ b/src/app/chart-screen.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { readRecord } from "@/components/globe/edge-hint-record";
+import { writeRecord as writeTourRecord } from "@/components/tour/tour-record-store";
 import { CHARTS, CODE_BR, CODE_US, COUNTRY_US } from "@/lib/__fixtures__";
 import type { AudioEngine } from "@/lib/audio-engine";
 import type { ChartFile, Country, Track } from "@/lib/chart-schema";
@@ -425,6 +426,67 @@ describe("ChartScreen commentary badge", () => {
     expect(
       screen.getByRole("button", { name: "Collapse commentary" }),
     ).toBeDefined();
+  });
+});
+
+describe("ChartScreen edge-skip cues", () => {
+  const playable = COUNTRY_US.tracks.find((t) => t.previewUrl)!;
+
+  function playFromTheChart() {
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Play preview of ${playable.name} by ${playable.artist}`,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    mockSearchParams.value = new URLSearchParams(`cc=${CODE_US}`);
+    localStorage.clear();
+    audioEngine.reset();
+    // The cues are touch-only; without a coarse pointer they'd stay hidden for
+    // that reason instead of the one under test.
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes("coarse"),
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("playing a track while the tour still has gestures to teach surfaces no cue", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
+
+    playFromTheChart();
+
+    expect(screen.queryByTestId("edge-tap-badge")).toBeNull();
+    expect(screen.queryByTestId("edge-chevrons")).toBeNull();
+  });
+
+  test("a track played mid-tour spends none of the hint's capped shows", () => {
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
+
+    playFromTheChart();
+
+    expect(readRecord().shows).toBe(0);
+  });
+
+  test("the cues surface once the tour has concluded", () => {
+    writeTourRecord({ learned: [], shows: 0, dismissed: true });
+
+    render(<ChartScreen charts={CHARTS} defaultCountryCode={CODE_US} />);
+    playFromTheChart();
+
+    expect(screen.getByTestId("edge-tap-badge")).toBeTruthy();
+    expect(screen.getByTestId("edge-chevrons")).toBeTruthy();
   });
 });
 

--- a/src/app/chart-screen.tsx
+++ b/src/app/chart-screen.tsx
@@ -17,6 +17,7 @@ import { EdgeTapHint } from "@/components/globe/edge-tap-hint";
 import { SkipFlash } from "@/components/globe/skip-flash";
 import { MiniPlayer } from "@/components/mini-player";
 import { TourHost } from "@/components/tour/tour-host";
+import { useTourGateOpen } from "@/components/tour/use-tour-gate-open";
 import { findAdjacentPlayable } from "@/lib/adjacent-playable";
 import type { ChartFile, Country } from "@/lib/chart-schema";
 import {
@@ -125,6 +126,13 @@ function ChartScreenInner({
   const hasCurrentTrack = currentTrack !== null;
   const currentTrackRank = currentTrack?.rank ?? null;
   const audioStore = useAudioStoreApi();
+  const tourGateOpen = useTourGateOpen();
+
+  // Only while the globe is visible: at full the sheet covers it, so a cue there
+  // would burn one of the hint's capped displays unseen. The tour gate is the
+  // third term because playback can start from a row tap the tour never asked
+  // for, which would otherwise teach the edge skip over the tour's own lesson.
+  const edgeCuesActive = hasCurrentTrack && snap !== "full" && tourGateOpen;
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -409,13 +417,8 @@ function ChartScreenInner({
         prevTrack={prevTrack}
         nextTrack={nextTrack}
       />
-      {/* Only while the globe is visible: at full the sheet covers it, so
-          showing the hint there would burn one of its capped displays unseen. */}
-      <EdgeTapHint active={hasCurrentTrack && snap !== "full"} snap={snap} />
-      <EdgeChevrons
-        active={hasCurrentTrack && snap !== "full"}
-        sheetSnap={snap}
-      />
+      <EdgeTapHint active={edgeCuesActive} snap={snap} />
+      <EdgeChevrons active={edgeCuesActive} sheetSnap={snap} />
       <SkipFlash skip={skipFlash} sheetSnap={snap} />
       <TourHost
         snap={snap}

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -623,6 +623,64 @@ describe("ChartSheet", () => {
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });
 
+  test("a step that lands in another country reveals its row once the displayed country catches up", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // A roll lands deep in the new chart while its list remounts at the top, so
+    // the row needs revealing rather than already sitting in view.
+    stubRects(rect(0, 100), rect(200, 240));
+    const landed = COUNTRY_KR.tracks[2].rank;
+    const base = { snap: "peek" as const, onSnapChange: vi.fn() };
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_US}
+          countryCode="us"
+          currentTrackRank={COUNTRY_US.tracks[0].rank}
+          currentCountryCode="us"
+          stepSignal={0}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    // The roll steps into another country's track a render before the route
+    // swaps the displayed chart over.
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_US}
+          countryCode="us"
+          currentTrackRank={landed}
+          currentCountryCode="kr"
+          stepSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+    await frames(2);
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_KR}
+          countryCode="kr"
+          currentTrackRank={landed}
+          currentCountryCode="kr"
+          stepSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+    await frames(2);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+
   test("drops a held reopen ask once nothing is playing, rather than firing it at the next track", async () => {
     const scrollIntoViewMock = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoViewMock;

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { COUNTRY_KR } from "@/lib/__fixtures__";
+import { COUNTRY_KR, COUNTRY_US } from "@/lib/__fixtures__";
 import type { AudioEngine } from "@/lib/audio-engine";
 import { createAudioStore } from "@/lib/audio-store";
 import type { Country } from "@/lib/chart-schema";
@@ -550,6 +550,132 @@ describe("ChartSheet", () => {
           onSnapChange={vi.fn()}
           currentTrackRank={next}
           currentCountryCode="us"
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  test("a reopen asked from another country scrolls on the first ask, once the displayed country catches up", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // A rank the browsed country also has, so a scroll during the mismatch would
+    // land on its unrelated row.
+    const rank = COUNTRY_KR.tracks[2].rank;
+    const props = {
+      snap: "peek" as const,
+      onSnapChange: vi.fn(),
+      currentTrackRank: rank,
+      currentCountryCode: "kr",
+    };
+
+    // Browsing one country while another's track plays. The reopen bumps the
+    // signal a render before the route swaps the displayed country over.
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...props}
+          country={COUNTRY_US}
+          countryCode="us"
+          scrollSignal={0}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...props}
+          country={COUNTRY_US}
+          countryCode="us"
+          scrollSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...props}
+          country={COUNTRY_KR}
+          countryCode="kr"
+          scrollSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("drops a held reopen ask once nothing is playing, rather than firing it at the next track", async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // The row the user goes on to tap is off-screen, so only a stale reopen
+    // surviving the silence could pull the list to it: a direct tap carries no
+    // step, and so must never scroll on its own.
+    stubRects(rect(0, 100), rect(200, 240));
+    const rank = COUNTRY_KR.tracks[2].rank;
+    const base = { snap: "peek" as const, onSnapChange: vi.fn() };
+
+    const { rerender } = render(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_KR}
+          countryCode="kr"
+          currentTrackRank={COUNTRY_KR.tracks[0].rank}
+          currentCountryCode="us"
+          scrollSignal={0}
+        />
+      </AudioStoreProvider>,
+    );
+    scrollIntoViewMock.mockClear();
+
+    // An ask raised while another country's track plays, so it goes unanswered.
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_KR}
+          countryCode="kr"
+          currentTrackRank={COUNTRY_KR.tracks[0].rank}
+          currentCountryCode="us"
+          scrollSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+
+    // That track ends and the chart falls silent.
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_KR}
+          countryCode="kr"
+          currentTrackRank={null}
+          currentCountryCode={null}
+          scrollSignal={1}
+        />
+      </AudioStoreProvider>,
+    );
+
+    // The user taps a row of the displayed country.
+    rerender(
+      <AudioStoreProvider>
+        <ChartSheet
+          {...base}
+          country={COUNTRY_KR}
+          countryCode="kr"
+          currentTrackRank={rank}
+          currentCountryCode="kr"
+          scrollSignal={1}
         />
       </AudioStoreProvider>,
     );

--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -24,6 +24,14 @@ function makeMockAudio(): AudioEngine {
   };
 }
 
+// The scroll is deferred by rAF: one frame to let the DOM catch up, a second
+// when the list remounted onto a new country.
+async function frames(count: number) {
+  for (let i = 0; i < count; i++) {
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  }
+}
+
 function setScrollTop(el: Element, value: number) {
   Object.defineProperty(el, "scrollTop", { value, configurable: true });
 }
@@ -609,7 +617,8 @@ describe("ChartSheet", () => {
         />
       </AudioStoreProvider>,
     );
-    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    // The swapped list takes the extra frame it waits for its layout on.
+    await frames(2);
 
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
   });

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -595,16 +595,19 @@ export function ChartSheet({
     // The <ol> is keyed by country, so a country change remounts the whole list.
     const listSwapped = prevCountryRef.current !== countryCode;
     prevSnapRef.current = snap;
-    prevStepRef.current = stepSignal;
     prevCountryRef.current = countryCode;
-    // Hold the signal only while another country's track plays, the same idiom
-    // as the focus nonce above: a reopen asked from there bumps the signal a
-    // render before the route swaps the displayed country over, so consuming it
-    // now would swallow the ask and leave the pass where the two finally align
-    // with nothing to act on. Only a second ask would scroll. Every other bail
-    // still consumes, so a held signal can't outlive its ask and fire as a
-    // reopen against some later, unrelated change.
-    if (!otherCountryPlaying) prevSignalRef.current = scrollSignal;
+    // Hold both asks while another country's track plays, the same idiom as the
+    // focus nonce above: a reopen tap and an end-of-chart roll each land their
+    // signal a render before the route swaps the displayed country over, so
+    // consuming one now would leave the pass where the two finally align with
+    // nothing to act on. The reopen would need a second tap; the roll would
+    // never reveal the row it just landed on. Every other bail still consumes
+    // both, so a held ask can't outlive its own change and fire against a later
+    // unrelated one.
+    if (!otherCountryPlaying) {
+      prevSignalRef.current = scrollSignal;
+      prevStepRef.current = stepSignal;
+    }
     if (snap === "closed" || snap === "hidden") return;
     if (currentTrackRank === null) return;
     // The now-playing row only exists in the displayed list when the playing

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -589,17 +589,25 @@ export function ChartSheet({
       prevSnapRef.current === "closed" || prevSnapRef.current === "hidden";
     const signalChanged = prevSignalRef.current !== scrollSignal;
     const stepChanged = prevStepRef.current !== stepSignal;
+    const otherCountryPlaying =
+      currentCountryCode !== null && currentCountryCode !== countryCode;
     prevSnapRef.current = snap;
-    prevSignalRef.current = scrollSignal;
     prevStepRef.current = stepSignal;
+    // Hold the signal only while another country's track plays, the same idiom
+    // as the focus nonce above: a reopen asked from there bumps the signal a
+    // render before the route swaps the displayed country over, so consuming it
+    // now would swallow the ask and leave the pass where the two finally align
+    // with nothing to act on. Only a second ask would scroll. Every other bail
+    // still consumes, so a held signal can't outlive its ask and fire as a
+    // reopen against some later, unrelated change.
+    if (!otherCountryPlaying) prevSignalRef.current = scrollSignal;
     if (snap === "closed" || snap === "hidden") return;
     if (currentTrackRank === null) return;
     // The now-playing row only exists in the displayed list when the playing
     // country is the one on screen. Ranks repeat across countries, so a
     // mismatch would scroll to an unrelated row of the browsed country; skip
     // until they align (null = nothing playing, already handled above).
-    if (currentCountryCode !== null && currentCountryCode !== countryCode)
-      return;
+    if (otherCountryPlaying) return;
     // Reveal the row on an INDIRECT change only: a reopen (raised from
     // minimized, or a mini-player tap that bumped the signal), or a skip /
     // auto-advance (a bumped step). A DIRECT tap changes the rank with no step,

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -583,6 +583,7 @@ export function ChartSheet({
   const prevSnapRef = useRef(snap);
   const prevSignalRef = useRef(scrollSignal);
   const prevStepRef = useRef(stepSignal);
+  const prevCountryRef = useRef(countryCode);
 
   useEffect(() => {
     const wasMin =
@@ -591,8 +592,11 @@ export function ChartSheet({
     const stepChanged = prevStepRef.current !== stepSignal;
     const otherCountryPlaying =
       currentCountryCode !== null && currentCountryCode !== countryCode;
+    // The <ol> is keyed by country, so a country change remounts the whole list.
+    const listSwapped = prevCountryRef.current !== countryCode;
     prevSnapRef.current = snap;
     prevStepRef.current = stepSignal;
+    prevCountryRef.current = countryCode;
     // Hold the signal only while another country's track plays, the same idiom
     // as the focus nonce above: a reopen asked from there bumps the signal a
     // render before the route swaps the displayed country over, so consuming it
@@ -616,8 +620,8 @@ export function ChartSheet({
     // A step to an already-visible neighbour still holds, gated below.
     const isReopen = wasMin || signalChanged;
     if (!isReopen && !stepChanged) return;
-    // Defer one frame so the new snap/country is in the DOM before query.
-    const id = requestAnimationFrame(() => {
+
+    const scrollToRow = () => {
       const ol = olRef.current;
       const el = ol?.querySelector<HTMLElement>(
         `[data-rank="${currentTrackRank}"]`,
@@ -628,8 +632,19 @@ export function ChartSheet({
         block: snap === "peek" ? "start" : "center",
         behavior: "smooth",
       });
-    });
-    return () => cancelAnimationFrame(id);
+    };
+
+    // One frame so the new snap/country is in the DOM before the query; a second
+    // when the list remounted, because the row exists a frame before the
+    // remounted list's layout settles and measuring there lands wrong.
+    let frame = 0;
+    const waitFrames = (n: number, run: () => void) => {
+      frame = requestAnimationFrame(
+        n <= 1 ? run : () => waitFrames(n - 1, run),
+      );
+    };
+    waitFrames(listSwapped ? 2 : 1, scrollToRow);
+    return () => cancelAnimationFrame(frame);
   }, [
     snap,
     currentTrackRank,

--- a/src/components/chart-sheet/use-commentary-hint-pulse.ts
+++ b/src/components/chart-sheet/use-commentary-hint-pulse.ts
@@ -1,18 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { useStore } from "zustand";
+import { useEffect, useRef, useState } from "react";
 
-import { tourConcluded } from "@/components/tour/tour-concluded";
-import { tourBridge } from "@/lib/tour-bridge";
+import { useTourGateOpen } from "@/components/tour/use-tour-gate-open";
 import { useSeenFlag } from "@/lib/use-seen-flag";
 
 import { commentarySeen } from "./seen-commentary-hint";
-
-// Reactive read of the tour-done gate. Unlike useSeenFlag's no-op subscribe, the
-// hint outlives the tour, so it must re-render when the tour flag flips
-// mid-session, not just read it once at mount.
-const tourServerSnapshot = (): boolean | null => null;
 
 // Wait a beat after the gate opens so the pulse reads as its own moment rather
 // than a continuation of the just-dismissed tour.
@@ -34,22 +27,14 @@ export interface CommentaryHintPulse {
 // Drives the one-time discovery pulse for the single target row. Mounted only on
 // that row, so its store reads and observer cost are paid once, not per row.
 export function useCommentaryHintPulse(): CommentaryHintPulse {
-  const tourDone = useSyncExternalStore(
-    tourConcluded.subscribe,
-    tourConcluded.isConcluded,
-    tourServerSnapshot,
-  );
-  // A capped final appearance marks the record concluded while the tour is still
-  // on screen; wait for it to leave so the pulse isn't spent under the tour dim.
-  const tourActive = useStore(tourBridge, (s) => s.tourActive);
+  const tourGateOpen = useTourGateOpen();
   const { seen: hintSeen, markSeen } = useSeenFlag(commentarySeen);
   const chevronRef = useRef<HTMLSpanElement>(null);
   const [pulsing, setPulsing] = useState(false);
 
-  // Both flags are booleans (null during SSR), so the effect keys off a single
-  // primitive: only arm once the tour is done, off screen, and the hint hasn't
-  // fired.
-  const armable = tourDone === true && !tourActive && hintSeen === false;
+  // Arm only once the tour gate is open and the hint hasn't fired. One boolean,
+  // so the effect below keys off a primitive (hintSeen is null during SSR).
+  const armable = tourGateOpen && hintSeen === false;
 
   useEffect(() => {
     if (!armable) return;

--- a/src/components/tour/tour-concluded.ts
+++ b/src/components/tour/tour-concluded.ts
@@ -1,10 +1,10 @@
 import { hasConcluded } from "./tour-record";
 import { readRecord, subscribeRecord } from "./tour-record-store";
 
-// The tour-done gate the commentary hint arms off, derived from the learned-aware
+// The tour-done gate the post-tour cues arm off, derived from the learned-aware
 // record: the tour has "concluded" once it will never show again (dismissed,
 // every gesture learned, or the appearance cap reached). subscribe fires on every
-// record write so a mid-session conclusion reaches the hint, which outlives the
+// record write so a mid-session conclusion reaches the cues, which outlive the
 // tour. A boolean reactive-store shape (subscribe + snapshot) for useSyncExternalStore.
 export const tourConcluded = {
   isConcluded: (): boolean => hasConcluded(readRecord()),

--- a/src/components/tour/tour-record.ts
+++ b/src/components/tour/tour-record.ts
@@ -57,7 +57,7 @@ export function recordLearned(
 }
 
 // The tour will never show again: dismissed, capped, or everything learned. The
-// commentary hint arms off this, so it waits only while the tour still might run.
+// post-tour cues arm off this, so they wait only while the tour still might run.
 export function hasConcluded(record: TourRecord): boolean {
   return !decideShow(record).show;
 }

--- a/src/components/tour/use-tour-gate-open.ts
+++ b/src/components/tour/use-tour-gate-open.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { useStore } from "zustand";
+
+import { tourBridge } from "@/lib/tour-bridge";
+
+import { tourConcluded } from "./tour-concluded";
+
+// Reactive read of the tour-done gate. Unlike useSeenFlag's no-op subscribe, the
+// cues that wait on this outlive the tour, so they must re-render when the flag
+// flips mid-session, not just read it once at mount.
+const serverSnapshot = (): boolean | null => null;
+
+// Whether a cue that must not compete with the tour may show: the tour will
+// never run again, and it isn't on screen right now. Both terms are needed,
+// because a capped final appearance marks the record concluded while the tour is
+// still up, so the record alone would let a cue fire under the tour dim.
+// Collapsed to one boolean, so callers re-render when the gate flips rather than
+// on every write to the underlying record.
+export function useTourGateOpen(): boolean {
+  const tourDone = useSyncExternalStore(
+    tourConcluded.subscribe,
+    tourConcluded.isConcluded,
+    serverSnapshot,
+  );
+  const tourActive = useStore(tourBridge, (s) => s.tourActive);
+  return tourDone === true && !tourActive;
+}

--- a/src/components/tour/use-tour-gate-open.ts
+++ b/src/components/tour/use-tour-gate-open.ts
@@ -10,7 +10,12 @@ import { tourConcluded } from "./tour-concluded";
 // Reactive read of the tour-done gate. Unlike useSeenFlag's no-op subscribe, the
 // cues that wait on this outlive the tour, so they must re-render when the flag
 // flips mid-session, not just read it once at mount.
-const serverSnapshot = (): boolean | null => null;
+//
+// The server can't read the record, and a closed gate is the honest answer for
+// an unknown one, so it renders the same markup the client hydrates to. False,
+// not null: the pair only re-renders when the snapshots differ, and a null the
+// client never returns would spend that render on every visit.
+const serverSnapshot = (): boolean => false;
 
 // Whether a cue that must not compete with the tour may show: the tour will
 // never run again, and it isn't on screen right now. Both terms are needed,
@@ -25,5 +30,5 @@ export function useTourGateOpen(): boolean {
     serverSnapshot,
   );
   const tourActive = useStore(tourBridge, (s) => s.tourActive);
-  return tourDone === true && !tourActive;
+  return tourDone && !tourActive;
 }


### PR DESCRIPTION
Two unrelated interaction bugs. Sits on top of #244, #246 and #249.

## 1. The edge-skip cues appear mid-tour

Playing a track from a chart row while the tour is still on its gesture beat surfaced the double-tap skip hint and the edge chevrons behind the running tour: a second lesson stacked on the one being taught, dimmed under the tour's own backdrop. It also spent one of the hint's three capped shows unseen, so the bug quietly cost a teaching opportunity.

`EdgeTapHint` rode on `hasCurrentTrack && snap !== "full"` alone. Playback can start from a row tap the tour never asked for, so any tap lit the cues regardless of the tour. It was the only tour-era cue with no tour gate.

The sibling `useCommentaryHintPulse` already had the right check (`tourDone === true && !tourActive`), so this extracts it to `useTourGateOpen()` and gates both cues on it. Two consumers now share one definition of the gate instead of restating it.

## 2. The first mini-player tap does not scroll (sheet at peek)

Two defects on the same path, found one behind the other.

**The ask was swallowed.** Tapping the mini-player after browsing away to another country scrolled to the playing track only on the *second* tap. The tap bumps `scrollSignal` a render before `pushState` reaches `countryCode`, but the effect consumed the signal *above* its country-mismatch guard, so the pass where the countries finally aligned had nothing left to act on. Fixed by holding the signal only while another country's track plays, the idiom the neighbouring `focusIntent` nonce already uses for the same wait. Every other bail still consumes it, so a held ask cannot outlive its reopen and later fire against a direct tap.

**Then it landed on the wrong row.** With the first tap scrolling, it stopped short of the now-playing row or ran past it. The `<ol>` is keyed by country, so a cross-country reopen remounts the whole list, and the row exists a frame before the remounted list has settled its layout: the deferred frame aimed at a list still finding its height. Fixed by waiting one more frame when the list swapped. This is the measurement race #243 described; #244 avoided it by not scrolling on a direct tap rather than fixing it, so restoring the scroll on this path brought it back into view.

## Open question

**`EdgeChevrons` is gated alongside the hint.** Only the hint was reported. The chevrons share the identical trigger, so half-gating the pair would leave the cue family inconsistent, but they have no capped-show record, so the "burns a show" half of the rationale does not apply to them. Happy to ungate them if that is the preferred call.

## Test plan

Regression tests, each confirmed to fail against its own counterfactual and pass with the fix:

- `chart-screen.test.tsx` — a track played mid-tour surfaces no cue, and spends none of the hint's capped shows.
- `chart-screen.test.tsx` — the cues still surface once the tour has concluded (guards against over-gating).
- `sheet.test.tsx` — a reopen asked from another country scrolls on the first ask, once the displayed country catches up. Also pins the extra frame the swapped list waits on.
- `sheet.test.tsx` — a held ask is dropped once nothing is playing, rather than firing at the next track the user taps. Also pins #244's direct-tap invariant.

Full local matrix green on top of `ba07e6b`: 782 tests, `lint`, `typecheck`, `build`. Verified additive: no `stepSignal` / `lastStep` / dismiss-first line is removed, so #244, #246 and #249 are untouched.

Both bugs confirmed fixed by hand on a phone against the preview build: the tour no longer leaks the edge cues on a stray row tap, and the first mini-player tap lands smoothly on the right row across countries. The landing race is frame timing, not the smooth behaviour, which is unchanged.