### PR TITLE
fix(chart-sheet): toggle the commentary card from the mini-player badge

### DIFF
--- a/src/components/chart-sheet/sheet.test.tsx
+++ b/src/components/chart-sheet/sheet.test.tsx
@@ -681,6 +681,33 @@ describe("ChartSheet commentary focus", () => {
     ).not.toBeNull();
   });
 
+  test("the commentary badge toggles: a repeat focus ask for the open row closes it", () => {
+    const store = createAudioStore(() => makeMockAudio());
+    const rank = COUNTRY_KR.tracks[0].rank;
+    const view = (nonce: number) => (
+      <AudioStoreContext.Provider value={store}>
+        <ChartSheet
+          country={COUNTRY_KR}
+          countryCode="kr"
+          snap="full"
+          onSnapChange={vi.fn()}
+          focusIntent={{ rank, nonce }}
+        />
+      </AudioStoreContext.Provider>
+    );
+
+    const { container, rerender } = render(view(1));
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+
+    // The same badge pressed again: a fresh nonce for the open row closes it.
+    rerender(view(2));
+    expect(container.querySelector("[data-commentary-card]")).toBeNull();
+
+    // Pressed once more: it opens again.
+    rerender(view(3));
+    expect(container.querySelector("[data-commentary-card]")).not.toBeNull();
+  });
+
   test("dimmed siblings and the gem card recede and go inert", () => {
     const { container } = renderSheet("full");
     fireEvent.click(firstTeaser(container)!);

--- a/src/components/chart-sheet/sheet.tsx
+++ b/src/components/chart-sheet/sheet.tsx
@@ -177,6 +177,8 @@ export function ChartSheet({
   // countries, so the intent targets its row only once the displayed country
   // is the playing one; until then the nonce stays unconsumed, so the focus
   // lands after the country change instead of being clobbered by its reset.
+  // The badge toggles: a fresh ask for the row already focused closes it, so
+  // the mini-player button both opens and dismisses its own card.
   const [consumedFocusNonce, setConsumedFocusNonce] = useState(0);
   if (
     focusIntent !== null &&
@@ -184,7 +186,9 @@ export function ChartSheet({
     (currentCountryCode === null || currentCountryCode === countryCode)
   ) {
     setConsumedFocusNonce(focusIntent.nonce);
-    setFocusedRank(focusIntent.rank);
+    setFocusedRank((cur) =>
+      cur === focusIntent.rank ? null : focusIntent.rank,
+    );
   }
 
   // While a card is focused, dismiss on Escape or a click outside it (a dimmed


### PR DESCRIPTION
## Why

The mini-player's commentary badge opened the now-playing track's focused reader card but a repeat press left it open — the one button that opened the card couldn't dismiss it (only the card, teaser, Escape, or an outside tap could).

## What

The sheet consumes the badge's `focusIntent` during render; it now sets the focused rank to null when the ask targets the row already focused, so the badge toggles: press to open, press again to close, and a press after switching tracks opens the new track's card.

## Test plan

- [x] typecheck / lint / build / 777 unit tests (new: repeat focus ask for the open row closes it, then reopens)
- [x] Device (cloudflared tunnel): badge opens the card, same badge closes it, switching tracks opens the new one

Closes #248